### PR TITLE
Urn oid namespace for coding "SYSTEM"

### DIFF
--- a/cumulus_library/studies/core/builder_encounter_coding.py
+++ b/cumulus_library/studies/core/builder_encounter_coding.py
@@ -121,10 +121,9 @@ class EncounterCodingBuilder(BaseTableBuilder):
                 "name": "type",
                 "is_array": True,
                 "code_systems": [
-                    "http://hl7.org/fhir/ValueSet/encounter-type",
                     "http://terminology.hl7.org/CodeSystem/encounter-type",
                     "http://terminology.hl7.org/CodeSystem/v2-0004",
-                    "2.16.840.1.113883.4.642.3.248",
+                    "urn:oid:2.16.840.1.113883.4.642.3.248",
                     "http://snomed.info/sct",
                 ],
                 "has_data": False,
@@ -133,9 +132,8 @@ class EncounterCodingBuilder(BaseTableBuilder):
                 "name": "servicetype",
                 "is_array": False,
                 "code_systems": [
-                    "http://hl7.org/fhir/ValueSet/service-type",
                     "http://terminology.hl7.org/CodeSystem/service-type",
-                    "2.16.840.1.113883.4.642.3.518",
+                    "urn:oid:2.16.840.1.113883.4.642.3.518",
                     "http://snomed.info/sct",
                 ],
                 "has_data": False,
@@ -144,7 +142,6 @@ class EncounterCodingBuilder(BaseTableBuilder):
                 "name": "priority",
                 "is_array": False,
                 "code_systems": [
-                    "http://terminology.hl7.org/ValueSet/v3-ActPriority",
                     "http://terminology.hl7.org/CodeSystem/v3-ActPriority",
                     "http://snomed.info/sct",
                 ],

--- a/cumulus_library/studies/core/builder_encounter_coding.sql
+++ b/cumulus_library/studies/core/builder_encounter_coding.sql
@@ -68,7 +68,7 @@ CREATE TABLE core__encounter_dn_type AS (
             UNNEST(cc.cc_row.coding) AS u (codeable_concept)
         
         WHERE
-            u.codeable_concept.system = '2.16.840.1.113883.4.642.3.248'
+            u.codeable_concept.system = 'urn:oid:2.16.840.1.113883.4.642.3.248'
     ), --noqa: LT07
     system_type_4 AS (
         SELECT DISTINCT
@@ -196,7 +196,7 @@ CREATE TABLE core__encounter_dn_servicetype AS (
         
             UNNEST(s.servicetype.coding) AS u (codeable_concept)
         WHERE
-            u.codeable_concept.system = '2.16.840.1.113883.4.642.3.518'
+            u.codeable_concept.system = 'urn:oid:2.16.840.1.113883.4.642.3.518'
     ), --noqa: LT07
     system_servicetype_3 AS (
         SELECT DISTINCT


### PR DESCRIPTION
1. when OID system is used, must include prefix "urn:oid:" 
2. valuesets are not codesystem, thusly removed valueset