### PR TITLE
Per Jamie's good suggestion, replace Encounter class code with displa…

### DIFF
--- a/cumulus_library/studies/core/condition.sql
+++ b/cumulus_library/studies/core/condition.sql
@@ -67,7 +67,7 @@ SELECT
     powerset.cnt_subject AS cnt,
     powerset.recorded_month AS cond_month,
     powerset.display AS cond_code_display,
-    enc_class.code AS enc_class_code
+    enc_class.display AS enc_class_code
 FROM powerset
 WHERE powerset.cnt_subject >= 10
 ORDER BY powerset.cnt_subject DESC, powerset.cnt_encounter DESC;

--- a/cumulus_library/studies/core/documentreference.sql
+++ b/cumulus_library/studies/core/documentreference.sql
@@ -35,7 +35,7 @@ WITH temp_documentreference AS (
 
 SELECT DISTINCT
     type_coding.type_row AS doc_type,
-    coalesce(type_coding.type_row.code, '?') AS doc_type_code,
+    coalesce(type_coding.type_row.code, 'None') AS doc_type_code,
     CASE
         WHEN
             type_coding.type_row.display IS NOT NULL
@@ -65,7 +65,7 @@ WITH powerset AS (
         count(DISTINCT d.doc_id) AS cnt_document,
         d.doc_type_display,
         d.author_month,
-        e.enc_class.code AS enc_class_code
+        e.enc_class.display AS enc_class_code
     FROM core__documentreference AS d, core__encounter AS e
     WHERE d.encounter_ref = e.encounter_ref
     GROUP BY cube(d.doc_type_display, d.author_month, e.enc_class)

--- a/cumulus_library/studies/core/encounter.sql
+++ b/cumulus_library/studies/core/encounter.sql
@@ -49,7 +49,7 @@ SELECT
     ce.subject_ref,
     ce.encounter_ref,
     ce.encounter_id,
-    ce.enc_class.code AS enc_class_code,
+    ce.enc_class.display AS enc_class_code,
     cp.gender,
     cp.race_display,
     cp.ethnicity_display,
@@ -63,7 +63,7 @@ WITH powerset AS (
     SELECT
         count(DISTINCT ce.subject_ref) AS cnt_subject,
         count(DISTINCT ce.encounter_id) AS cnt_encounter,
-        ce.enc_class.code AS enc_class_code,
+        ce.enc_class.display AS enc_class_code,
         ce.start_month,
         ce.age_at_visit,
         cp.gender,
@@ -100,7 +100,7 @@ WITH powerset AS (
     SELECT
         count(DISTINCT ce.subject_ref) AS cnt_subject,
         count(DISTINCT ce.encounter_id) AS cnt_encounter,
-        ce.enc_class.code AS enc_class_code,
+        ce.enc_class.display AS enc_class_code,
         ce.start_date
     FROM core__encounter AS ce, core__patient AS cp
     WHERE ce.subject_ref = cp.subject_ref

--- a/cumulus_library/studies/core/patient.sql
+++ b/cumulus_library/studies/core/patient.sql
@@ -26,7 +26,7 @@ SELECT DISTINCT
         WHEN
             t_address.addr_row.postalcode IS NOT NULL
             THEN substr(t_address.addr_row.postalcode, 1, 3)
-        ELSE '?'
+        ELSE 'None'
     END AS postalcode3,
     tp.subject_id,
     tp.subject_ref,

--- a/cumulus_library/studies/core/study_period.sql
+++ b/cumulus_library/studies/core/study_period.sql
@@ -17,8 +17,8 @@ WITH documented_encounter AS (
         ce.encounter_ref,
         cd.doc_ref,
         date_diff('day', ce.start_date, cd.author_date) AS diff_enc_note_days,
-        coalesce(ce.enc_class.code, '?') AS enc_class_code,
-        coalesce(cd.doc_type.code, '?') AS doc_type_code,
+        coalesce(ce.enc_class.display, 'None') AS enc_class_code,
+        coalesce(cd.doc_type.code, 'None') AS doc_type_code,
         coalesce(cd.doc_type.display, cd.doc_type.code) AS doc_type_display
     FROM
         core__patient AS cp,


### PR DESCRIPTION
Suggestion: **Encounter.class.display** will be more useful than **code** #66
https://github.com/smart-on-fhir/cumulus-library/issues/66

This is a PATCH to force the use of Encounter.class.display and 'None" instead of '?' everywhere in library CORE 
