### PR TITLE
Updated name of patient count field in stats

### DIFF
--- a/cumulus_library/statistics/counts.py
+++ b/cumulus_library/statistics/counts.py
@@ -47,11 +47,11 @@ class CountsBuilder(BaseTableBuilder):
         """Convenience method for constructing arbitrary where clauses.
 
         :param clause: either a string or a list of sql where statements
-        :param min_subject: if clause is none, the bin size for a cnt_subject filter
+        :param min_subject: if clause is none, the bin size for a cnt_subject_ref filter
             (deprecated, use count_[fhir_resource](min_subject) instead)
         """
         if clause is None:
-            return [f"cnt_subject >= {min_subject}"]
+            return [f"cnt_subject_ref >= {min_subject}"]
         elif isinstance(clause, str):
             return [clause]
         elif isinstance(clause, list):

--- a/tests/test_counts_builder.py
+++ b/tests/test_counts_builder.py
@@ -27,8 +27,8 @@ def test_get_table_name(name, duration, expected):
 @pytest.mark.parametrize(
     "clause,min_subject,expected,raises",
     [
-        (None, None, ["cnt_subject >= 10"], does_not_raise()),
-        (None, 5, ["cnt_subject >= 5"], does_not_raise()),
+        (None, None, ["cnt_subject_ref >= 10"], does_not_raise()),
+        (None, 5, ["cnt_subject_ref >= 5"], does_not_raise()),
         ("age > 5", None, ["age > 5"], does_not_raise()),
         (["age > 5", "sex =='F'"], None, ["age > 5", "sex =='F'"], does_not_raise()),
         ("age > 5", 7, ["age > 5"], does_not_raise()),


### PR DESCRIPTION
This updates the subject field generated by the counts builder to match the correct v2 name.
### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration