### PR TITLE
Make it easier to run studies from git checkouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           sqlfluff lint
       - name: Run ruff
-        if: success() || failure() # still run black if above checks fails
+        if: success() || failure() # still run ruff if above checks fails
         run: |
           ruff check
           ruff format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.4.4  # if you update this, also update pyproject.toml
     hooks:
       - name: Ruff formatting
         id: ruff-format
+        entry: bash -c 'ruff format --force-exclude "$@"; git add -u' --
       - name: Ruff linting
         id: ruff
         stages: [pre-push]

--- a/cumulus_library/apis/umls.py
+++ b/cumulus_library/apis/umls.py
@@ -1,4 +1,5 @@
 """Class for communicating with the umls API"""
+
 import os
 import pathlib
 

--- a/cumulus_library/base_table_builder.py
+++ b/cumulus_library/base_table_builder.py
@@ -1,4 +1,4 @@
-""" abstract base for python-based study executors """
+"""abstract base for python-based study executors"""
 
 import pathlib
 import re

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -1,4 +1,4 @@
-""" Collection of small commonly used utility functions """
+"""Collection of small commonly used utility functions"""
 
 import dataclasses
 import datetime

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -318,14 +318,18 @@ def get_study_dict(alt_dir_paths: list) -> dict[str, pathlib.Path] | None:
     return manifest_studies
 
 
-def get_studies_by_manifest_path(path: pathlib.Path) -> dict:
+def get_studies_by_manifest_path(path: pathlib.Path) -> dict[str, pathlib.Path]:
     """Recursively search for manifest.toml files from a given path"""
     manifest_paths = {}
     for child_path in path.iterdir():
         if child_path.is_dir():
             manifest_paths.update(get_studies_by_manifest_path(child_path))
         elif child_path.name == "manifest.toml":
-            manifest_paths[path.name] = path
+            try:
+                manifest = study_parser.StudyManifestParser(path)
+                manifest_paths[manifest.get_study_prefix()] = path
+            except errors.StudyManifestParsingError as exc:
+                rich.print(f"[bold red] Ignoring study in '{path}': {exc}")
     return manifest_paths
 
 

--- a/cumulus_library/enums.py
+++ b/cumulus_library/enums.py
@@ -1,4 +1,4 @@
-""" Holds enums used across more than one module """
+"""Holds enums used across more than one module"""
 
 from enum import Enum
 

--- a/cumulus_library/protected_table_builder.py
+++ b/cumulus_library/protected_table_builder.py
@@ -1,4 +1,4 @@
-""" Builder for creating tables for tracking state/logging changes"""
+"""Builder for creating tables for tracking state/logging changes"""
 
 from cumulus_library import base_table_builder, enums
 from cumulus_library.template_sql import base_templates

--- a/cumulus_library/statistics/statistics_templates/psm_templates.py
+++ b/cumulus_library/statistics/statistics_templates/psm_templates.py
@@ -1,4 +1,4 @@
-""" Collection of jinja template getters for common SQL queries """
+"""Collection of jinja template getters for common SQL queries"""
 
 from pathlib import Path
 

--- a/cumulus_library/studies/core/builder_medication.py
+++ b/cumulus_library/studies/core/builder_medication.py
@@ -1,4 +1,4 @@
-""" Module for generating core medication table"""
+"""Module for generating core medication table"""
 
 from cumulus_library import base_table_builder, databases
 from cumulus_library.studies.core.core_templates import core_templates

--- a/cumulus_library/studies/core/builder_medicationrequest.py
+++ b/cumulus_library/studies/core/builder_medicationrequest.py
@@ -1,4 +1,4 @@
-""" Module for extracting US core extensions from medicationrequests
+"""Module for extracting US core extensions from medicationrequests
 
 Note: This module assumes that you have already run builder_medication,
 as it leverages the core__medication table for data population"""

--- a/cumulus_library/studies/core/builder_observation.py
+++ b/cumulus_library/studies/core/builder_observation.py
@@ -1,4 +1,4 @@
-""" Module for extracting US core extensions from patient records"""
+"""Module for extracting US core extensions from patient records"""
 
 from dataclasses import dataclass
 

--- a/cumulus_library/studies/core/builder_patient.py
+++ b/cumulus_library/studies/core/builder_patient.py
@@ -1,4 +1,4 @@
-""" Module for extracting US core extensions from patient records"""
+"""Module for extracting US core extensions from patient records"""
 
 from cumulus_library import databases
 from cumulus_library.base_table_builder import BaseTableBuilder

--- a/cumulus_library/studies/core/builder_prereq_tables.py
+++ b/cumulus_library/studies/core/builder_prereq_tables.py
@@ -1,6 +1,6 @@
-""" This builder primarily exists to make sure that the FHIR lookup
+"""This builder primarily exists to make sure that the FHIR lookup
 tables are created before other builders in the core study run, so that
-they are available for joins. """
+they are available for joins."""
 
 import pathlib
 

--- a/cumulus_library/studies/discovery/code_detection.py
+++ b/cumulus_library/studies/discovery/code_detection.py
@@ -1,4 +1,4 @@
-""" Module for generating encounter codeableConcept table"""
+"""Module for generating encounter codeableConcept table"""
 
 from cumulus_library import base_table_builder, base_utils, databases
 from cumulus_library.studies.discovery import code_definitions

--- a/cumulus_library/studies/vocab/vocab_icd_builder.py
+++ b/cumulus_library/studies/vocab/vocab_icd_builder.py
@@ -1,4 +1,4 @@
-""" Module for directly loading ICD bsvs into athena tables """
+"""Module for directly loading ICD bsvs into athena tables"""
 
 import pathlib
 

--- a/cumulus_library/template_sql/base_templates.py
+++ b/cumulus_library/template_sql/base_templates.py
@@ -1,4 +1,4 @@
-""" Collection of jinja template getters for common SQL queries """
+"""Collection of jinja template getters for common SQL queries"""
 
 import enum
 import pathlib

--- a/cumulus_library/template_sql/sql_utils.py
+++ b/cumulus_library/template_sql/sql_utils.py
@@ -8,7 +8,7 @@ simply. This includes, but is not limited, to:
     - Data with deep missing elements
     - Data which may or may not be in an array depending on context
 """
-import abc
+
 from dataclasses import dataclass, field
 
 from cumulus_library import base_utils, databases
@@ -26,8 +26,8 @@ REFERENCE = ["reference"]
 
 
 @dataclass(kw_only=True)
-class BaseConfig(abc.ABC):
-    """Abstract ase class for handling table detection/denormalization"""
+class BaseConfig:
+    """Base class for handling table detection/denormalization"""
 
     source_table: str = None
     source_id: str = "id"

--- a/cumulus_library/upload.py
+++ b/cumulus_library/upload.py
@@ -1,4 +1,4 @@
-""" Handles pushing data to the aggregator"""
+"""Handles pushing data to the aggregator"""
 
 import sys
 from pathlib import Path

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -73,7 +73,7 @@ file_names = [
 # The following tables will be output to disk when an export is run. In most cases,
 # only count tables should be output in this way.
 export_list = [
-    "template__count_influenza_test_month",
+    "my_study__count_influenza_test_month",
 ]
 
 # For generating counts table in a more standardized manner, we have a class in the 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ classifiers = [
 dynamic=["version"]
 [project.optional-dependencies]
 dev = [
-    "ruff == 0.2.1",
+    # if you update the ruff version, also update .pre-commit-config.yaml
+    "ruff == 0.4.4",
     "pre-commit",
 ]
 test = [
@@ -41,8 +42,8 @@ test = [
 ]
 
 [project.urls]
-Home = "https://smarthealthit.org/cumulus-a-universal-sidecar-for-a-smart-learning-healthcare-system/"
-Documentation = "https://docs.smarthealthit.org/cumulus/"
+Home = "https://smarthealthit.org/cumulus/"
+Documentation = "https://docs.smarthealthit.org/cumulus/library/"
 Source = "https://github.com/smart-on-fhir/cumulus-library"
 
 
@@ -61,9 +62,6 @@ minversion = "6.0"
 testpaths = [
     "tests",
 ]
-
-[tool.ruff]
-target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,7 @@ def mock_db_core(tmp_path, mock_db):  # pylint: disable=redefined-outer-name
     """Provides a DuckDatabaseBackend with the core study ran for local testing"""
     builder = cli.StudyRunner(mock_db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
-        f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
+        Path(__file__).parent.parent / "cumulus_library/studies/core",
         config=base_utils.StudyConfig(stats_build=True, db=mock_db),
     )
     yield mock_db
@@ -229,7 +229,7 @@ def mock_db_stats(tmp_path):
     )
     builder = cli.StudyRunner(db, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
-        f"{Path(__file__).parent.parent}/cumulus_library/studies/core",
+        Path(__file__).parent.parent / "cumulus_library/studies/core",
         config=base_utils.StudyConfig(stats_build=True, db=db),
     )
     yield db

--- a/tests/regression/run_regression.py
+++ b/tests/regression/run_regression.py
@@ -1,6 +1,6 @@
 """Checks export against known dataset.
 
-This file is excluded from the pytest suite because it's finicky to 
+This file is excluded from the pytest suite because it's finicky to
 run locally at BCH:
 
 - You need to be on the BCH VPN

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -1,4 +1,5 @@
 """Tests for Athena database support"""
+
 import json
 import os
 import pathlib

--- a/tests/test_base_templates.py
+++ b/tests/test_base_templates.py
@@ -1,4 +1,4 @@
-""" tests for jinja sql templates """
+"""tests for jinja sql templates"""
 
 import pytest
 from pandas import DataFrame

--- a/tests/test_counts_builder.py
+++ b/tests/test_counts_builder.py
@@ -1,4 +1,4 @@
-""" tests for outputs of counts_builder module """
+"""tests for outputs of counts_builder module"""
 
 from contextlib import nullcontext as does_not_raise
 from unittest import mock

--- a/tests/test_counts_templates.py
+++ b/tests/test_counts_templates.py
@@ -1,4 +1,4 @@
-""" validates sql output of counts table sql generation """
+"""validates sql output of counts table sql generation"""
 
 import pytest
 

--- a/tests/test_data/study_different_dir/manifest.toml
+++ b/tests/test_data/study_different_dir/manifest.toml
@@ -1,0 +1,7 @@
+study_prefix = "study_different_name"
+
+[sql_config]
+file_names = ["test.sql"]
+
+[export_config]
+export_list = ["study_different_name__table"]

--- a/tests/test_data/study_different_dir/test.sql
+++ b/tests/test_data/study_different_dir/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE study_different_name__table (test int);

--- a/tests/test_data/study_invalid_bad_query/manifest.toml
+++ b/tests/test_data/study_invalid_bad_query/manifest.toml
@@ -1,7 +1,7 @@
-study_prefix = "study_valid"
+study_prefix = "study_invalid_bad_query"
 
 [sql_config]
 file_names = ["test.sql"]
 
 [export_config]
-export_list = ["study_valid__table"]
+export_list = ["study_invalid_bad_query__table"]

--- a/tests/test_data/study_python_local_template/module1.py
+++ b/tests/test_data/study_python_local_template/module1.py
@@ -1,5 +1,6 @@
+from study_python_local_template import local_template
+
 from cumulus_library.base_table_builder import BaseTableBuilder
-from tests.test_data.study_python_local_template import local_template
 
 
 class ModuleOneRunner(BaseTableBuilder):

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -1,4 +1,4 @@
-""" tests for duckdb backend support """
+"""tests for duckdb backend support"""
 
 import glob
 import json

--- a/tests/test_psm.py
+++ b/tests/test_psm.py
@@ -1,4 +1,4 @@
-""" tests for propensity score matching generation """
+"""tests for propensity score matching generation"""
 
 from datetime import datetime
 from pathlib import Path

--- a/tests/test_psm_templates.py
+++ b/tests/test_psm_templates.py
@@ -1,4 +1,4 @@
-""" validates sql output of psm table sql generation """
+"""validates sql output of psm table sql generation"""
 
 from contextlib import nullcontext as does_not_raise
 

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -1,4 +1,4 @@
-""" tests for study parser against mocks in test_data """
+"""tests for study parser against mocks in test_data"""
 
 import builtins
 import pathlib
@@ -225,7 +225,7 @@ def test_run_protected_table_builder(mock_db, study_path, stats):
 )
 def test_table_builder(mock_db, study_path, verbose, expects, raises):
     with raises:
-        parser = study_parser.StudyManifestParser(study_path)
+        parser = study_parser.StudyManifestParser(pathlib.Path(study_path))
         parser.run_table_builder(
             mock_db.cursor(),
             "main",

--- a/tests/test_template_sql_utils.py
+++ b/tests/test_template_sql_utils.py
@@ -1,4 +1,4 @@
-""" tests for the cli interface to studies """
+"""tests for the cli interface to studies"""
 
 from contextlib import nullcontext as does_not_raise
 


### PR DESCRIPTION
- When loading a builder, we add the study dir's parent folder into sys.path, so that builders can import helper code. This is basically equivalent to doing PYTHONPATH=. from a checkout.
- When searching for the study dir, and we find a manifest.toml, actually read the manifest to find the study_prefix instead of using the directory name for the study name. This allows more natural python package layouts (rather than `module_name/study_name`, you can just do `module_name`)

This also bumps ruff's version to 0.4.4 and has the commit hook just auto-commit any formatting changes.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration