### PR TITLE
fix: if a table does not exist, use an empty schema

### DIFF
--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -156,6 +156,17 @@ class DatabaseBackend(abc.ABC):
     def parser(self) -> DatabaseParser:
         """Returns parser object for interrogating DB schemas"""
 
+    def operational_errors(self) -> tuple[Exception]:
+        """Returns a tuple of operational exception classes
+
+        An operational error is something that went wrong while performing a database
+        query. So something like "table doesn't exist" but not like a network or
+        syntax error.
+
+        This is designed to be used in an `except` clause.
+        """
+        return ()
+
     def upload_file(
         self,
         *,
@@ -218,6 +229,9 @@ class AthenaDatabaseBackend(DatabaseBackend):
 
     def parser(self) -> DatabaseParser:
         return AthenaParser()
+
+    def operational_errors(self) -> tuple[Exception]:
+        return (pyathena.OperationalError,)
 
     def upload_file(
         self,
@@ -453,6 +467,9 @@ class DuckDatabaseBackend(DatabaseBackend):
 
     def parser(self) -> DatabaseParser:
         return DuckDbParser()
+
+    def operational_errors(self) -> tuple[Exception]:
+        return (duckdb.OperationalError,)
 
     def close(self) -> None:
         self.connection.close()

--- a/cumulus_library/studies/core/builder_condition.py
+++ b/cumulus_library/studies/core/builder_condition.py
@@ -1,4 +1,4 @@
-from cumulus_library import base_table_builder, databases
+from cumulus_library import base_table_builder, base_utils
 from cumulus_library.studies.core.core_templates import core_templates
 from cumulus_library.template_sql import base_templates, sql_utils
 
@@ -75,16 +75,12 @@ class CoreConditionBuilder(base_table_builder.BaseTableBuilder):
 
     def prepare_queries(
         self,
-        cursor: object,
-        schema: str,
         *args,
-        parser: databases.DatabaseParser = None,
+        config: base_utils.StudyConfig,
         **kwargs,
     ):
         self.denormalize_codes()
-        validated_schema = sql_utils.validate_schema(
-            cursor, schema, expected_table_cols, parser
-        )
+        validated_schema = sql_utils.validate_schema(config.db, expected_table_cols)
         self.queries.append(
             core_templates.get_core_template("condition", validated_schema)
         )

--- a/cumulus_library/studies/core/builder_documentreference.py
+++ b/cumulus_library/studies/core/builder_documentreference.py
@@ -1,4 +1,4 @@
-from cumulus_library import base_table_builder, databases
+from cumulus_library import base_table_builder, base_utils
 from cumulus_library.studies.core.core_templates import core_templates
 from cumulus_library.template_sql import sql_utils
 
@@ -19,16 +19,12 @@ class CoreDocumentreferenceBuilder(base_table_builder.BaseTableBuilder):
 
     def prepare_queries(
         self,
-        cursor: object,
-        schema: str,
         *args,
-        parser: databases.DatabaseParser = None,
+        config: base_utils.StudyConfig,
         **kwargs,
     ):
         self.queries = sql_utils.denormalize_complex_objects(
-            schema,
-            cursor,
-            parser,
+            config.db,
             [
                 sql_utils.CodeableConceptConfig(
                     source_table="documentreference",
@@ -62,9 +58,7 @@ class CoreDocumentreferenceBuilder(base_table_builder.BaseTableBuilder):
                 ),
             ],
         )
-        validated_schema = sql_utils.validate_schema(
-            cursor, schema, expected_table_cols, parser
-        )
+        validated_schema = sql_utils.validate_schema(config.db, expected_table_cols)
         self.queries.append(
             core_templates.get_core_template("documentreference", validated_schema)
         )

--- a/cumulus_library/studies/core/builder_medication.py
+++ b/cumulus_library/studies/core/builder_medication.py
@@ -1,6 +1,6 @@
 """Module for generating core medication table"""
 
-from cumulus_library import base_table_builder, databases
+from cumulus_library import base_table_builder, base_utils
 from cumulus_library.studies.core.core_templates import core_templates
 from cumulus_library.template_sql import sql_utils
 
@@ -19,17 +19,13 @@ class MedicationBuilder(base_table_builder.BaseTableBuilder):
 
     def prepare_queries(
         self,
-        cursor: databases.DatabaseCursor,
-        schema: str,
-        parser: databases.DatabaseParser = None,
         *args,
+        config: base_utils.StudyConfig,
         **kwargs,
     ) -> None:
         """Constructs queries related to condition codeableConcept
 
-        :param cursor: A database cursor object
-        :param schema: the schema/db name, matching the cursor
-        :param parser: A database parser
+        :param config: A study config object
         """
         code_sources = [
             sql_utils.CodeableConceptConfig(
@@ -57,12 +53,8 @@ class MedicationBuilder(base_table_builder.BaseTableBuilder):
                 ],
             ),
         ]
-        self.queries += sql_utils.denormalize_complex_objects(
-            schema, cursor, parser, code_sources
-        )
-        validated_schema = sql_utils.validate_schema(
-            cursor, schema, expected_table_cols, parser
-        )
+        self.queries += sql_utils.denormalize_complex_objects(config.db, code_sources)
+        validated_schema = sql_utils.validate_schema(config.db, expected_table_cols)
         self.queries += [
             core_templates.get_core_template("medication", validated_schema),
         ]

--- a/cumulus_library/studies/core/builder_medicationrequest.py
+++ b/cumulus_library/studies/core/builder_medicationrequest.py
@@ -3,7 +3,7 @@
 Note: This module assumes that you have already run builder_medication,
 as it leverages the core__medication table for data population"""
 
-from cumulus_library import base_table_builder, databases
+from cumulus_library import base_table_builder, base_utils
 from cumulus_library.studies.core.core_templates import core_templates
 from cumulus_library.template_sql import sql_utils
 
@@ -26,16 +26,13 @@ class MedicationRequestBuilder(base_table_builder.BaseTableBuilder):
 
     def prepare_queries(
         self,
-        cursor: object,
-        schema: str,
         *args,
-        parser: databases.DatabaseParser = None,
+        config: base_utils.StudyConfig,
         **kwargs,
     ):
         """constructs queries related to patient extensions of interest
 
-        :param cursor: A database cursor object
-        :param schema: the schema/db name, matching the cursor
+        :param config: A study config object
         """
         code_sources = [
             sql_utils.CodeableConceptConfig(
@@ -45,12 +42,8 @@ class MedicationRequestBuilder(base_table_builder.BaseTableBuilder):
                 target_table="core__medicationrequest_dn_category",
             ),
         ]
-        self.queries += sql_utils.denormalize_complex_objects(
-            schema, cursor, parser, code_sources
-        )
-        validated_schema = sql_utils.validate_schema(
-            cursor, schema, expected_table_cols, parser
-        )
+        self.queries += sql_utils.denormalize_complex_objects(config.db, code_sources)
+        validated_schema = sql_utils.validate_schema(config.db, expected_table_cols)
         self.queries.append(
             core_templates.get_core_template("medicationrequest", validated_schema)
         )

--- a/cumulus_library/studies/core/builder_observation.py
+++ b/cumulus_library/studies/core/builder_observation.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from cumulus_library import base_table_builder, databases
+from cumulus_library import base_table_builder, base_utils
 from cumulus_library.studies.core.core_templates import core_templates
 from cumulus_library.template_sql import sql_utils
 
@@ -41,16 +41,13 @@ class ObservationBuilder(base_table_builder.BaseTableBuilder):
 
     def prepare_queries(
         self,
-        cursor: object,
-        schema: str,
         *args,
-        parser: databases.DatabaseParser = None,
+        config: base_utils.StudyConfig,
         **kwargs,
     ):
         """constructs queries related to patient extensions of interest
 
-        :param cursor: A database cursor object
-        :param schema: the schema/db name, matching the cursor
+        :param config: A study config object
         """
         code_sources = [
             ObsConfig(column_hierarchy=[("category", list)], filter_priority=False),
@@ -88,12 +85,8 @@ class ObservationBuilder(base_table_builder.BaseTableBuilder):
             ),
         ]
 
-        self.queries += sql_utils.denormalize_complex_objects(
-            schema, cursor, parser, code_sources
-        )
-        validated_schema = sql_utils.validate_schema(
-            cursor, schema, expected_table_cols, parser
-        )
+        self.queries += sql_utils.denormalize_complex_objects(config.db, code_sources)
+        validated_schema = sql_utils.validate_schema(config.db, expected_table_cols)
         self.queries += [
             core_templates.get_core_template("observation", validated_schema),
             core_templates.get_core_template(

--- a/cumulus_library/studies/core/core_templates/observation_component_valuequantity.sql.jinja
+++ b/cumulus_library/studies/core/core_templates/observation_component_valuequantity.sql.jinja
@@ -60,7 +60,7 @@ CREATE TABLE core__observation_component_valuequantity AS (
         'x' AS comparator,
         'x' AS unit,
         'x' AS code_system,
-        'x' AS code,
+        'x' AS code
     WHERE 1=0 -- empty table
     {%- endif %}
 );

--- a/cumulus_library/template_sql/sql_utils.py
+++ b/cumulus_library/template_sql/sql_utils.py
@@ -116,7 +116,7 @@ def _check_data_in_fields(
 
     with base_utils.get_progress_bar(transient=True) as progress:
         task = progress.add_task(
-            "Detecting available encounter codeableConcepts...",
+            "Detecting available codeableConcepts...",
             # Each column in code_sources requires at most 3 queries to
             # detect valid data is in the DB
             total=len(code_sources),
@@ -209,7 +209,12 @@ def validate_schema(
     validated_schema = {}
     for table, cols in expected_table_cols.items():
         query = base_templates.get_column_datatype_query(schema, table, cols.keys())
-        table_schema = cursor.execute(query).fetchall()
+        try:
+            table_schema = cursor.execute(query).fetchall()
+        except Exception:
+            # The database might reasonably raise an exception in cases like
+            # the table not existing. Here we treat error tables as no-column tables.
+            table_schema = []
         validated_schema[table] = parser.validate_table_schema(cols, table_schema)
     return validated_schema
 

--- a/cumulus_library/template_sql/sql_utils.py
+++ b/cumulus_library/template_sql/sql_utils.py
@@ -90,9 +90,7 @@ class ExtensionConfig(BaseConfig):
 
 
 def _check_data_in_fields(
-    schema: str,
-    cursor: databases.DatabaseCursor,
-    parser: databases.DatabaseParser,
+    database: databases.DatabaseBackend,
     code_sources: list[CodeableConceptConfig],
 ) -> dict:
     """checks if CodeableConcept fields actually have data available
@@ -123,9 +121,7 @@ def _check_data_in_fields(
         )
         for code_source in code_sources:
             code_source.has_data = is_field_populated(
-                schema=schema,
-                cursor=cursor,
-                parser=parser,
+                database=database,
                 source_table=code_source.source_table,
                 hierarchy=code_source.column_hierarchy,
                 expected=code_source.expected,
@@ -135,13 +131,11 @@ def _check_data_in_fields(
 
 
 def denormalize_complex_objects(
-    schema: str,
-    cursor: databases.DatabaseCursor,
-    parser: databases.DatabaseParser,
+    database: databases.DatabaseBackend,
     code_sources: list[BaseConfig],
 ):
     queries = []
-    code_sources = _check_data_in_fields(schema, cursor, parser, code_sources)
+    code_sources = _check_data_in_fields(database, code_sources)
     for code_source in code_sources:
         # TODO: This method of pairing classed config objects to
         # specific queries should be considered temporary. This should be
@@ -177,7 +171,7 @@ def denormalize_complex_objects(
                         col_types += ["varchar"] * len(code_source.extra_fields)
                     queries.append(
                         base_templates.get_ctas_empty_query(
-                            schema_name=schema,
+                            schema_name=database.schema_name,
                             table_name=code_source.target_table,
                             table_cols=table_cols,
                             table_cols_types=col_types,
@@ -191,7 +185,7 @@ def denormalize_complex_objects(
                 else:
                     queries.append(
                         base_templates.get_ctas_empty_query(
-                            schema_name=schema,
+                            schema_name=database.schema_name,
                             table_name=code_source.target_table,
                             table_cols=["id", "code", "code_system", "display"],
                         )
@@ -201,29 +195,31 @@ def denormalize_complex_objects(
 
 
 def validate_schema(
-    cursor: databases.DatabaseCursor,
-    schema: str,
+    database: databases.DatabaseBackend,
     expected_table_cols: dict,
-    parser: databases.DatabaseParser,
 ) -> dict:
     validated_schema = {}
     for table, cols in expected_table_cols.items():
-        query = base_templates.get_column_datatype_query(schema, table, cols.keys())
+        query = base_templates.get_column_datatype_query(
+            database.schema_name, table, cols.keys()
+        )
+
         try:
-            table_schema = cursor.execute(query).fetchall()
-        except Exception:
-            # The database might reasonably raise an exception in cases like
-            # the table not existing. Here we treat error tables as no-column tables.
+            table_schema = database.cursor().execute(query).fetchall()
+        except database.operational_errors():
+            # A database backend might reasonably raise an exception in cases like
+            # the table not existing (Athena does this).
             table_schema = []
-        validated_schema[table] = parser.validate_table_schema(cols, table_schema)
+
+        validated_schema[table] = database.parser().validate_table_schema(
+            cols, table_schema
+        )
     return validated_schema
 
 
 def is_field_populated(
     *,
-    schema: str,
-    cursor: databases.DatabaseCursor,
-    parser: databases.DatabaseParser,
+    database: databases.DatabaseBackend,
     source_table: str,
     hierarchy: list[tuple],
     expected: list | dict | None = None,
@@ -233,8 +229,7 @@ def is_field_populated(
     Non-core studies that rely on the core tables shouldn't need this method.
     This is just to examine the weird and wonderful world of the raw FHIR tables.
 
-    :keyword schema: The schema/database name
-    :keyword cursor: a PEP-249 compliant database cursor
+    :keyword database: The database backend
     :keyword source_table: The table to query against
     :keyword hierarchy: a list of tuples defining the FHIR path to the element.
         Each tuple should be of the form ('element_name', dict | list), where
@@ -244,9 +239,7 @@ def is_field_populated(
     :returns: a boolean indicating if valid data is present.
     """
     if not is_field_present(
-        schema=schema,
-        cursor=cursor,
-        parser=parser,
+        database=database,
         source_table=source_table,
         source_col=hierarchy[0][0],
         expected=expected,
@@ -276,7 +269,7 @@ def is_field_populated(
     query = base_templates.get_is_table_not_empty_query(
         source_table=source_table, field=".".join(source_field), unnests=unnests
     )
-    res = cursor.execute(query).fetchall()
+    res = database.cursor().execute(query).fetchall()
     if len(res) == 0:
         return False
     return True
@@ -284,18 +277,14 @@ def is_field_populated(
 
 def is_field_present(
     *,
-    schema: str,
-    cursor: databases.DatabaseCursor,
-    parser: databases.DatabaseParser,
+    database: databases.DatabaseBackend,
     source_table: str,
     source_col: str,
     expected: list | dict | None = None,
 ) -> bool:
     """Validation check for a column existing, and having the expected schema
 
-    :keyword schema: The schema/database name
-    :keyword cursor: a PEP-249 compliant database cursor
-    :keyword parser: a database schema parser
+    :keyword database: The database backend
     :keyword source_table: The table to query against
     :keyword source_col: The column to check the schema against
     :keyword expected: a list of elements that should be present in source_col.
@@ -306,7 +295,7 @@ def is_field_present(
         expected = CODEABLE_CONCEPT
 
     table_cols = {source_table: {source_col: expected}}
-    schema = validate_schema(cursor, schema, table_cols, parser)
+    schema = validate_schema(database, table_cols)
 
     def _get_all_values(d: dict) -> list:
         all_values = []

--- a/tests/test_template_sql_utils.py
+++ b/tests/test_template_sql_utils.py
@@ -54,11 +54,9 @@ from cumulus_library.template_sql import sql_utils
 def test_is_field_populated(mock_db, table, hierarchy, expected, returns, raises):
     with raises:
         res = sql_utils.is_field_populated(
-            schema="main",
+            database=mock_db,
             source_table=table,
             hierarchy=hierarchy,
             expected=expected,
-            cursor=mock_db.cursor(),
-            parser=mock_db.parser(),
         )
         assert res == returns


### PR DESCRIPTION
(Instead of erroring out.)

This helps in cases where some tables get optionally created (like the ETL completion tables), because Athena generates an exception for that.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration