### PR TITLE
performance tuning for codeableConcepts

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -1,2 +1,2 @@
 """Package metadata"""
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
+++ b/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
@@ -30,7 +30,21 @@ CREATE TABLE {{ target_table }} AS (
         UNION 
         {%- endif -%}
         {%- endfor %}
-        ORDER BY id, priority
+    ),
+    partitioned_table AS (
+        SELECT
+            id,
+            code,
+            code_system,
+            display,
+            priority,
+            ROW_NUMBER()
+            OVER (
+                PARTITION BY id
+            ) AS available_priority
+        FROM union_table
+        GROUP BY id, priority, code_system, code, display
+        ORDER BY priority ASC
     )
 
     SELECT
@@ -38,18 +52,6 @@ CREATE TABLE {{ target_table }} AS (
         code,
         code_system,
         display
-    FROM (
-        SELECT
-            id,
-            code,
-            code_system,
-            display,
-            ROW_NUMBER()
-            OVER (
-                PARTITION BY id
-            ) AS available_priority
-        FROM union_table
-        GROUP BY id, code_system, code, display
-    )
+    FROM partitioned_table
     WHERE available_priority = 1
 );

--- a/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
+++ b/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
@@ -31,6 +31,7 @@ CREATE TABLE {{ target_table }} AS (
         {%- endif -%}
         {%- endfor %}
     ),
+
     partitioned_table AS (
         SELECT
             id,


### PR DESCRIPTION
This improves the codableConcept query for large datasets by moving the ordering step to the partitioned subtable, so it can be better map/reduced.

### Checklist
- [X ] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration