### PR TITLE
StudyConfig infrastructure

### DIFF
--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -1,8 +1,8 @@
 """ Collection of small commonly used utility functions """
 
+import dataclasses
 import datetime
 import json
-import os
 import pathlib
 import shutil
 import zipfile
@@ -10,9 +10,34 @@ from contextlib import contextmanager
 
 from rich import progress
 
+from cumulus_library import databases
 
-def filepath(filename: str) -> str:
-    return os.path.join(os.path.dirname(__file__), filename)
+
+@dataclasses.dataclass
+class StudyConfig:
+    """Class for containing study-centric parameters
+
+    The intent of this class is that if you want something passed through to the
+    prepare_queries section of a study, this is the place it should go. If you're
+    doing something above that level, consider explicit arguments instead. This should
+    be an interface aimed at a study author.
+
+    :param db_backend: a databaseBackend object for a specific target database
+    :keyword db_type: the argument passed in from the CLI indicating the requested DB
+        (this is easier to use in things like jinja templates than db_backend, if they
+        need to run DB technology aware queries)
+    :keyword replace_existing: If the study downloads data from an external resource,
+        force it to skip any cached data when running
+    :keyword stats_build: If the study runs a stats builder, force regeneration of
+        any sampling or other stochastic techniques
+    :keyword umls: A UMLS API key
+    """
+
+    db_backend: databases.DatabaseBackend
+    db_type: str | None = None
+    replace_existing: bool = False
+    stats_build: bool = False
+    umls: str | None = None
 
 
 def load_text(path: str) -> str:
@@ -39,17 +64,6 @@ def parse_sql(sql_text: str) -> list[str]:
 
 def filter_strip(commands) -> list[str]:
     return list(filter(None, [c.strip() for c in commands]))
-
-
-def list_coding(code_display: dict, system=None) -> list[dict]:
-    as_list = []
-    for code, display in code_display.items():
-        if system:
-            item = {"code": code, "display": display, "system": system}
-        else:
-            item = {"code": code, "display": display}
-        as_list.append(item)
-    return as_list
 
 
 @contextmanager

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -33,11 +33,11 @@ class StudyConfig:
     :keyword umls: A UMLS API key
     """
 
-    db_backend: databases.DatabaseBackend
+    db: databases.DatabaseBackend
     db_type: str | None = None
-    replace_existing: bool = False
+    force_upload: bool = False
     stats_build: bool = False
-    umls: str | None = None
+    umls_key: str | None = None
 
 
 def load_text(path: str) -> str:

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -34,7 +34,6 @@ class StudyConfig:
     """
 
     db: databases.DatabaseBackend
-    db_type: str | None = None
     force_upload: bool = False
     stats_build: bool = False
     umls_key: str | None = None

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -345,7 +345,6 @@ def run_cli(args: dict):
     # all other actions require connecting to the database
     else:
         config = base_utils.StudyConfig(
-            db_type=args.get("db_type"),
             db=databases.create_db_backend(args),
             force_upload=args.get("replace_existing", False),
             stats_build=args.get("stats_build", False),

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -103,20 +103,20 @@ class StudyRunner:
         self,
         target: pathlib.Path,
         *,
-        stats_build: bool,
+        config: base_utils.StudyConfig,
         continue_from: str | None = None,
     ) -> None:
         """Recreates study views/tables
 
         :param target: A path to the study directory
-        :param stats_build: if True, forces creation of new stats tables
+        :param config: A StudyConfig object containing optional params
         :keyword continue_from: Restart a run from a specific sql file (for dev only)
         """
         studyparser = study_parser.StudyManifestParser(target, self.data_path)
         try:
             if not continue_from:
                 studyparser.run_protected_table_builder(
-                    self.cursor, self.schema_name, verbose=self.verbose
+                    self.cursor, self.schema_name, verbose=self.verbose, config=config
                 )
                 self.update_transactions(studyparser.get_study_prefix(), "started")
                 cleaned_tables = studyparser.clean_study(
@@ -127,25 +127,31 @@ class StudyRunner:
                 )
                 # If the study hasn't been created before, force stats table generation
                 if len(cleaned_tables) == 0:
-                    stats_build = True
+                    config.stats_build = True
                 studyparser.run_table_builder(
                     self.cursor,
                     self.schema_name,
                     verbose=self.verbose,
                     parser=self.db.parser(),
+                    config=config,
                 )
             else:
                 self.update_transactions(studyparser.get_study_prefix(), "resumed")
 
-            studyparser.build_study(self.cursor, self.verbose, continue_from)
+            studyparser.build_study(
+                self.cursor,
+                verbose=self.verbose,
+                continue_from=continue_from,
+                config=config,
+            )
             studyparser.run_counts_builders(
-                self.cursor, self.schema_name, verbose=self.verbose
+                self.cursor, self.schema_name, verbose=self.verbose, config=config
             )
             studyparser.run_statistics_builders(
                 self.cursor,
                 self.schema_name,
                 verbose=self.verbose,
-                stats_build=stats_build,
+                config=config,
             )
             self.update_transactions(studyparser.get_study_prefix(), "finished")
 
@@ -158,12 +164,16 @@ class StudyRunner:
             raise e
 
     def run_matching_table_builder(
-        self, target: pathlib.Path, table_builder_name: str
+        self,
+        target: pathlib.Path,
+        table_builder_name: str,
+        config: base_utils.StudyConfig,
     ) -> None:
         """Runs a single table builder
 
         :param target: A path to the study directory
         :param table_builder_name: a builder file referenced in the study's manifest
+        :param config: A StudyConfig object containing optional params
         """
         studyparser = study_parser.StudyManifestParser(target)
         studyparser.run_matching_table_builder(
@@ -172,26 +182,27 @@ class StudyRunner:
             table_builder_name,
             self.verbose,
             parser=self.db.parser(),
+            config=config,
         )
 
-    def clean_and_build_all(self, study_dict: dict, stats_build: bool) -> None:
-        """Builds views for all studies.
+    def clean_and_build_all(
+        self, study_dict: dict, config: base_utils.StudyConfig
+    ) -> None:
+        """Builds tables for all studies.
 
         NOTE: By design, this method will always exclude the `template` study dir,
         since 99% of the time you don't need a live copy in the database.
 
         :param study_dict: A dict of paths
-        :param stats_build: if True, regen stats tables
+        :param config: A StudyConfig object containing optional params
         """
         study_dict = dict(study_dict)
         study_dict.pop("template")
         for precursor_study in ["vocab", "core"]:
-            self.clean_and_build_study(
-                study_dict[precursor_study], stats_build=stats_build
-            )
+            self.clean_and_build_study(study_dict[precursor_study], config=config)
             study_dict.pop(precursor_study)
         for key in study_dict:
-            self.clean_and_build_study(study_dict[key], stats_build=stats_build)
+            self.clean_and_build_study(study_dict[key], config=config)
 
     ### Data exporters
     def export_study(
@@ -212,11 +223,16 @@ class StudyRunner:
             self.export_study(study_dict[key], data_path, archive)
 
     def generate_study_sql(
-        self, target: pathlib.Path, builder: str | None = None
+        self,
+        target: pathlib.Path,
+        *,
+        config: base_utils.StudyConfig,
+        builder: str | None = None,
     ) -> None:
         """Materializes study sql from templates
 
         :param target: A path to the study directory
+        :param config: A StudyConfig object containing optional params
         :param builder: Specify a single builder to generate sql from
         """
         studyparser = study_parser.StudyManifestParser(target)
@@ -226,6 +242,7 @@ class StudyRunner:
             builder=builder,
             verbose=self.verbose,
             parser=self.db.parser(),
+            config=config,
         )
 
     def generate_study_markdown(
@@ -327,9 +344,15 @@ def run_cli(args: dict):
 
     # all other actions require connecting to the database
     else:
-        db_backend = databases.create_db_backend(args)
+        config = base_utils.StudyConfig(
+            db_type=args.get("db_type"),
+            db_backend=databases.create_db_backend(args),
+            replace_existing=args.get("replace_existing", False),
+            stats_build=args.get("stats_build", False),
+            umls=args.get("umls"),
+        )
         try:
-            runner = StudyRunner(db_backend, data_path=args.get("data_path"))
+            runner = StudyRunner(config.db_backend, data_path=args.get("data_path"))
             if args.get("verbose"):
                 runner.verbose = True
             console.print("[italic] Connecting to database...")
@@ -354,18 +377,17 @@ def run_cli(args: dict):
                 )
             elif args["action"] == "build":
                 if "all" in args["target"]:
-                    runner.clean_and_build_all(study_dict, args["stats_build"])
+                    runner.clean_and_build_all(study_dict, config=config)
                 else:
                     for target in args["target"]:
                         if args["builder"]:
                             runner.run_matching_table_builder(
-                                study_dict[target], args["builder"]
+                                study_dict[target], config=config
                             )
                         else:
                             runner.clean_and_build_study(
                                 study_dict[target],
-                                stats_build=args["stats_build"],
-                                continue_from=args["continue_from"],
+                                config=config,
                             )
 
             elif args["action"] == "export":
@@ -394,13 +416,15 @@ def run_cli(args: dict):
 
             elif args["action"] == "generate-sql":
                 for target in args["target"]:
-                    runner.generate_study_sql(study_dict[target], args["builder"])
+                    runner.generate_study_sql(
+                        study_dict[target], builder=args["builder"], config=config
+                    )
 
             elif args["action"] == "generate-md":
                 for target in args["target"]:
                     runner.generate_study_markdown(study_dict[target])
         finally:
-            db_backend.close()
+            config.db_backend.close()
 
 
 def main(cli_args=None):
@@ -421,17 +445,18 @@ def main(cli_args=None):
                 break
 
     arg_env_pairs = (
-        ("db_type", "CUMULUS_LIBRARY_DB_TYPE"),
-        ("profile", "CUMULUS_LIBRARY_PROFILE"),
-        ("schema_name", "CUMULUS_LIBRARY_DATABASE"),
-        ("workgroup", "CUMULUS_LIBRARY_WORKGROUP"),
-        ("region", "CUMULUS_LIBRARY_REGION"),
-        ("study_dir", "CUMULUS_LIBRARY_STUDY_DIR"),
         ("data_path", "CUMULUS_LIBRARY_DATA_PATH"),
-        ("load_ndjson_dir", "CUMULUS_LIBRARY_LOAD_NDJSON_DIR"),
-        ("user", "CUMULUS_AGGREGATOR_USER"),
+        ("db_type", "CUMULUS_LIBRARY_DB_TYPE"),
         ("id", "CUMULUS_AGGREGATOR_ID"),
+        ("load_ndjson_dir", "CUMULUS_LIBRARY_LOAD_NDJSON_DIR"),
+        ("profile", "CUMULUS_LIBRARY_PROFILE"),
+        ("region", "CUMULUS_LIBRARY_REGION"),
+        ("schema_name", "CUMULUS_LIBRARY_DATABASE"),
+        ("study_dir", "CUMULUS_LIBRARY_STUDY_DIR"),
+        ("umls", "UMLS_API_KEY"),
         ("url", "CUMULUS_AGGREGATOR_URL"),
+        ("user", "CUMULUS_AGGREGATOR_USER"),
+        ("workgroup", "CUMULUS_LIBRARY_WORKGROUP"),
     )
     read_env_vars = []
     for pair in arg_env_pairs:

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -346,13 +346,13 @@ def run_cli(args: dict):
     else:
         config = base_utils.StudyConfig(
             db_type=args.get("db_type"),
-            db_backend=databases.create_db_backend(args),
-            replace_existing=args.get("replace_existing", False),
+            db=databases.create_db_backend(args),
+            force_upload=args.get("replace_existing", False),
             stats_build=args.get("stats_build", False),
-            umls=args.get("umls"),
+            umls_key=args.get("umls"),
         )
         try:
-            runner = StudyRunner(config.db_backend, data_path=args.get("data_path"))
+            runner = StudyRunner(config.db, data_path=args.get("data_path"))
             if args.get("verbose"):
                 runner.verbose = True
             console.print("[italic] Connecting to database...")
@@ -424,7 +424,7 @@ def run_cli(args: dict):
                 for target in args["target"]:
                     runner.generate_study_markdown(study_dict[target])
         finally:
-            config.db_backend.close()
+            config.db.close()
 
 
 def main(cli_args=None):

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -183,6 +183,15 @@ following order of preference is used to select credentials:
         dest="stats_build",
     )
     build.add_argument(
+        "--umls",
+        help="An API Key for the UMLS API",
+    )
+    build.add_argument(
+        "--replace-existing",
+        action="store_true",
+        help="Forces file downloads/uploads to occur, even if they already exist",
+    )
+    build.add_argument(
         "--continue",
         dest="continue_from",
         help=argparse.SUPPRESS,

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -183,11 +183,11 @@ following order of preference is used to select credentials:
         dest="stats_build",
     )
     build.add_argument(
-        "--umls",
+        "--umls-key",
         help="An API Key for the UMLS API",
     )
     build.add_argument(
-        "--replace-existing",
+        "--force-upload",
         action="store_true",
         help="Forces file downloads/uploads to occur, even if they already exist",
     )

--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -26,7 +26,7 @@ import pyathena
 from pyathena.common import BaseCursor as AthenaCursor
 from pyathena.pandas.cursor import PandasCursor as AthenaPandasCursor
 
-from cumulus_library import errors
+from cumulus_library import db_config, errors
 
 
 class DatabaseCursor(Protocol):
@@ -551,15 +551,15 @@ def read_ndjson_dir(path: str) -> dict[str, pyarrow.Table]:
 
 
 def create_db_backend(args: dict[str, str]) -> DatabaseBackend:
-    db_type = args["db_type"]
+    db_config.db_type = args["db_type"]
     database = args["schema_name"]
     load_ndjson_dir = args.get("load_ndjson_dir")
 
-    if db_type == "duckdb":
+    if db_config.db_type == "duckdb":
         backend = DuckDatabaseBackend(database)  # `database` is path name in this case
         if load_ndjson_dir:
             backend.insert_tables(read_ndjson_dir(load_ndjson_dir))
-    elif db_type == "athena":
+    elif db_config.db_type == "athena":
         backend = AthenaDatabaseBackend(
             args["region"],
             args["workgroup"],
@@ -569,6 +569,6 @@ def create_db_backend(args: dict[str, str]) -> DatabaseBackend:
         if load_ndjson_dir:
             sys.exit("Loading an ndjson dir is not supported with --db-type=athena.")
     else:
-        raise ValueError(f"Unexpected --db-type value '{db_type}'")
+        raise ValueError(f"Unexpected --db-type value '{db_config.db_type}'")
 
     return backend

--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -220,8 +220,7 @@ class AthenaDatabaseBackend(DatabaseBackend):
         remote_filename: str | None = None,
         replace_existing=False,
     ) -> str | None:
-        # We'll investigate the cursor to get the relevant params for S3 upload
-        # TODO: this could be retrieved from a config object passed to builders
+        # We'll investigate the connection to get the relevant S3 upload path.
         wg_conf = self.connection._client.get_work_group(WorkGroup=self.work_group)[
             "WorkGroup"
         ]["Configuration"]["ResultConfiguration"]

--- a/cumulus_library/db_config.py
+++ b/cumulus_library/db_config.py
@@ -1,4 +1,4 @@
 # Variables in this file should only be written to by databases.py, and should be
-# treated as read only elsewhere.
-# TODO: Move to config object passed down from main cli to builders
+# treated as read only elsewhere (and really only by jinja envrionments)
+# TODO: Consider moving to config object passed down from main cli to builders
 db_type = None

--- a/cumulus_library/statistics/psm.py
+++ b/cumulus_library/statistics/psm.py
@@ -54,7 +54,7 @@ class PsmBuilder(base_table_builder.BaseTableBuilder):
 
     display_text = "Building PSM tables..."
 
-    def __init__(self, toml_config_path: str, data_path: pathlib.Path):
+    def __init__(self, toml_config_path: str, data_path: pathlib.Path, **kwargs):
         """Loads PSM job details from a PSM configuration file"""
         super().__init__()
         # We're stashing the toml path for error reporting later
@@ -346,16 +346,20 @@ class PsmBuilder(base_table_builder.BaseTableBuilder):
                 "your sample size."
             )
 
-    def prepare_queries(self, cursor: object, schema: str, table_suffix: str):
+    def prepare_queries(
+        self, cursor: object, schema: str, table_suffix: str, *args, **kwargs
+    ):
         self._create_covariate_table(cursor, schema, table_suffix)
 
     def post_execution(
         self,
         cursor: object,
         schema: str,
-        verbose: bool,
+        *args,
+        verbose: bool = False,
         drop_table: bool = False,
         table_suffix: str | None = None,
+        **kwargs,
     ):
         # super().execute_queries(cursor, schema, verbose, drop_table)
         self.generate_psm_analysis(cursor, schema, table_suffix)

--- a/cumulus_library/studies/vocab/README.MD
+++ b/cumulus_library/studies/vocab/README.MD
@@ -1,0 +1,6 @@
+# Deprecation notice
+
+The vocab study is being superseded by the 
+[UMLS study](https://github.com/smart-on-fhir/cumulus-library-umls).
+If you need clinical coding definitions, use that study instead. This study will
+be removed in the next major release.

--- a/cumulus_library/studies/vocab/vocab_icd_builder.py
+++ b/cumulus_library/studies/vocab/vocab_icd_builder.py
@@ -47,12 +47,12 @@ class VocabIcdRunner(base_table_builder.BaseTableBuilder):
             if not parquet_path.is_file():
                 df = pandas.read_csv(file, delimiter="|", names=headers)
                 df.to_parquet(parquet_path)
-            remote_path = config.db_backend.upload_file(
+            remote_path = config.db.upload_file(
                 file=parquet_path,
                 study="vocab",
                 topic="icd",
                 remote_filename=f"{file.stem}.parquet",
-                replace_existing=config.replace_existing,
+                force_upload=config.force_upload,
             )
         # Since we are building one table from these three files, it's fine to just
         # use the last value of remote location

--- a/cumulus_library/studies/vocab/vocab_icd_builder.py
+++ b/cumulus_library/studies/vocab/vocab_icd_builder.py
@@ -48,7 +48,6 @@ class VocabIcdRunner(base_table_builder.BaseTableBuilder):
                 df = pandas.read_csv(file, delimiter="|", names=headers)
                 df.to_parquet(parquet_path)
             remote_path = config.db_backend.upload_file(
-                cursor=cursor,
                 file=parquet_path,
                 study="vocab",
                 topic="icd",

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -388,9 +388,7 @@ class StudyManifestParser:
             table_builder.comment_queries(doc_str=doc_str)
             new_filename = pathlib.Path(f"{filename}").stem + ".sql"
             table_builder.write_queries(
-                path=pathlib.Path(
-                    f"{self._study_path}/reference_sql/" + new_filename, config=config
-                )
+                path=pathlib.Path(f"{self._study_path}/reference_sql/" + new_filename)
             )
         else:
             table_builder.execute_queries(

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -329,6 +329,8 @@ class StudyManifestParser:
         filename: str,
         cursor: databases.DatabaseCursor,
         schema: str,
+        *,
+        config: base_utils.StudyConfig,
         verbose: bool = False,
         drop_table: bool = False,
         parser: databases.DatabaseParser = None,
@@ -382,15 +384,22 @@ class StudyManifestParser:
         table_builder_class = table_builder_subclasses[0]
         table_builder = table_builder_class()
         if write_reference_sql:
-            table_builder.prepare_queries(cursor, schema, parser=parser)
+            table_builder.prepare_queries(cursor, schema, parser=parser, config=config)
             table_builder.comment_queries(doc_str=doc_str)
             new_filename = pathlib.Path(f"{filename}").stem + ".sql"
             table_builder.write_queries(
-                path=pathlib.Path(f"{self._study_path}/reference_sql/" + new_filename)
+                path=pathlib.Path(
+                    f"{self._study_path}/reference_sql/" + new_filename, config=config
+                )
             )
         else:
             table_builder.execute_queries(
-                cursor, schema, verbose=verbose, drop_table=drop_table, parser=parser
+                cursor,
+                schema,
+                verbose=verbose,
+                drop_table=drop_table,
+                parser=parser,
+                config=config,
             )
 
         # After running the executor code, we'll remove
@@ -400,7 +409,12 @@ class StudyManifestParser:
         del table_builder_module
 
     def run_protected_table_builder(
-        self, cursor: databases.DatabaseCursor, schema: str, verbose: bool = False
+        self,
+        cursor: databases.DatabaseCursor,
+        schema: str,
+        *,
+        config: base_utils.StudyConfig,
+        verbose: bool = False,
     ) -> None:
         """Creates protected tables for persisting selected data across runs
 
@@ -415,12 +429,15 @@ class StudyManifestParser:
             verbose,
             study_name=self._study_config.get("study_prefix"),
             study_stats=self._study_config.get("statistics_config"),
+            config=config,
         )
 
     def run_table_builder(
         self,
         cursor: databases.DatabaseCursor,
         schema: str,
+        *,
+        config: base_utils.StudyConfig,
         verbose: bool = False,
         parser: databases.DatabaseParser = None,
     ) -> None:
@@ -432,11 +449,16 @@ class StudyManifestParser:
         """
         for file in self.get_table_builder_file_list():
             self._load_and_execute_builder(
-                file, cursor, schema, verbose=verbose, parser=parser
+                file, cursor, schema, verbose=verbose, parser=parser, config=config
             )
 
     def run_counts_builders(
-        self, cursor: databases.DatabaseCursor, schema: str, verbose: bool = False
+        self,
+        cursor: databases.DatabaseCursor,
+        schema: str,
+        *,
+        config: base_utils.StudyConfig,
+        verbose: bool = False,
     ) -> None:
         """Loads counts modules from a manifest and executes code via BaseTableBuilder
 
@@ -450,14 +472,17 @@ class StudyManifestParser:
         :param verbose: toggle from progress bar to query output
         """
         for file in self.get_counts_builder_file_list():
-            self._load_and_execute_builder(file, cursor, schema, verbose=verbose)
+            self._load_and_execute_builder(
+                file, cursor, schema, verbose=verbose, config=config
+            )
 
     def run_statistics_builders(
         self,
         cursor: databases.DatabaseCursor,
         schema: str,
+        *,
+        config: base_utils.StudyConfig,
         verbose: bool = False,
-        stats_build: bool = False,
     ) -> None:
         """Loads statistics modules from toml definitions and executes
 
@@ -466,7 +491,7 @@ class StudyManifestParser:
         :keyword verbose: toggle from progress bar to query output
         :keyword stats_build: If true, will run statistical sampling & table generation
         """
-        if not stats_build:
+        if not config.stats_build:
             return
         for file in self.get_statistics_file_list():
             # This open is a bit redundant with the open inside of the PSM builder,
@@ -480,14 +505,16 @@ class StudyManifestParser:
                 target_table = config["target_table"]
             if config_type == "psm":
                 builder = psm.PsmBuilder(
-                    toml_path, self.data_path / f"{self.get_study_prefix()}/psm"
+                    toml_path,
+                    self.data_path / f"{self.get_study_prefix()}/psm",
+                    config=config,
                 )
             else:
                 raise errors.StudyManifestParsingError(
                     f"{toml_path} references an invalid statistics type {config_type}."
                 )
             builder.execute_queries(
-                cursor, schema, verbose, table_suffix=safe_timestamp
+                cursor, schema, verbose, table_suffix=safe_timestamp, config=config
             )
 
             insert_query = base_templates.get_insert_into_query(
@@ -518,6 +545,8 @@ class StudyManifestParser:
         cursor: databases.DatabaseCursor,
         schema: str,
         builder: str,
+        *,
+        config: base_utils.StudyConfig,
         verbose: bool = False,
         parser: databases.DatabaseParser = None,
     ):
@@ -527,13 +556,21 @@ class StudyManifestParser:
             if builder and file.find(builder) == -1:
                 continue
             self._load_and_execute_builder(
-                file, cursor, schema, verbose=verbose, drop_table=True, parser=parser
+                file,
+                cursor,
+                schema,
+                verbose=verbose,
+                drop_table=True,
+                parser=parser,
+                config=config,
             )
 
     def run_generate_sql(
         self,
         cursor: databases.DatabaseCursor,
         schema: str,
+        *,
+        config: base_utils.StudyConfig,
         builder: str | None = None,
         parser: databases.DatabaseParser = None,
         verbose: bool = False,
@@ -564,6 +601,7 @@ class StudyManifestParser:
                 write_reference_sql=True,
                 doc_str=doc_str,
                 verbose=verbose,
+                config=config,
             )
 
     def run_generate_markdown(
@@ -619,6 +657,8 @@ class StudyManifestParser:
     def build_study(
         self,
         cursor: databases.DatabaseCursor,
+        *,
+        config: base_utils.StudyConfig,
         verbose: bool = False,
         continue_from: str | None = None,
     ) -> list:
@@ -650,6 +690,7 @@ class StudyManifestParser:
                 queries,
                 progress,
                 task,
+                config,
             )
         return queries
 
@@ -671,6 +712,7 @@ class StudyManifestParser:
         queries: list,
         progress: Progress,
         task: TaskID,
+        config: base_utils.StudyConfig,
     ) -> None:
         """Handler for executing create table queries and displaying console output.
 

--- a/docs/creating-sql-with-python.md
+++ b/docs/creating-sql-with-python.md
@@ -141,27 +141,26 @@ Add your count generator file to the `counts_builder_config` section of your
 ### Adding a static dataset
 
 Occasionally you will have a dataset from a third party that is useful for working
-with your dataset. In the vocab study (requiring a license to use), we 
-[add coding system data](https://github.com/smart-on-fhir/cumulus-library/blob/main//cumulus_library/studies/vocab/vocab_icd_builder.py)
-from flat files to Athena. If you need to do this, you should extend the base
+with your dataset. 
+
+If you need to do this, you should extend the base
 `TableBuilder` class, and your `prepare_queries` function should do the following,
 leveraging the
 [template function library](https://github.com/smart-on-fhir/cumulus-library/blob/main/cumulus_library/template_sql/base_templates.py):
-- Use the `get_ctas_query` function to get a `CREATE TABLE AS` statement to 
-instantiate your table in Athena
-- Since Athena SQL queries are limited in size to 262144 bytes, if you have
-a large dataset, break it up into smaller chunks
-- Use the `get_insert_into` function to add the data from each table to
-the chunk you just created.
+- Convert your data to parquet format. The 
+[UMLS study](https://github.com/smart-on-fhir/cumulus-library-umls) provides an example
+of how to do this using a pandas DataFrame
+- Use the `upload_data` function from the StudyConfig.db_backend (passed to 
+TableBuilders as `config`) to push files to the appropriate location for databases
+Cumulus supports
+- Use the `get_ctas_from_parquet_query` function from the template library to get 
+a `CREATE TABLE AS` statement for the appropriate database, and add that to the builder's
+`queries` array.
 
 Add the dataset uploader to the `table_builder_config` section of your
 `manifest.toml` to include it in your build - this will make this data
 available for downstream queries
 
-{: .note }
-We have an
-[open issue](https://github.com/smart-on-fhir/cumulus-library/issues/58)
-to develop an easier methodology for adding new datasets.
 
 ### Querying nested data
 

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -45,7 +45,7 @@ study_prefix = "my_study"
 
 # For most use cases, this should not be required, but if you need to programmatically
 # build tables, you can provide a list of files implementing BaseTableBuilder.
-# See vocab and core studies for examples of this pattern. These run before
+# See the core studies for examples of this pattern. These run before
 # any SQL execution
 # [table_builder_config]
 # file_names = [

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -45,7 +45,7 @@ study_prefix = "my_study"
 
 # For most use cases, this should not be required, but if you need to programmatically
 # build tables, you can provide a list of files implementing BaseTableBuilder.
-# See the core studies for examples of this pattern. These run before
+# See the core study for examples of this pattern. These run before
 # any SQL execution
 # [table_builder_config]
 # file_names = [

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -43,8 +43,7 @@ loading data into analytics packages.
 
 By default, all available studies will be used by build and export, but you can use
 or `--target` to specify a specific study to be run. You can use it multiple
-times to configure several studies in order. The `vocab` study, in particular, can take a
-bit of time to generate, so we recommend using targets after your initial configuration.
+times to configure several studies in order. 
 
 Several pip installable studies will automatically be added to the list of available
 studies to run. See [study list](./study-list.md) for more details.
@@ -61,20 +60,16 @@ this completed, you'll be ready to move on to [Creating studies](./creating-stud
 if you haven't already. Our follown steps assume you use the default names and
 deploy in Amazon's US-East zone.
 - Configure your system to talk to AWS as mentioned in the [AWS setup guide](./aws-setup.md)
-- Now we'll build the tables we'll need to run the template study. The `vocab`
-study creates mappings of system codes to strings, and the `core` study creates
-tables for commonly used base FHIR resources like `Patient` and `Observation`
-using those `vocab` mappings. To do this, run the following command:
+- Now we'll build the tables we'll need to run the template study. The `core` study 
+creates tables for commonly used base FHIR resources like `Patient` and `Observation`.
+To do this, run the following command:
 ```bash
-cumulus-library build --target vocab --target core
+cumulus-library build --target core
 ```
 This usually takes around five minutes, but once it's done, you won't need to build
-`vocab` again unless there's a coding system addition, and you'll only need to build
-`core` again if data changes.
+`core` again unless the data changes.
 You should see some progress bars like this while the tables are being created:
 ```
-Uploading vocab__icd data... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸ 100% 0:00:00
-Creating vocab study in db... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 Creating core study in db... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
 ```
 - Now, we'll build the built-in example `template` study.

--- a/docs/study-list.md
+++ b/docs/study-list.md
@@ -17,6 +17,10 @@ for more details and any associated publications.
 - [Covid symptoms](https://github.com/smart-on-fhir/cumulus-library-covid)
 - [Suicidality length of stay](https://github.com/smart-on-fhir/cumulus-library-suicidality-los)
 
+### 2024
+- [Hypertension](https://github.com/smart-on-fhir/cumulus-library-hypertension)
+- [UMLS vocabulary](https://github.com/smart-on-fhir/cumulus-library-umls)
+
 ## Third party studies
 
 If you are using Cumulus to manage your own clinical studies and would like

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pandas
 import pytest
 from rich import console, table
 
-from cumulus_library.cli import StudyRunner
+from cumulus_library import base_utils, cli
 from cumulus_library.databases import create_db_backend
 
 # Useful constants
@@ -208,9 +208,10 @@ def mock_db(tmp_path):
 @pytest.fixture
 def mock_db_core(tmp_path, mock_db):  # pylint: disable=redefined-outer-name
     """Provides a DuckDatabaseBackend with the core study ran for local testing"""
-    builder = StudyRunner(mock_db, data_path=f"{tmp_path}/data_path")
+    builder = cli.StudyRunner(mock_db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
-        f"{Path(__file__).parent.parent}/cumulus_library/studies/core", stats_build=True
+        f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
+        config=base_utils.StudyConfig(stats_build=True, db_backend=mock_db),
     )
     yield mock_db
 
@@ -226,8 +227,9 @@ def mock_db_stats(tmp_path):
             "load_ndjson_dir": f"{tmp_path}/mock_data",
         }
     )
-    builder = StudyRunner(db, data_path=f"{tmp_path}/data_path")
+    builder = cli.StudyRunner(db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
-        f"{Path(__file__).parent.parent}/cumulus_library/studies/core", stats_build=True
+        f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
+        config=base_utils.StudyConfig(stats_build=True, db_backend=db),
     )
     yield db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,7 @@ def mock_db_core(tmp_path, mock_db):  # pylint: disable=redefined-outer-name
     builder = cli.StudyRunner(mock_db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
         f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
-        config=base_utils.StudyConfig(stats_build=True, db_backend=mock_db),
+        config=base_utils.StudyConfig(stats_build=True, db=mock_db),
     )
     yield mock_db
 
@@ -230,6 +230,6 @@ def mock_db_stats(tmp_path):
     builder = cli.StudyRunner(db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
         f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
-        config=base_utils.StudyConfig(stats_build=True, db_backend=db),
+        config=base_utils.StudyConfig(stats_build=True, db=db),
     )
     yield db

--- a/tests/core/test_core_meds.py
+++ b/tests/core/test_core_meds.py
@@ -1,8 +1,6 @@
 """Tests for core__medicationrequest"""
 
 import json
-import os
-from unittest import mock
 
 import pytest
 
@@ -81,10 +79,6 @@ def test_core_medreq_only_inline(tmp_path):
     assert [x[0] for x in ids] == ["Inline"]
 
 
-@mock.patch.dict(
-    os.environ,
-    clear=True,
-)
 def test_core_med_all_types(tmp_path):
     """Verify that we handle all types of medications"""
     testbed = testbed_utils.LocalTestbed(tmp_path)

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -50,7 +50,7 @@ def test_schema_parsing():
 @mock.patch("botocore.session.Session")
 def test_upload_parquet(s3_session_mock):
     path = pathlib.Path(__file__).resolve().parent
-    db_backend = databases.AthenaDatabaseBackend(
+    db = databases.AthenaDatabaseBackend(
         region="us-east-1",
         work_group="work_group",
         profile="profile",
@@ -59,12 +59,12 @@ def test_upload_parquet(s3_session_mock):
     client = mock.MagicMock()
     with open(path / "test_data/aws/boto3.client.athena.get_work_group.json") as f:
         client.get_work_group.return_value = json.load(f)
-    db_backend.connection._client = client
+    db.connection._client = client
     s3_client = mock.MagicMock()
     with open(path / "test_data/aws/boto3.client.s3.list_objects_v2.json") as f:
         s3_client.list_objects_v2.return_value = json.load(f)
     s3_session_mock.return_value.create_client.return_value = s3_client
-    resp = db_backend.upload_file(
+    resp = db.upload_file(
         file=path / "test_data/count_synthea_patient.parquet",
         study="test_study",
         topic="count_patient",

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 from unittest import mock
 
-from cumulus_library import databases, db_config
+from cumulus_library import databases
 
 
 def test_schema_parsing():
@@ -48,21 +48,23 @@ def test_schema_parsing():
     clear=True,
 )
 @mock.patch("botocore.session.Session")
-def test_upload_parquet(s3_client_mock):
+def test_upload_parquet(s3_session_mock):
     path = pathlib.Path(__file__).resolve().parent
-    db_config.db_type = "athena"
-    cursor = mock.MagicMock()
-    cursor._schema_name = "db_schema"
-    cursor.connection.work_group = "workgroup"
-    cursor.connection.profile_name = "profile"
+    db_backend = databases.AthenaDatabaseBackend(
+        region="us-east-1",
+        work_group="work_group",
+        profile="profile",
+        schema_name="db_schema",
+    )
+    client = mock.MagicMock()
     with open(path / "test_data/aws/boto3.client.athena.get_work_group.json") as f:
-        cursor.connection._client.get_work_group.return_value = json.load(f)
+        client.get_work_group.return_value = json.load(f)
+    db_backend.connection._client = client
     s3_client = mock.MagicMock()
-    with open(path / "test_data/aws/boto3.client.s3.put_object.json") as f:
-        s3_client.put_object.return_value = json.load(f)
-    s3_client_mock.patch("botocore.client.S3", return_value=s3_client)
-    resp = databases.upload_file(
-        cursor=cursor,
+    with open(path / "test_data/aws/boto3.client.s3.list_objects_v2.json") as f:
+        s3_client.list_objects_v2.return_value = json.load(f)
+    s3_session_mock.return_value.create_client.return_value = s3_client
+    resp = db_backend.upload_file(
         file=path / "test_data/count_synthea_patient.parquet",
         study="test_study",
         topic="count_patient",

--- a/tests/test_data/aws/boto3.client.s3.list_objects_v2.json
+++ b/tests/test_data/aws/boto3.client.s3.list_objects_v2.json
@@ -1,0 +1,38 @@
+{
+    "ResponseMetadata": {
+        "RequestId": "1234567890ABCDEFGHI",
+        "HostId": "1234567890ABCDEFGHIJK=",
+        "HTTPStatusCode": 200,
+        "HTTPHeaders": {
+            "x-amz-id-2": "1234567890ABCDEFGHIJK=",
+            "x-amz-request-id": "0987654321FEDCBA",
+            "date": "Fri, 03 May 2024 16:04:03 GMT",
+            "x-amz-bucket-region": "us-east-1",
+            "content-type": "application/xml",
+            "transfer-encoding": "chunked",
+            "server": "AmazonS3"
+        },
+        "RetryAttempts": 0
+    },
+    "IsTruncated": false,
+    "Contents": [
+        {
+            "Key": "key.path/topic/file.parquet",
+            "LastModified": "datetime.datetime(2024",
+            "5": null,
+            "2": null,
+            "20": null,
+            "13": null,
+            "34": null,
+            "tzinfo=tzutc())": null,
+            "ETag": "\"12678120alskc\"",
+            "Size": 2104615,
+            "StorageClass": "STANDARD"
+        }
+    ],
+    "Name": "cumulus-athena-123456789012-us-east-1",
+    "Prefix": "key.path/topic/file.parquet",
+    "MaxKeys": 1000,
+    "EncodingType": "url",
+    "KeyCount": 1
+}

--- a/tests/test_psm.py
+++ b/tests/test_psm.py
@@ -63,8 +63,7 @@ def test_psm_create(
 ):
     builder = cli.StudyRunner(mock_db_stats, data_path=Path(tmp_path))
     psmbuilder = psm.PsmBuilder(
-        f"{Path(__file__).parent}/test_data/psm/{toml_def}",
-        Path(tmp_path),  # config=study_parser.StudyConfig(db_type='duckdb')
+        f"{Path(__file__).parent}/test_data/psm/{toml_def}", Path(tmp_path)
     )
     mock_db_stats.cursor().execute(
         "create table psm_test__psm_cohort as (select * from core__condition "

--- a/tests/test_psm.py
+++ b/tests/test_psm.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 from freezegun import freeze_time
 
-from cumulus_library.cli import StudyRunner
-from cumulus_library.statistics.psm import PsmBuilder
+from cumulus_library import cli
+from cumulus_library.statistics import psm
 
 
 @freeze_time("2024-01-01")
@@ -61,13 +61,14 @@ def test_psm_create(
     expected_first_record,
     expected_last_record,
 ):
-    builder = StudyRunner(mock_db_stats, data_path=Path(tmp_path))
-    psm = PsmBuilder(
-        f"{Path(__file__).parent}/test_data/psm/{toml_def}", Path(tmp_path)
+    builder = cli.StudyRunner(mock_db_stats, data_path=Path(tmp_path))
+    psmbuilder = psm.PsmBuilder(
+        f"{Path(__file__).parent}/test_data/psm/{toml_def}",
+        Path(tmp_path),  # config=study_parser.StudyConfig(db_type='duckdb')
     )
     mock_db_stats.cursor().execute(
         "create table psm_test__psm_cohort as (select * from core__condition "
-        f"ORDER BY {psm.config.primary_ref} limit 100)"
+        f"ORDER BY {psmbuilder.config.primary_ref} limit 100)"
     ).df()
     mock_db_stats.cursor().execute("select * from psm_test__psm_cohort").fetchall()
     safe_timestamp = (
@@ -77,7 +78,7 @@ def test_psm_create(
         .replace(":", "_")
         .replace("-", "_")
     )
-    psm.execute_queries(
+    psmbuilder.execute_queries(
         mock_db_stats.pandas_cursor(),
         builder.schema_name,
         False,

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -8,9 +8,7 @@ from unittest import mock
 
 import pytest
 
-from cumulus_library import errors
-from cumulus_library.enums import ProtectedTableKeywords, ProtectedTables
-from cumulus_library.study_parser import StudyManifestParser
+from cumulus_library import base_utils, enums, errors, study_parser
 from tests.test_data.parser_mock_data import get_mock_toml, mock_manifests
 
 
@@ -34,7 +32,7 @@ def test_load_manifest(manifest_path, raises):
             path = f"{pathlib.Path(__file__).resolve().parents[0]}/{manifest_path}"
         else:
             path = None
-        StudyManifestParser(path)
+        study_parser.StudyManifestParser(path)
 
 
 @pytest.mark.parametrize(
@@ -54,9 +52,9 @@ def test_manifest_data(manifest_key, raises):
     ):
         with raises:
             if manifest_key == "invalid_none":
-                parser = StudyManifestParser()
+                parser = study_parser.StudyManifestParser()
             else:
-                parser = StudyManifestParser("./path")
+                parser = study_parser.StudyManifestParser("./path")
             expected = mock_manifests[manifest_key]
             assert parser.get_study_prefix() == expected["study_prefix"]
             if "sql_config" in expected.keys():
@@ -108,16 +106,20 @@ def test_manifest_data(manifest_key, raises):
 )
 def test_clean_study(mock_db, schema, verbose, prefix, confirm, stats, target, raises):
     with raises:
-        protected_strs = [x.value for x in ProtectedTableKeywords]
+        protected_strs = [x.value for x in enums.ProtectedTableKeywords]
         with mock.patch.object(builtins, "input", lambda _: confirm):
-            parser = StudyManifestParser("./tests/test_data/study_valid/")
-            parser.run_protected_table_builder(mock_db.cursor(), schema)
+            parser = study_parser.StudyManifestParser("./tests/test_data/study_valid/")
+            parser.run_protected_table_builder(
+                mock_db.cursor(),
+                schema,
+                config=base_utils.StudyConfig(db_backend=mock_db),
+            )
 
             # We're mocking stats tables since creating them programmatically
             # is very slow and we're trying a lot of conditions
             mock_db.cursor().execute(
                 f"CREATE TABLE {parser.get_study_prefix()}__"
-                f"{ProtectedTables.STATISTICS.value} "
+                f"{enums.ProtectedTables.STATISTICS.value} "
                 "AS SELECT 'study_valid' as study_name, "
                 "'study_valid__123' AS table_name"
             )
@@ -142,16 +144,16 @@ def test_clean_study(mock_db, schema, verbose, prefix, confirm, stats, target, r
             else:
                 assert (target,) not in remaining_tables
             assert (
-                f"{parser.get_study_prefix()}__{ProtectedTables.TRANSACTIONS.value}",
+                f"{parser.get_study_prefix()}__{enums.ProtectedTables.TRANSACTIONS.value}",
             ) in remaining_tables
             if stats:
                 assert (
-                    f"{parser.get_study_prefix()}__{ProtectedTables.STATISTICS.value}",
+                    f"{parser.get_study_prefix()}__{enums.ProtectedTables.STATISTICS.value}",
                 ) not in remaining_tables
                 assert ("study_valid__123",) not in remaining_tables
             else:
                 assert (
-                    f"{parser.get_study_prefix()}__{ProtectedTables.STATISTICS.value}",
+                    f"{parser.get_study_prefix()}__{enums.ProtectedTables.STATISTICS.value}",
                 ) in remaining_tables
                 assert ("study_valid__123",) in remaining_tables
 
@@ -164,23 +166,25 @@ def test_clean_study(mock_db, schema, verbose, prefix, confirm, stats, target, r
     ],
 )
 def test_run_protected_table_builder(mock_db, study_path, stats):
-    parser = StudyManifestParser(study_path)
-    parser.run_protected_table_builder(mock_db.cursor(), "main")
+    parser = study_parser.StudyManifestParser(study_path)
+    parser.run_protected_table_builder(
+        mock_db.cursor(), "main", config=base_utils.StudyConfig(db_backend=mock_db)
+    )
     tables = (
         mock_db.cursor()
         .execute("SELECT distinct(table_name) FROM information_schema.tables ")
         .fetchall()
     )
     assert (
-        f"{parser.get_study_prefix()}__{ProtectedTables.TRANSACTIONS.value}",
+        f"{parser.get_study_prefix()}__{enums.ProtectedTables.TRANSACTIONS.value}",
     ) in tables
     if stats:
         assert (
-            f"{parser.get_study_prefix()}__{ProtectedTables.STATISTICS.value}",
+            f"{parser.get_study_prefix()}__{enums.ProtectedTables.STATISTICS.value}",
         ) in tables
     else:
         assert (
-            f"{parser.get_study_prefix()}__{ProtectedTables.STATISTICS.value}",
+            f"{parser.get_study_prefix()}__{enums.ProtectedTables.STATISTICS.value}",
         ) not in tables
 
 
@@ -221,11 +225,12 @@ def test_run_protected_table_builder(mock_db, study_path, stats):
 )
 def test_table_builder(mock_db, study_path, verbose, expects, raises):
     with raises:
-        parser = StudyManifestParser(study_path)
+        parser = study_parser.StudyManifestParser(study_path)
         parser.run_table_builder(
             mock_db.cursor(),
             "main",
-            verbose,
+            verbose=verbose,
+            config=base_utils.StudyConfig(db_backend=mock_db),
         )
         tables = (
             mock_db.cursor()
@@ -284,8 +289,12 @@ def test_table_builder(mock_db, study_path, verbose, expects, raises):
 )
 def test_build_study(mock_db, study_path, verbose, expects, raises):
     with raises:
-        parser = StudyManifestParser(study_path)
-        parser.build_study(mock_db.cursor(), verbose)
+        parser = study_parser.StudyManifestParser(study_path)
+        parser.build_study(
+            mock_db.cursor(),
+            verbose=verbose,
+            config=base_utils.StudyConfig(db_backend=mock_db),
+        )
         tables = (
             mock_db.cursor()
             .execute("SELECT distinct(table_name) FROM information_schema.tables ")
@@ -315,12 +324,13 @@ def test_run_statistics_builders(
     tmp_path, mock_db_stats, study_path, stats, expects, raises
 ):
     with raises:
-        parser = StudyManifestParser(study_path, data_path=tmp_path)
-        parser.run_protected_table_builder(mock_db_stats.cursor(), "main")
-        parser.build_study(mock_db_stats.cursor(), "main")
-        parser.run_statistics_builders(
-            mock_db_stats.cursor(), "main", stats_build=stats
+        parser = study_parser.StudyManifestParser(study_path, data_path=tmp_path)
+        config = base_utils.StudyConfig(db_backend=mock_db_stats, stats_build=stats)
+        parser.run_protected_table_builder(
+            mock_db_stats.cursor(), "main", config=config
         )
+        parser.build_study(mock_db_stats.cursor(), config=config)
+        parser.run_statistics_builders(mock_db_stats.cursor(), "main", config=config)
         tables = (
             mock_db_stats.cursor()
             .execute("SELECT distinct(table_name) FROM information_schema.tables")
@@ -334,7 +344,7 @@ def test_run_statistics_builders(
 
 
 def test_export_study(tmp_path, mock_db_core):
-    parser = StudyManifestParser(
+    parser = study_parser.StudyManifestParser(
         f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
         data_path=f"{tmp_path}/export",
     )

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -112,7 +112,7 @@ def test_clean_study(mock_db, schema, verbose, prefix, confirm, stats, target, r
             parser.run_protected_table_builder(
                 mock_db.cursor(),
                 schema,
-                config=base_utils.StudyConfig(db_backend=mock_db),
+                config=base_utils.StudyConfig(db=mock_db),
             )
 
             # We're mocking stats tables since creating them programmatically
@@ -168,7 +168,7 @@ def test_clean_study(mock_db, schema, verbose, prefix, confirm, stats, target, r
 def test_run_protected_table_builder(mock_db, study_path, stats):
     parser = study_parser.StudyManifestParser(study_path)
     parser.run_protected_table_builder(
-        mock_db.cursor(), "main", config=base_utils.StudyConfig(db_backend=mock_db)
+        mock_db.cursor(), "main", config=base_utils.StudyConfig(db=mock_db)
     )
     tables = (
         mock_db.cursor()
@@ -230,7 +230,7 @@ def test_table_builder(mock_db, study_path, verbose, expects, raises):
             mock_db.cursor(),
             "main",
             verbose=verbose,
-            config=base_utils.StudyConfig(db_backend=mock_db),
+            config=base_utils.StudyConfig(db=mock_db),
         )
         tables = (
             mock_db.cursor()
@@ -293,7 +293,7 @@ def test_build_study(mock_db, study_path, verbose, expects, raises):
         parser.build_study(
             mock_db.cursor(),
             verbose=verbose,
-            config=base_utils.StudyConfig(db_backend=mock_db),
+            config=base_utils.StudyConfig(db=mock_db),
         )
         tables = (
             mock_db.cursor()
@@ -325,7 +325,7 @@ def test_run_statistics_builders(
 ):
     with raises:
         parser = study_parser.StudyManifestParser(study_path, data_path=tmp_path)
-        config = base_utils.StudyConfig(db_backend=mock_db_stats, stats_build=stats)
+        config = base_utils.StudyConfig(db=mock_db_stats, stats_build=stats)
         parser.run_protected_table_builder(
             mock_db_stats.cursor(), "main", config=config
         )

--- a/tests/testbed_utils.py
+++ b/tests/testbed_utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import duckdb
 
-from cumulus_library import cli
+from cumulus_library import base_utils, cli
 from cumulus_library.databases import create_db_backend
 
 
@@ -236,6 +236,6 @@ class LocalTestbed:
         # builder.verbose = True
         builder.clean_and_build_study(
             Path(__file__).parent.parent / "cumulus_library/studies" / study,
-            stats_build=False,
+            config=base_utils.StudyConfig(db_backend=db, stats_build=False),
         )
         return duckdb.connect(db_file)

--- a/tests/testbed_utils.py
+++ b/tests/testbed_utils.py
@@ -236,6 +236,6 @@ class LocalTestbed:
         # builder.verbose = True
         builder.clean_and_build_study(
             Path(__file__).parent.parent / "cumulus_library/studies" / study,
-            config=base_utils.StudyConfig(db_backend=db, stats_build=False),
+            config=base_utils.StudyConfig(db=db, stats_build=False),
         )
         return duckdb.connect(db_file)


### PR DESCRIPTION
This PR adds a StudyConfig object, which transports values from the CLI down to individual studies, for customizing behavior of study runs.

It also contains several tweaks in support of the UMLS study, and moves the upload logic for databases into each database class.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration