### PR TITLE
Track db type for jinja templates

### DIFF
--- a/cumulus_library/.sqlfluff
+++ b/cumulus_library/.sqlfluff
@@ -76,6 +76,7 @@ dataset =
         ["foo","foo"],
         ["bar","bar"]
     ]
+db_type = duckdb
 dependent_variable = is_flu
 ext_systems = ["omb", "text"]
 field = 'column_name'

--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -24,6 +24,8 @@ import pyathena
 from pyathena.common import BaseCursor as AthenaCursor
 from pyathena.pandas.cursor import PandasCursor as AthenaPandasCursor
 
+from cumulus_library import db_config
+
 
 class DatabaseCursor(Protocol):
     """Protocol for a PEP-249 compatible cursor"""
@@ -474,6 +476,7 @@ def read_ndjson_dir(path: str) -> dict[str, pyarrow.Table]:
 
 def create_db_backend(args: dict[str, str]) -> DatabaseBackend:
     db_type = args["db_type"]
+    db_config.db_type = db_type
     database = args["schema_name"]
     load_ndjson_dir = args.get("load_ndjson_dir")
 

--- a/cumulus_library/db_config.py
+++ b/cumulus_library/db_config.py
@@ -1,0 +1,4 @@
+# Variables in this file should only be written to by databases.py, and should be
+# treated as read only elsewhere.
+# TODO: Move to config object passed down from main cli to builders
+db_type = None

--- a/cumulus_library/template_sql/base_templates.py
+++ b/cumulus_library/template_sql/base_templates.py
@@ -6,6 +6,7 @@ import pathlib
 import jinja2
 import pandas
 
+from cumulus_library import db_config
 from cumulus_library.template_sql import sql_utils
 
 
@@ -36,7 +37,7 @@ def get_base_template(
             macro_paths.append(path)
         loader = jinja2.FileSystemLoader(macro_paths)
         env = jinja2.Environment(loader=loader).from_string(template)
-        return env.render(**kwargs)
+        return env.render(**kwargs, db_type=db_config.db_type)
 
 
 # All remaining functions are context-specific calls aimed at providing

--- a/tests/test_data/study_python_local_template/local_template.py
+++ b/tests/test_data/study_python_local_template/local_template.py
@@ -1,0 +1,15 @@
+import pathlib
+
+from cumulus_library.template_sql import base_templates
+
+PATH = pathlib.Path(__file__).parent
+
+
+def get_local_template(
+    target_table: str,
+    schema: dict[dict[bool]] | None = None,
+    config: dict | None = None,
+) -> str:
+    return base_templates.get_base_template(
+        target_table, path=PATH, schema=schema, config=config
+    )

--- a/tests/test_data/study_python_local_template/manifest.toml
+++ b/tests/test_data/study_python_local_template/manifest.toml
@@ -1,0 +1,4 @@
+study_prefix = "study_python_local_template"
+
+[table_builder_config]
+file_names = ["module1.py"]

--- a/tests/test_data/study_python_local_template/module1.py
+++ b/tests/test_data/study_python_local_template/module1.py
@@ -1,0 +1,11 @@
+from cumulus_library.base_table_builder import BaseTableBuilder
+from tests.test_data.study_python_local_template import local_template
+
+
+class ModuleOneRunner(BaseTableBuilder):
+    display_text = "module1"
+
+    def prepare_queries(self, cursor: object, schema: str, *args, **kwargs):
+        self.queries.append(
+            local_template.get_local_template("table", config={"field": "foo"})
+        )

--- a/tests/test_data/study_python_local_template/table.sql.jinja
+++ b/tests/test_data/study_python_local_template/table.sql.jinja
@@ -1,0 +1,2 @@
+CREATE TABLE IF NOT EXISTS study_python_valid__table_{{ db_type }}_{{ config.field }}
+(test int);

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -19,7 +19,6 @@ from cumulus_library.template_sql import base_templates
     clear=True,
 )
 def test_duckdb_core_build_and_export(tmp_path):
-    print(tmp_path)
     data_dir = f"{Path(__file__).parent}/test_data/duckdb_data"
     cli.main(
         [

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -211,6 +211,12 @@ def test_run_protected_table_builder(mock_db, study_path, stats):
             (),
             pytest.raises(errors.StudyManifestParsingError),
         ),
+        (
+            "./tests/test_data/study_python_local_template/",
+            False,
+            ("study_python_valid__table_duckdb_foo",),
+            does_not_raise(),
+        ),
     ],
 )
 def test_table_builder(mock_db, study_path, verbose, expects, raises):


### PR DESCRIPTION
This commit adds a module for storing information about the type of database requested via the CLI.

This is planned to be replaced the next time we make a breaking change: #225 

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration