### PR TITLE
Confirm drop by prefix, add --continue

### DIFF
--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -141,6 +141,12 @@ following order of preference is used to select credentials:
     add_verbose_argument(build)
     add_aws_config(build)
 
+    build.add_argument(
+        "--continue",
+        dest="continue_from",
+        help=(argparse.SUPPRESS),
+    )
+
     export = actions.add_parser(
         "export", help="Generates files on disk from Athena views"
     )

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -16,7 +16,7 @@ def add_table_builder_argument(parser: argparse.ArgumentParser) -> None:
     """Adds --builder arg to a subparser"""
     parser.add_argument(
         "--builder",
-        help=(argparse.SUPPRESS),
+        help=argparse.SUPPRESS,
     )
 
 
@@ -129,7 +129,7 @@ following order of preference is used to select credentials:
     clean.add_argument(
         "--prefix",
         action="store_true",
-        help=(argparse.SUPPRESS),
+        help=argparse.SUPPRESS,
     )
 
     build = actions.add_parser(
@@ -145,7 +145,7 @@ following order of preference is used to select credentials:
     build.add_argument(
         "--continue",
         dest="continue_from",
-        help=(argparse.SUPPRESS),
+        help=argparse.SUPPRESS,
     )
 
     export = actions.add_parser(

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -123,6 +123,7 @@ following order of preference is used to select credentials:
     )
 
     add_target_argument(clean)
+    add_study_dir_argument(clean)
     add_verbose_argument(clean)
     add_aws_config(clean)
     clean.add_argument(

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -94,15 +94,11 @@ class StudyManifestParser:
         sql_config = self._study_config.get("sql_config", {})
         sql_files = sql_config.get("file_names", [])
         if continue_from:
-            match_found = False
-            for file in sql_files:
-                print(continue_from.replace(".sql", ""))
-                print(file.replace(".sql", ""))
+            for pos, file in enumerate(sql_files):
                 if continue_from.replace(".sql", "") == file.replace(".sql", ""):
-                    sql_files = sql_files[sql_files.index(file) :]
-                    match_found = True
+                    sql_files = sql_files[pos:]
                     break
-            if not match_found:
+            else:
                 sys.exit(f"No tables matching '{continue_from}' found")
         return sql_files
 
@@ -206,7 +202,7 @@ class StudyManifestParser:
             print("The following views/tables were selected by prefix:")
             for view_table in view_table_list:
                 print(f"  {view_table[0]}")
-            confirm = input("Remove these tables? (Y/N)")
+            confirm = input("Remove these tables? (y/N)")
             if confirm.lower() not in ("y", "yes"):
                 sys.exit("Table cleaning aborted")
         with get_progress_bar(disable=verbose) as progress:

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -86,13 +86,25 @@ class StudyManifestParser:
         """
         return self._study_config.get("study_prefix")
 
-    def get_sql_file_list(self) -> Optional[StrList]:
+    def get_sql_file_list(self, continue_from: str = None) -> Optional[StrList]:
         """Reads the contents of the sql_config array from the manifest
 
         :returns: An array of sql files from the manifest, or None if not found.
         """
         sql_config = self._study_config.get("sql_config", {})
-        return sql_config.get("file_names", [])
+        sql_files = sql_config.get("file_names", [])
+        if continue_from:
+            match_found = False
+            for file in sql_files:
+                print(continue_from.replace(".sql", ""))
+                print(file.replace(".sql", ""))
+                if continue_from.replace(".sql", "") == file.replace(".sql", ""):
+                    sql_files = sql_files[sql_files.index(file) :]
+                    match_found = True
+                    break
+            if not match_found:
+                sys.exit(f"No tables matching '{continue_from}' found")
+        return sql_files
 
     def get_table_builder_file_list(self) -> Optional[StrList]:
         """Reads the contents of the table_builder_config array from the manifest
@@ -190,6 +202,13 @@ class StudyManifestParser:
             ):
                 view_table_list.remove(view_table)
         # We want to only show a progress bar if we are :not: printing SQL lines
+        if prefix:
+            print("The following views/tables were selected by prefix:")
+            for view_table in view_table_list:
+                print(f"  {view_table[0]}")
+            confirm = input("Remove these tables? (Y/N)")
+            if confirm.lower() not in ("y", "yes"):
+                sys.exit("Table cleaning aborted")
         with get_progress_bar(disable=verbose) as progress:
             task = progress.add_task(
                 f"Removing {display_prefix} study artifacts...",
@@ -314,7 +333,9 @@ class StudyManifestParser:
             name = f"{name}.py"
         self._load_and_execute_builder(name, cursor, schema, verbose, drop_table=True)
 
-    def build_study(self, cursor: object, verbose: bool = False) -> List:
+    def build_study(
+        self, cursor: object, verbose: bool = False, continue_from: str = None
+    ) -> List:
         """Creates tables in the schema by iterating through the sql_config.file_names
 
         :param cursor: A PEP-249 compatible cursor object
@@ -323,7 +344,7 @@ class StudyManifestParser:
         :returns: loaded queries (for unit testing only)
         """
         queries = []
-        for file in self.get_sql_file_list():
+        for file in self.get_sql_file_list(continue_from):
             for query in parse_sql(load_text(f"{self._study_path}/{file}")):
                 queries.append([query, file])
         if len(queries) == 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,11 +116,11 @@ def test_count_builder_mapping(
             [
                 "clean",
                 "-t",
-                "study_python_counts_valid",
+                "core",
                 "--database",
                 "test",
             ],
-            "study_python_counts_valid__",
+            "core__",
         ),
         (
             [


### PR DESCRIPTION
This PR makes the following changes:
- Asks for confirmation when using the `--prefix` argument #129 
- Adds a `--continue` param for specifying a point in the manifest's list of SQL files to continue a build from (useful for debugging errors that occur at near the end of a build)
- As a result of doing this, cleaned up some places where clean wasn't quite wired into reading a prefix directly from a manifest

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration