### PR TITLE
Removed extra indexing on schema removal

### DIFF
--- a/cumulus_library/base_table_builder.py
+++ b/cumulus_library/base_table_builder.py
@@ -55,7 +55,7 @@ class BaseTableBuilder(ABC):
                     table_name = table_name[0]
                     # if it contains a schema, remove it (usually it won't, but some CTAS
                     # forms may)
-                    if "." in table_name[0]:
+                    if "." in table_name:
                         table_name = table_name.split(".")[1].replace('"', "")
                     table_names.append(table_name)
             for table_name in table_names:


### PR DESCRIPTION
This PR removes a second instance of array indexing in the base_table_builder, which was causing us to search only the first character of a potential string for a name like `"schema"."table"`

This is currently only an issue when we are creating a completely empty table.
### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration