### PR TITLE
fix(duckdb): skip nulls inside array for array_join()

### DIFF
--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -148,10 +148,12 @@ class DuckDatabaseBackend(DatabaseBackend):
             self.connection.register(name, table)
 
     @staticmethod
-    def _compat_array_join(value: Optional[list[str]], delimiter: str) -> Optional[str]:
+    def _compat_array_join(
+        value: Optional[list[Optional[str]]], delimiter: str
+    ) -> Optional[str]:
         if value is None:
             return None
-        return delimiter.join(value)
+        return delimiter.join(v for v in value if v is not None)
 
     @staticmethod
     def _compat_date(


### PR DESCRIPTION
This is how Athena handles them.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies
- [x] Update template repo if there are changes to study configuration