### PR TITLE
Added core versioning

### DIFF
--- a/cumulus_library/studies/core/manifest.toml
+++ b/cumulus_library/studies/core/manifest.toml
@@ -10,6 +10,7 @@ file_names = [
 
 [sql_config]
 file_names = [
+    "version.sql",
     "setup.sql",
     "fhir_define.sql",
     "patient.sql",
@@ -36,4 +37,5 @@ export_list = [
     "core__count_condition_month",
     "core__count_medicationrequest_month",
     "core__meta_date",
+    "core__meta_version",
 ]

--- a/cumulus_library/studies/core/version.sql
+++ b/cumulus_library/studies/core/version.sql
@@ -1,0 +1,2 @@
+CREATE TABLE core__meta_version AS
+SELECT 1 AS data_package_version;

--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -28,7 +28,7 @@ def upload_data(
         json={
             "study": study,
             "data_package": data_package,
-            "version": f"{version:03d}",
+            "data_package_version": version,
             "filename": f"{args['user']}_{file_name}",
         },
         auth=(args["user"], args["id"]),
@@ -77,13 +77,13 @@ def upload_files(args: dict):
         sys.exit("user/id not provided, please pass --user and --id")
     with get_progress_bar() as progress:
         file_upload_progress = progress.add_task("Uploading", total=num_uploads)
-        meta_version = next(
-            filter(lambda x: "__meta_version" in str(x), file_paths), None
-        )
-        if meta_version:
+        try:
+            meta_version = next(
+                filter(lambda x: str(x).endswith("__meta_version"), file_paths)
+            )
             version = read_parquet(meta_version)["data_package_version"][0]
             file_paths.remove(meta_version)
-        else:
+        except StopIteration:
             version = 0
         for file_path in file_paths:
             upload_data(progress, file_upload_progress, file_path, version, args)

--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -87,4 +87,3 @@ def upload_files(args: dict):
             version = 0
         for file_path in file_paths:
             upload_data(progress, file_upload_progress, file_path, version, args)
-            exit()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,8 +76,8 @@ def test_cli_path_mapping(
     "args,cursor_calls,pandas_cursor_calls",
     [
         (["build", "-t", "vocab", "--database", "test"], 344, 0),
-        (["build", "-t", "core", "--database", "test"], 45, 0),
-        (["export", "-t", "core", "--database", "test"], 1, 9),
+        (["build", "-t", "core", "--database", "test"], 46, 0),
+        (["export", "-t", "core", "--database", "test"], 1, 10),
         (
             [
                 "build",
@@ -106,7 +106,7 @@ def test_cli_path_mapping(
         ),
         (
             ["build", "-t", "core", "-s", "tests/test_data/", "--database", "test"],
-            45,
+            46,
             0,
         ),
         (
@@ -119,7 +119,7 @@ def test_cli_path_mapping(
                 "cumulus_library/data_export",
             ],
             1,
-            9,
+            10,
         ),
     ],
 )


### PR DESCRIPTION
This PR makes the following change:
- Added new core__meta_version table with basic version number (i.e. major only)
- Upload will now look for an exported {study}__meta_version table
- If found, will add version to aggregator post. If not, will assume no version (i.e. version 0)

This is one half of the implementation for versioning - the other half is at [this aggregator PR](https://github.com/smart-on-fhir/cumulus-aggregator/pull/99).

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration