### PR TITLE
Uprev pandas/sqlfluff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/psf/black
     #this version is synced with the black mentioned in .github/workflows/ci.yml
-    rev: 22.12.0
+    rev: 23.10.0
     hooks:
       - id: black
         entry: bash -c 'black "$@"; git add -u' --
@@ -12,6 +12,6 @@ repos:
         language_version: python3.9
 
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 2.0.2
+    rev: 2.3.4
     hooks:
       - id: sqlfluff-lint

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,15 +1,3 @@
-# The following valid templates are ignored until sqlfluff support SHOW statements
-# https://github.com/sqlfluff/sqlfluff/issues/4811
-show_tables.sql.jinja
-show_views.sql.jinja
 /scratch/
-
-# This is a temporary ignore due to time pressure - not sure of root cause,
-# but the table in question builds
-codeable_concept_denormalize.sql.jinja
-
-# This template causes sqlfluff to hang - need to try a version uprev at some point
-code_system_pairs.sql.jinja
-
 # This is a common destination for debugging sql generation
 output.sql

--- a/cumulus_library/studies/core/documentreference.sql
+++ b/cumulus_library/studies/core/documentreference.sql
@@ -72,7 +72,7 @@ WITH powerset AS (
     WHERE
         d.encounter_ref = e.encounter_ref
         AND d.status = 'current'
-        AND d.docstatus IN (null, 'final', 'amended')
+        AND d.docstatus IN (NULL, 'final', 'amended')
     GROUP BY cube(d.doc_type_display, d.author_month, e.enc_class_display)
 )
 

--- a/cumulus_library/studies/core/encounter.sql
+++ b/cumulus_library/studies/core/encounter.sql
@@ -58,7 +58,7 @@ SELECT DISTINCT
     p.postalcode3
 FROM temp_encounter AS e
 LEFT JOIN core__fhir_mapping_expected_act_encounter_code_v3 AS eac
-    ON eac.found = e.class.code
+    ON e.class.code = eac.found
 LEFT JOIN core__fhir_act_encounter_code_v3 AS ac ON eac.expected = ac.code
 INNER JOIN core__patient AS p ON e.subject_ref = p.subject_ref
 WHERE

--- a/cumulus_library/studies/core/fhir_lookup_tables.sql
+++ b/cumulus_library/studies/core/fhir_lookup_tables.sql
@@ -51,4 +51,4 @@ FROM
             'virtual'
         )
     )
-    AS t (code, display)
+        AS t (code, display)

--- a/cumulus_library/studies/core/fhir_mapping_tables.sql
+++ b/cumulus_library/studies/core/fhir_mapping_tables.sql
@@ -114,7 +114,7 @@ SELECT * FROM
             'http://hl7.org/fhir/observation-definitions.html#Observation.value_x_'
         ),
         ('VitalSign', 'http://hl7.org/fhir/observation-vitalsigns.html')
-    ) AS t (resource, uri); --noqa: AL05
+    ) AS t (resource, uri);
 
 -- ############################################################
 -- FHIR mapping of as found Encounter codes to the expected encounter code from

--- a/cumulus_library/studies/core/medication_request.sql
+++ b/cumulus_library/studies/core/medication_request.sql
@@ -6,7 +6,7 @@ SELECT
     mr.intent,
     date(from_iso8601_timestamp(mr.authoredon)) AS authoredon,
     date_trunc('month', date(from_iso8601_timestamp(mr.authoredon)))
-    AS authoredon_month,
+        AS authoredon_month,
     mr.category,
     cm.code_system AS rx_system,
     cm.code AS rx_code,
@@ -14,7 +14,7 @@ SELECT
     mr.id AS med_admin_id,
     mr.subject.reference AS subject_ref
 FROM medicationrequest AS mr
-INNER JOIN core__medication AS cm ON cm.id = mr.id
+INNER JOIN core__medication AS cm ON mr.id = cm.id
 WHERE cm.code_system = 'http://www.nlm.nih.gov/research/umls/rxnorm';
 
 

--- a/cumulus_library/studies/core/observation.sql
+++ b/cumulus_library/studies/core/observation.sql
@@ -16,7 +16,7 @@ WITH temp_observation AS (
         o.id AS observation_id,
         concat('Observation/', o.id) AS observation_ref
     FROM observation AS o,
-        unnest(code.coding) AS t_coding (code_row) --noqa: AL05
+        unnest(code.coding) AS t_coding (code_row)
 )
 
 SELECT

--- a/cumulus_library/studies/core/observation_lab.sql
+++ b/cumulus_library/studies/core/observation_lab.sql
@@ -29,8 +29,8 @@ WITH temp_observation_lab AS (
         concat('Observation/', o.id) AS observation_ref
     -- , valueQuantity
     FROM observation AS o,
-        unnest(category) AS t_category(observation_category), --noqa
-        unnest(observation_category.coding) AS t_coding(category_row) --noqa
+        unnest(category) AS t_category (observation_category),
+        unnest(observation_category.coding) AS t_coding (category_row)
     WHERE category_row.code = 'laboratory'
 )
 

--- a/cumulus_library/studies/core/observation_vital_signs.sql
+++ b/cumulus_library/studies/core/observation_vital_signs.sql
@@ -36,6 +36,6 @@ SELECT
     t_obs.observation_category,
     t_cat.category_row
 FROM core__observation AS co,
-    UNNEST(category) AS t_obs (observation_category), --noqa: AL05
-    UNNEST(observation_category.coding) AS t_cat (category_row) --noqa: AL05
+    UNNEST(category) AS t_obs (observation_category),
+    UNNEST(observation_category.coding) AS t_cat (category_row)
 WHERE category_row.code = 'vital-signs';

--- a/cumulus_library/studies/core/patient.sql
+++ b/cumulus_library/studies/core/patient.sql
@@ -34,7 +34,7 @@ SELECT DISTINCT
     coalesce(tp.ethnicity_display, 'unknown') AS ethnicity_display
 FROM
     temp_patient AS tp,
-    unnest(tp.address) AS t_address (addr_row) --noqa: AL05
+    unnest(tp.address) AS t_address (addr_row)
 
 WHERE
     tp.birthdate IS NOT NULL

--- a/cumulus_library/studies/core/patient_extensions.sql
+++ b/cumulus_library/studies/core/patient_extensions.sql
@@ -23,7 +23,7 @@ CREATE TABLE core__patient_ext_race AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
             AND ext_child.ext.url = 'ombCategory'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     system_detailed AS (
         SELECT DISTINCT
@@ -40,7 +40,7 @@ CREATE TABLE core__patient_ext_race AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
             AND ext_child.ext.url = 'detailed'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     system_text AS (
         SELECT DISTINCT
@@ -57,7 +57,7 @@ CREATE TABLE core__patient_ext_race AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
             AND ext_child.ext.url = 'text'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     union_table AS (
         SELECT
@@ -126,7 +126,7 @@ CREATE TABLE core__patient_ext_ethnicity AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
             AND ext_child.ext.url = 'ombCategory'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     system_detailed AS (
         SELECT DISTINCT
@@ -143,7 +143,7 @@ CREATE TABLE core__patient_ext_ethnicity AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
             AND ext_child.ext.url = 'detailed'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     system_text AS (
         SELECT DISTINCT
@@ -160,7 +160,7 @@ CREATE TABLE core__patient_ext_ethnicity AS (
             ext_parent.ext.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
             AND ext_child.ext.url = 'text'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     union_table AS (
         SELECT

--- a/cumulus_library/studies/core/setup.sql
+++ b/cumulus_library/studies/core/setup.sql
@@ -60,4 +60,4 @@ FROM
             'Emergency department Consult note'
         )
     )
-    AS t (from_system, from_code, analyte, code_system, code, display);
+        AS t (from_system, from_code, analyte, code_system, code, display);

--- a/cumulus_library/studies/core/study_period.sql
+++ b/cumulus_library/studies/core/study_period.sql
@@ -56,7 +56,7 @@ SELECT
     de.enc_class_display,
     de.doc_type_code,
     de.doc_type_display,
-    coalesce(ed.code IS NOT NULL, false) AS ed_note
+    coalesce(ed.code IS NOT NULL, FALSE) AS ed_note
 FROM documented_encounter AS de
 LEFT JOIN core__ed_note AS ed
     ON de.doc_type_code = ed.from_code;

--- a/cumulus_library/studies/template/counts.sql
+++ b/cumulus_library/studies/template/counts.sql
@@ -9,9 +9,9 @@ WITH powerset AS (
     FROM template__influenza_lab_observations AS tflo
     GROUP BY
         cube(
-            tflo.influenza_test_code,
-            tflo.influenza_test_result,
-            tflo.influenza_test_month
+                tflo.influenza_test_code,
+                tflo.influenza_test_result,
+                tflo.influenza_test_month
         )
 )
 

--- a/cumulus_library/studies/vocab/icd_legend.sql
+++ b/cumulus_library/studies/vocab/icd_legend.sql
@@ -11,10 +11,10 @@ FROM (
         CONCAT(code, ' ', str) AS code_display,
         sab AS code_system,
         ROW_NUMBER()
-        OVER (
-            PARTITION BY sab, code
-            ORDER BY LENGTH(str) ASC
-        ) AS pref
+            OVER (
+                PARTITION BY sab, code
+                ORDER BY LENGTH(str) ASC
+            ) AS pref
     FROM vocab__icd
 )
 WHERE pref = 1;

--- a/cumulus_library/template_sql/code_system_pairs.sql.jinja
+++ b/cumulus_library/template_sql/code_system_pairs.sql.jinja
@@ -27,18 +27,24 @@ SELECT DISTINCT
     t.row.display,
     t.row.system
 FROM {{ source.table_name }},
-UNNEST({{source.column_name}}.coding) AS t (row)
+UNNEST({{ source.column_name }}.coding) AS t (row)
 {%- endif %}
 {%- else %}
-SELECT * 
-    FROM ( 
-        VALUES (
-            ('{{ source.table_name }}','{{ source.column_name }}', '', '', '')
+SELECT *
+FROM (
+    VALUES (
+        (
+            {{ source.table_name }}',
+            {{ source.column_name }}',
+            '',
+            '',
+            ''
         )
     )
-AS t ( table_name, column_name, code, display, system ) -- noqa: L025
+)
+    AS t (table_name, column_name, code, display, system) -- noqa: L025
 {%- endif -%}
 {%- if not loop.last %}
 UNION
 {%- endif -%}
-{%  endfor %}
+{% endfor %}

--- a/cumulus_library/template_sql/code_system_pairs.sql.jinja
+++ b/cumulus_library/template_sql/code_system_pairs.sql.jinja
@@ -42,7 +42,7 @@ FROM (
         )
     )
 )
-    AS t (table_name, column_name, code, display, system) -- noqa: L025
+    AS t (table_name, column_name, code, display, system)
 {%- endif -%}
 {%- if not loop.last %}
 UNION

--- a/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
+++ b/cumulus_library/template_sql/codeable_concept_denormalize.sql.jinja
@@ -1,12 +1,13 @@
 CREATE TABLE {{ target_table }} AS (
     WITH
     {%- for system in code_systems %}
+
     system_{{ column_name }}_{{ loop.index0 }} AS (
         SELECT DISTINCT
             s.{{ source_id }} AS id,
-        {%- if filter_priority %}
+            {%- if filter_priority %}
             '{{ loop.index0 }}' AS priority,
-        {%- endif %}
+            {%- endif %}
             u.codeable_concept.code AS code,
             u.codeable_concept.display AS display,
             u.codeable_concept.system AS code_system
@@ -29,9 +30,9 @@ CREATE TABLE {{ target_table }} AS (
         {%- for system in code_systems %}
         SELECT
             id,
-        {%- if filter_priority %}
+            {%- if filter_priority %}
             priority,
-        {%- endif %}
+            {%- endif %}
             code_system,
             code,
             display
@@ -41,7 +42,7 @@ CREATE TABLE {{ target_table }} AS (
         {%- endif -%}
         {%- endfor %}
     )
-{%- if filter_priority -%},
+    {%- if filter_priority -%},
 
     partitioned_table AS (
         SELECT
@@ -51,9 +52,9 @@ CREATE TABLE {{ target_table }} AS (
             display,
             priority,
             ROW_NUMBER()
-            OVER (
-                PARTITION BY id
-            ) AS available_priority
+                OVER (
+                    PARTITION BY id
+                ) AS available_priority
         FROM union_table
         GROUP BY id, priority, code_system, code, display
         ORDER BY priority ASC

--- a/cumulus_library/template_sql/core_medication.sql.jinja
+++ b/cumulus_library/template_sql/core_medication.sql.jinja
@@ -95,9 +95,9 @@ CREATE TABLE core__medication AS (
             'None' AS code,
             cu.code.text AS display,
             'None' AS code_system,
-            false AS userselected
+            FALSE AS userselected
         FROM mrc_contained_unnest AS cu
-        INNER JOIN mrc_ref_id AS ri ON ri.id = cu.id
+        INNER JOIN mrc_ref_id AS ri ON cu.id = ri.id
     )
     {%- endif -%}
     {# comma handling for ctas chaining #}
@@ -151,7 +151,7 @@ CREATE TABLE core__medication AS (
             t.r.code AS code,
             mmn.code.text AS display,
             t.r.system AS code_system,
-            false AS userselected
+            FALSE AS userselected
         FROM mre_med_nonnull AS mmn,
             unnest(mmn.code.coding) AS t (r)
     )

--- a/cumulus_library/template_sql/create_view_as.sql.jinja
+++ b/cumulus_library/template_sql/create_view_as.sql.jinja
@@ -15,13 +15,13 @@ CREATE OR REPLACE VIEW {{ view_name }} AS (
         {%- endif -%}
         {%- endfor %}
     )
-    AS t -- noqa: L025
-    (
-        {%- for col in view_cols -%}
-        "{{ col }}"
-        {%- if not loop.last -%}
-        , 
-        {%- endif -%}
-        {%- endfor -%}
-    )
+        AS t
+        (
+            {%- for col in view_cols -%}
+            "{{ col }}"
+            {%- if not loop.last -%}
+            , 
+            {%- endif -%}
+            {%- endfor -%}
+        )
 );

--- a/cumulus_library/template_sql/ctas.sql.jinja
+++ b/cumulus_library/template_sql/ctas.sql.jinja
@@ -15,13 +15,13 @@ CREATE TABLE "{{ schema_name }}"."{{ table_name }}" AS (
         {%- endif -%}
         {%- endfor %}
     )
-    AS t -- noqa: L025
-    (
-        {%- for col in table_cols -%}
-        "{{ col }}"
-        {%- if not loop.last -%}
-        , 
-        {%- endif -%}
-        {%- endfor -%}
-    )
+        AS t
+        (
+            {%- for col in table_cols -%}
+            "{{ col }}"
+            {%- if not loop.last -%}
+            , 
+            {%- endif -%}
+            {%- endfor -%}
+        )
 );

--- a/cumulus_library/template_sql/ctas_empty.sql.jinja
+++ b/cumulus_library/template_sql/ctas_empty.sql.jinja
@@ -10,13 +10,13 @@ CREATE TABLE "{{ schema_name }}"."{{ table_name }}" AS (
             {%- endfor -%}
         ))
     )
-    AS t -- noqa: L025
-    (
-        {%- for col in table_cols -%}
-        "{{ col }}"
-        {%- if not loop.last -%}
-        , 
-        {%- endif -%}
-        {%- endfor -%}
-    )
+        AS t
+        (
+            {%- for col in table_cols -%}
+            "{{ col }}"
+            {%- if not loop.last -%}
+            , 
+            {%- endif -%}
+            {%- endfor -%}
+        )
 );

--- a/cumulus_library/template_sql/extension_denormalize.sql.jinja
+++ b/cumulus_library/template_sql/extension_denormalize.sql.jinja
@@ -17,7 +17,7 @@ CREATE TABLE {{ target_table }} AS (
             ext_parent.ext.url = '{{ fhir_extension }}'
             AND ext_child.ext.url = '{{ system }}'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
     {%- endfor %}
 
     union_table AS (
@@ -55,7 +55,7 @@ CREATE TABLE {{ target_table }} AS (
                     ), '; '
                 )
             )
-            AS {{ target_col_prefix }}_code,
+                AS {{ target_col_prefix }}_code,
             LOWER(
                 ARRAY_JOIN(
                     ARRAY_SORT(
@@ -72,9 +72,9 @@ CREATE TABLE {{ target_table }} AS (
             ) AS {{ target_col_prefix }}_display,
             {%- endif %}
             ROW_NUMBER()
-            OVER (
-                PARTITION BY id, system
-            ) AS available_priority
+                OVER (
+                    PARTITION BY id, system
+                ) AS available_priority
         FROM union_table
         GROUP BY id, system
     )

--- a/cumulus_library/template_sql/show_tables.sql.jinja
+++ b/cumulus_library/template_sql/show_tables.sql.jinja
@@ -1,1 +1,1 @@
-SHOW TABLES FROM `{{schema_name}}` '{{prefix}}*';
+SHOW TABLES IN `{{ schema_name }}` '{{ prefix }}*';

--- a/cumulus_library/template_sql/show_views.sql.jinja
+++ b/cumulus_library/template_sql/show_views.sql.jinja
@@ -1,1 +1,1 @@
-SHOW VIEWS IN "{{schema_name}}" LIKE '{{prefix}}*';
+SHOW VIEWS IN "{{ schema_name }}" LIKE '{{ prefix }}*';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,12 @@ dependencies = [
     "ctakesclient >= 1.3",
     "fhirclient >= 4.1",
     "Jinja2 > 3",
-    "pandas <2, >=1.5.0",
+    "pandas <3, >=2.1.1",
     "pyarrow >= 11.0",
     "pyathena >= 2.23",
     "requests >= 2.28",
     "rich >= 13.2",
-    # There are some bugfix actions occuring in sqlfluff that are currently
-    # breaking autoformatting for CTAS queries - pinning until this shakes out
-    "sqlfluff == 2.0.2",
+    "sqlfluff >= 2.3.4",
     "toml >= 0.10"
 ]
 description = "Clinical study SQL generation for data derived from bulk FHIR"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -19,6 +19,7 @@ from cumulus_library.template_sql.templates import (
 def test_codeable_concept_denormalize_all_creation():
     expected = """CREATE TABLE target__concepts AS (
     WITH
+
     system_code_col_0 AS (
         SELECT DISTINCT
             s.id AS id,
@@ -61,6 +62,7 @@ def test_codeable_concept_denormalize_all_creation():
 def test_codeable_concept_denormalize_filter_creation():
     expected = """CREATE TABLE target__concepts AS (
     WITH
+
     system_code_col_0 AS (
         SELECT DISTINCT
             s.id AS id,
@@ -74,6 +76,7 @@ def test_codeable_concept_denormalize_filter_creation():
         WHERE
             u.codeable_concept.system = 'http://snomed.info/sct'
     ), --noqa: LT07
+
     system_code_col_1 AS (
         SELECT DISTINCT
             s.id AS id,
@@ -114,9 +117,9 @@ def test_codeable_concept_denormalize_filter_creation():
             display,
             priority,
             ROW_NUMBER()
-            OVER (
-                PARTITION BY id
-            ) AS available_priority
+                OVER (
+                    PARTITION BY id
+                ) AS available_priority
         FROM union_table
         GROUP BY id, priority, code_system, code, display
         ORDER BY priority ASC
@@ -349,8 +352,8 @@ def test_create_view_query_creation():
         ('foo','foo'),
         ('bar','bar')
     )
-    AS t -- noqa: L025
-    ("a","b")
+        AS t
+        ("a","b")
 );"""
     query = get_create_view_query(
         view_name="test_view",
@@ -367,8 +370,8 @@ def test_ctas_query_creation():
         ((cast('foo' AS varchar),cast('foo' AS varchar))),
         ((cast('bar' AS varchar),cast('bar' AS varchar)))
     )
-    AS t -- noqa: L025
-    ("a","b")
+        AS t
+        ("a","b")
 );"""
     query = get_ctas_query(
         schema_name="test_schema",
@@ -398,7 +401,7 @@ def test_extension_denormalize_creation():
             ext_parent.ext.url = 'fhir_extension'
             AND ext_child.ext.url = 'omb'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     system_text AS (
         SELECT DISTINCT
@@ -415,7 +418,7 @@ def test_extension_denormalize_creation():
             ext_parent.ext.url = 'fhir_extension'
             AND ext_child.ext.url = 'text'
             AND ext_child.ext.valuecoding.display != ''
-    ), --noqa: LT07
+    ),
 
     union_table AS (
         SELECT
@@ -450,9 +453,9 @@ def test_extension_denormalize_creation():
                 prefix_display
             ) AS prefix_display,
             ROW_NUMBER()
-            OVER (
-                PARTITION BY id, system
-            ) AS available_priority
+                OVER (
+                    PARTITION BY id, system
+                ) AS available_priority
         FROM union_table
         GROUP BY id, system
     )
@@ -487,7 +490,7 @@ def test_extension_denormalize_creation():
                     ), '; '
                 )
             )
-            AS prefix_code,
+                AS prefix_code,
             LOWER(
                 ARRAY_JOIN(
                     ARRAY_SORT(
@@ -591,13 +594,19 @@ SELECT DISTINCT
     bcol.system
 FROM bare
 UNION
-SELECT * 
-    FROM ( 
-        VALUES (
-            ('empty','empty', '', '', '')
+SELECT *
+FROM (
+    VALUES (
+        (
+            empty',
+            empty',
+            '',
+            '',
+            ''
         )
     )
-AS t ( table_name, column_name, code, display, system ) -- noqa: L025"""
+)
+    AS t (table_name, column_name, code, display, system)"""
     query = get_code_system_pairs(
         "output_table",
         [


### PR DESCRIPTION
This PR makes the following changes:
- Uprevs pandas #127 
- Updates SqlFluff to latest version 
  - This removes the need for all our current rule exceptions (thank god)
  - Global rerun (the bulk of changes in this PR

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration