### PR TITLE
Template coding, system namespace cleanup

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -1,2 +1,2 @@
 """Package metadata"""
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/cumulus_library/studies/core/setup.sql
+++ b/cumulus_library/studies/core/setup.sql
@@ -5,7 +5,7 @@ SELECT
     t.from_system,
     t.from_code,
     t.analyte,
-    t.system,
+    t.code_system,
     t.code,
     t.display
 FROM
@@ -60,4 +60,4 @@ FROM
             'Emergency department Consult note'
         )
     )
-    AS t (from_system, from_code, analyte, system, code, display);
+    AS t (from_system, from_code, analyte, code_system, code, display);

--- a/cumulus_library/template_sql/count.sql.jinja
+++ b/cumulus_library/template_sql/count.sql.jinja
@@ -11,7 +11,7 @@ CREATE TABLE {{ table_name }} AS (
             count(DISTINCT encounter_ref) AS cnt_encounter,
             {%- endif -%}
             {% for col in table_cols %}
-            {{ col }}
+            "{{ col }}"
             {%- if not loop.last -%}
             , 
             {%- endif -%}
@@ -20,7 +20,7 @@ CREATE TABLE {{ table_name }} AS (
         GROUP BY
             cube( 
                 {%- for col in table_cols %}
-                {{ col }}
+                "{{ col }}"
                 {%- if not loop.last -%}
                 , 
                 {%- endif -%}
@@ -35,7 +35,7 @@ CREATE TABLE {{ table_name }} AS (
         cnt_subject
         {%- endif %} AS cnt,
         {%- for col in table_cols %}
-        {{ col }}
+        "{{ col }}"
         {%- if not loop.last -%}
         , 
         {%- endif -%}

--- a/cumulus_library/template_sql/create_view_as.sql.jinja
+++ b/cumulus_library/template_sql/create_view_as.sql.jinja
@@ -18,7 +18,7 @@ CREATE OR REPLACE VIEW {{ view_name }} AS (
     AS t -- noqa: L025
     (
         {%- for col in view_cols -%}
-        {{ col }}
+        "{{ col }}"
         {%- if not loop.last -%}
         , 
         {%- endif -%}

--- a/cumulus_library/template_sql/ctas.sql.jinja
+++ b/cumulus_library/template_sql/ctas.sql.jinja
@@ -18,7 +18,7 @@ CREATE TABLE "{{ schema_name }}"."{{ table_name }}" AS (
     AS t -- noqa: L025
     (
         {%- for col in table_cols -%}
-        {{ col }}
+        "{{ col }}"
         {%- if not loop.last -%}
         , 
         {%- endif -%}

--- a/cumulus_library/template_sql/ctas_empty.sql.jinja
+++ b/cumulus_library/template_sql/ctas_empty.sql.jinja
@@ -13,7 +13,7 @@ CREATE TABLE "{{ schema_name }}"."{{ table_name }}" AS (
     AS t -- noqa: L025
     (
         {%- for col in table_cols -%}
-        {{ col }}
+        "{{ col }}"
         {%- if not loop.last -%}
         , 
         {%- endif -%}

--- a/cumulus_library/template_sql/insert_into.sql.jinja
+++ b/cumulus_library/template_sql/insert_into.sql.jinja
@@ -1,7 +1,7 @@
 INSERT INTO {{ table_name }}
 (
     {%- for col in table_cols -%}
-    {{ col }}
+    "{{ col }}"
     {%- if not loop.last -%}
     , 
     {%- endif -%}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -219,20 +219,20 @@ CREATE TABLE test_table AS (
     WITH powerset AS (
         SELECT
             count(DISTINCT subject_ref) AS cnt_subject,
-            age,
-            sex
+            "age",
+            "sex"
         FROM test_source
         GROUP BY
             cube(
-                age,
-                sex
+                "age",
+                "sex"
             )
     )
 
     SELECT
         cnt_subject AS cnt,
-        age,
-        sex
+        "age",
+        "sex"
     FROM powerset
     WHERE 
         cnt_subject >= 10
@@ -248,7 +248,6 @@ CREATE TABLE test_table AS (
         f.write(query)
     assert query == expected
     query = get_count_query("test_table", "test_source", ["age", "sex"], min_subject=5)
-    print(query)
     assert "cnt_subject >= 5" in query
 
     expected = """
@@ -257,20 +256,20 @@ CREATE TABLE test_table AS (
         SELECT
             count(DISTINCT subject_ref) AS cnt_subject,
             count(DISTINCT encounter_ref) AS cnt_encounter,
-            age,
-            sex
+            "age",
+            "sex"
         FROM test_source
         GROUP BY
             cube(
-                age,
-                sex
+                "age",
+                "sex"
             )
     )
 
     SELECT
         cnt_encounter AS cnt,
-        age,
-        sex
+        "age",
+        "sex"
     FROM powerset
     WHERE
         age > 10
@@ -284,8 +283,6 @@ CREATE TABLE test_table AS (
         where_clauses=["age > 10", "sex ==  'F'"],
         cnt_encounter=True,
     )
-    with open("output.sql", "w") as f:
-        f.write(query)
     assert query == expected
 
 
@@ -297,14 +294,13 @@ def test_create_view_query_creation():
         ('bar','bar')
     )
     AS t -- noqa: L025
-    (a,b)
+    ("a","b")
 );"""
     query = get_create_view_query(
         view_name="test_view",
         dataset=[["foo", "foo"], ["bar", "bar"]],
         view_cols=["a", "b"],
     )
-    print(query)
     assert query == expected
 
 
@@ -316,7 +312,7 @@ def test_ctas_query_creation():
         ((cast('bar' AS varchar),cast('bar' AS varchar)))
     )
     AS t -- noqa: L025
-    (a,b)
+    ("a","b")
 );"""
     query = get_ctas_query(
         schema_name="test_schema",
@@ -324,7 +320,6 @@ def test_ctas_query_creation():
         dataset=[["foo", "foo"], ["bar", "bar"]],
         table_cols=["a", "b"],
     )
-    print(query)
     assert query == expected
 
 
@@ -421,7 +416,7 @@ def test_extension_denormalize_creation():
 
 def test_insert_into_query_creation():
     expected = """INSERT INTO test_table
-(a,b)
+("a","b")
 VALUES
 (('foo','foo')),
 (('bar','bar'));"""


### PR DESCRIPTION
This PR makes the following changes:
- Updates all 1:1 insertion of column names in templates to be quoted for safety #111
- Cleans up the last bare instance of 'system' in core #65
- Prepatory version bump to 1.3

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration