### PR TITLE
Fix duckdb's from_iso8601_timestamp() to handle just-year timestamps

### DIFF
--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -251,6 +251,15 @@ class DuckDatabaseBackend(DatabaseBackend):
     ) -> Optional[datetime.datetime]:
         if value is None:
             return None
+
+        # handle partial dates like 1970 or 1980-12 (which spec allows)
+        if len(value) < 10:
+            pieces = value.split("-")
+            if len(pieces) == 1:
+                return datetime.datetime(int(pieces[0]), 1, 1)
+            else:
+                return datetime.datetime(int(pieces[0]), int(pieces[1]), 1)
+
         return datetime.datetime.fromisoformat(value)
 
     def cursor(self) -> duckdb.DuckDBPyConnection:


### PR DESCRIPTION
i.e. "2024" -> "2024-01-01"


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Run pylint if you're making changes beyond adding studies
- [x] Update template repo if there are changes to study configuration