### PR TITLE
feat: add Medication to duckdb schema list

### DIFF
--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -175,6 +175,7 @@ def read_ndjson_dir(path: str) -> dict[str, pyarrow.Table]:
         "DocumentReference",
         "Encounter",
         "Immunization",
+        "Medication",
         "MedicationRequest",
         "Observation",
         "Patient",


### PR DESCRIPTION
I just forgot about Medication because it's a weird little generated table from ETL.

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies
- [x] Update template repo if there are changes to study configuration