### PR TITLE
Read AWS creds from profile, central error lib

### DIFF
--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -47,18 +47,30 @@ class StudyBuilder:
     def __init__(  # pylint: disable=too-many-arguments
         self, region: str, workgroup: str, profile: str, schema: str
     ):
+        connect_kwargs = {}
+        for aws_env_name in [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ]:
+            if aws_env_val := os.environ.get(aws_env_name):
+                connect_kwargs[aws_env_name.lower()] = aws_env_val
+        # the profile may not be required, provided the above three AWS env vars
+        # are set. If both are present, the env vars take precedence
+        if profile is not None:
+            connect_kwargs["profile_name"] = profile
         self.cursor = pyathena.connect(
             region_name=region,
             work_group=workgroup,
-            profile_name=profile,
             schema_name=schema,
+            **connect_kwargs,
         ).cursor()
         self.pandas_cursor = pyathena.connect(
             region_name=region,
             work_group=workgroup,
-            profile_name=profile,
             schema_name=schema,
             cursor_class=PandasCursor,
+            **connect_kwargs,
         ).cursor()
         self.schema_name = schema
 

--- a/cumulus_library/errors.py
+++ b/cumulus_library/errors.py
@@ -14,4 +14,6 @@ class LibrarySchemaError(Exception):
     Package level error
     """
 
-    pass
+
+class StudyManifestParsingError(Exception):
+    """Basic error for StudyManifestParser"""

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -11,6 +11,7 @@ import toml
 from rich.progress import Progress, TaskID, track
 
 from cumulus_library.base_runner import BaseRunner
+from cumulus_library.errors import StudyManifestParsingError
 from cumulus_library.helper import (
     query_console_output,
     load_text,
@@ -26,10 +27,6 @@ from cumulus_library.template_sql.templates import (
 StrList = List[str]
 
 RESERVED_TABLE_KEYWORDS = ["etl", "nlp", "lib"]
-
-
-class StudyManifestParsingError(Exception):
-    """Basic error for StudyManifestParser"""
 
 
 class StudyManifestParser:


### PR DESCRIPTION
This PR makes the following changes:
Adds support for global AWS env settings #20 
Moves existing custom error into cumulus_library.errors #3 

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies
- [x] Update template repo if there are changes to study configuration