### PR TITLE
flipped userselected detection in templates

### DIFF
--- a/cumulus_library/template_sql/core_medication.sql.jinja
+++ b/cumulus_library/template_sql/core_medication.sql.jinja
@@ -23,10 +23,10 @@ CREATE TABLE core__medication AS (
             t.r.code,
             t.r.display,
             t.r.system AS code_system,
-            {% if missing_userselected %}
-            false AS userselected
-            {% else %}
+            {% if has_userselected %}
             t.r.userselected
+            {% else %}
+            false AS userselected
             {% endif %}
         FROM mcc_nonnull,
         unnest(medicationcodeableconcept.coding) AS t(r)
@@ -95,10 +95,10 @@ CREATE TABLE core__medication AS (
             'None' AS code,
             cu.code.text AS display,
             'None' AS code_system,
-            {% if missing_userselected %}
-            false AS userselected
-            {% else %}
+            {% if has_userselected %}
             t.r.userselected
+            {% else %}
+            false AS userselected
             {% endif %}
         FROM mrc_contained_unnest AS cu
         INNER JOIN mrc_ref_id AS ri ON ri.id = cu.id
@@ -155,10 +155,10 @@ CREATE TABLE core__medication AS (
             t.r.code AS code,
             mmn.code.text AS display,
             t.r.system AS code_system,
-            {% if missing_userselected %}
-            false AS userselected
-            {% else %}
+            {% if has_userselected %}
             t.r.userselected
+            {% else %}
+            false AS userselected
             {% endif %}
         FROM mre_med_nonnull AS mmn,
             unnest(mmn.code.coding) AS t (r)

--- a/cumulus_library/template_sql/templates.py
+++ b/cumulus_library/template_sql/templates.py
@@ -250,13 +250,13 @@ def get_is_table_not_empty_query(
 
 
 def get_core_medication_query(
-    medication_datasources: dict, missing_userselected: bool = False
+    medication_datasources: dict, has_userselected: bool = False
 ):
     path = Path(__file__).parent
     with open(f"{path}/core_medication.sql.jinja") as core_medication:
         return Template(core_medication.read()).render(
             medication_datasources=medication_datasources,
-            missing_userselected=missing_userselected,
+            has_userselected=has_userselected,
         )
 
 


### PR DESCRIPTION
This PR makes the following change:
- flips the template infrastructure for core_medication from `missing_selected` to `has_selected` to match the invocation in the builder.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration