### PR TITLE
Improved upload error reporting

### DIFF
--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -323,7 +323,7 @@ def run_cli(args: dict):
             upload.upload_files(args)
         except requests.RequestException as e:
             print(str(e))
-            exit()
+            sys.exit()
 
     # all other actions require connecting to the database
     else:

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import sysconfig
 
+import requests
 import rich
 
 from cumulus_library import (
@@ -318,7 +319,11 @@ def run_cli(args: dict):
         create_template(args["create_dir"])
 
     elif args["action"] == "upload":
-        upload.upload_files(args)
+        try:
+            upload.upload_files(args)
+        except requests.RequestException as e:
+            print(str(e))
+            exit()
 
     # all other actions require connecting to the database
     else:

--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -42,9 +42,8 @@ def upload_data(
 
     if prefetch_res.status_code != 200:
         print("Invalid user/site id")
-        raise requests.RequestException(response=prefetch_res)
+        prefetch_res.raise_for_status()
     res_body = prefetch_res.json()
-
     with open(file_path, "rb") as data_file:
         files = {"file": (file_name, data_file)}
         upload_req = requests.Request(
@@ -55,7 +54,7 @@ def upload_data(
             upload_res = s.send(upload_req, timeout=60)
             if upload_res.status_code != 204:
                 print(f"Error uploading {study}/{file_name}")
-                raise requests.RequestException(response=upload_res)
+                upload_res.raise_for_status()
         else:
             print("upload_req")
             print("headers", upload_req.headers)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-import requests
 import requests_mock
 import toml
 
@@ -507,13 +506,13 @@ def test_cli_stats_rebuild(tmp_path):
             ["upload", "--user", "user", "--id", "id"],
             500,
             False,
-            pytest.raises(requests.exceptions.RequestException),
+            pytest.raises(SystemExit),
         ),
         (
             ["upload", "--user", "baduser", "--id", "badid"],
             204,
             True,
-            pytest.raises(requests.exceptions.RequestException),
+            pytest.raises(SystemExit),
         ),
         (
             ["upload", "--user", "user", "--id", "id", "./foo"],


### PR DESCRIPTION
This PR makes the following changes:
- Switches to the builtin response.raise_for_status() function for error generation on rejected uploads for nicer formatting
- Catches the RequestException gracefully rather than dumping a stack trace

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration