### PR TITLE
Added upload check for targets

### DIFF
--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -72,7 +72,7 @@ def upload_files(args: dict):
             "study export folder."
         )
     file_paths = list(args["data_path"].glob("**/*.parquet"))
-    if args["target"] is not None:
+    if args["target"]:
         filtered_paths = []
         for path in file_paths:
             if any(study in str(path) for study in args["target"]):

--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -72,6 +72,13 @@ def upload_files(args: dict):
             "study export folder."
         )
     file_paths = list(args["data_path"].glob("**/*.parquet"))
+    if args["target"] is not None:
+        filtered_paths = []
+        for path in file_paths:
+            if any(study in str(path) for study in args["target"]):
+                filtered_paths.append(path)
+        file_paths = filtered_paths
+
     if not args["user"] or not args["id"]:
         sys.exit("user/id not provided, please pass --user and --id")
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,4 +246,8 @@ def test_cli_upload_filter(mock_upload_data, mock_glob, args, calls):
         ],
     ]
     cli.main(cli_args=args)
+    if len(mock_upload_data.call_args_list) == 1:
+        target = args[args.index("-t") + 1]
+        # filepath is in the third argument position in the upload data arg list
+        assert target in str(mock_upload_data.call_args[0][2])
     assert mock_upload_data.call_count == calls


### PR DESCRIPTION
This PR updates the upload `--target` argument to actually filter the list of files to upload

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies
- [x] Update template repo if there are changes to study configuration