### PR TITLE
fix quoting in code pair template

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -1,2 +1,2 @@
 """Package metadata"""
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/cumulus_library/template_sql/code_system_pairs.sql.jinja
+++ b/cumulus_library/template_sql/code_system_pairs.sql.jinja
@@ -34,8 +34,8 @@ SELECT *
 FROM (
     VALUES (
         (
-            {{ source.table_name }}',
-            {{ source.column_name }}',
+            '{{ source.table_name }}',
+            '{{ source.column_name }}',
             '',
             '',
             ''

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -598,8 +598,8 @@ SELECT *
 FROM (
     VALUES (
         (
-            empty',
-            empty',
+            'empty',
+            'empty',
             '',
             '',
             ''


### PR DESCRIPTION
This PR cleans up some missing quotes in the code pairs template.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Run pylint if you're making changes beyond adding studies
- [X] Update template repo if there are changes to study configuration