### PR TITLE
Allow a study to specify a schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
         run: |
           python -m pytest --cov-report xml --cov=cumulus_library tests
       - name: Generate coverage report
+        if: github.ref != 'refs/heads/main'
         uses: orgoro/coverage@v3.1
         with:
             coverageFile: coverage.xml

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,0 +1,39 @@
+# Maintainer notes
+
+This document is intended for users contributing/manitaining this repository.
+It is not comprehensive, but aims to capture items relevant to architecture
+that are not covered in another document.
+
+## Intended usage and database schemas
+
+Since these terms are used somewhat haphazardly in different database implementations, 
+we'll quickly define them for the purposes of this document:
+
+- database - a single instance of a database product, local or in the cloud. it can
+contain serveral schemas.
+- schema - a namespaced collection of tables inside a database
+
+Cumulus, as a holistic system, is designed to allow querying against the entire history
+of a medical institution. You do not need to preselect a cohort - that can be done
+by the author of a given study. We generally recommend using this approach, and it
+is the one that we are trying to use in house.
+
+However, for technical and philosophical reasons, users may wish instead to select
+a cohort at their EHR, and upload that data to a specific named schema in their
+database, and work against that. It's important that we remember this use case
+as we roll out new features.
+
+From the perspective of this repository, and studies which run on top of it, it's 
+important to remember these dual use cases - we should never make assumptions 
+about which database schema will be used, and it may change from one run to the next.
+But all data associated with a single schema (source data and Cumulus studies) should
+exist inside that schema.
+
+As of this writing, the sole exception to this is for third party vocabulary systems.
+For these, the CLI will automatically create these in a unique schema, basically
+(but not enforced) as read only tables that can be referenced by other studies
+via cross-database joining. Additional tables should not be created by users in these
+schemas.
+
+A user could elect to use these vocabulary builders and skip the entire rest of the
+Cumulus ecosystem, if they wanted to. 

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -348,13 +348,13 @@ def build_study(
             queries.append([query, file])
     if len(queries) == 0:
         return []
-    # We want to only show a progress bar if we are :not: printing SQL lines
     if manifest.get_dedicated_schema():
         for query in queries:
             query[0] = query[0].replace(
                 f"`{manifest.get_study_prefix()}__",
                 "`",
             )
+    # We want to only show a progress bar if we are :not: printing SQL lines
     with base_utils.get_progress_bar(disable=verbose) as progress:
         task = progress.add_task(
             f"Creating {manifest.get_study_prefix()} study in db...",

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -348,12 +348,12 @@ def build_study(
             queries.append([query, file])
     if len(queries) == 0:
         return []
-    if manifest.get_dedicated_schema():
-        for query in queries:
-            query[0] = query[0].replace(
-                f"`{manifest.get_study_prefix()}__",
-                "`",
-            )
+    for query in queries:
+        query[0] = base_utils.update_query_if_schema_specified(query[0], manifest)
+        query[0] = query[0].replace(
+            f"`{manifest.get_study_prefix()}__",
+            "`",
+        )
     # We want to only show a progress bar if we are :not: printing SQL lines
     with base_utils.get_progress_bar(disable=verbose) as progress:
         task = progress.add_task(
@@ -406,7 +406,10 @@ def _execute_build_queries(
     """
     for query in queries:
         create_line = query[0].split("\n")[0]
-        if f" {manifest.get_study_prefix()}__" not in create_line:
+        if (
+            f" {manifest.get_study_prefix()}__" not in create_line
+            and not manifest.get_dedicated_schema()
+        ):
             _query_error(
                 query,
                 "This query does not contain the study prefix. All tables should "

--- a/cumulus_library/actions/cleaner.py
+++ b/cumulus_library/actions/cleaner.py
@@ -152,10 +152,10 @@ def clean_study(
         confirm = input("Remove these tables? (y/N)")
         if confirm.lower() not in ("y", "yes"):
             sys.exit("Table cleaning aborted")
-    if manifest_parser.get_dedicated_schema():
+    if dedicated := manifest_parser.get_dedicated_schema():
         view_table_list = [
             (
-                f"`{manifest_parser.get_dedicated_schema()}`.`{x[0]}`",
+                f"`{dedicated}`.`{x[0]}`",
                 x[1],
             )
             for x in view_table_list

--- a/cumulus_library/base_table_builder.py
+++ b/cumulus_library/base_table_builder.py
@@ -86,11 +86,7 @@ class BaseTableBuilder(ABC):
             )
             for query in self.queries:
                 try:
-                    if manifest and manifest.get_dedicated_schema():
-                        query = query.replace(
-                            f"`{manifest.get_study_prefix()}__",
-                            "`",
-                        )
+                    query = base_utils.update_query_if_schema_specified(query, manifest)
                     with base_utils.query_console_output(
                         verbose, query, progress, task
                     ):

--- a/cumulus_library/base_table_builder.py
+++ b/cumulus_library/base_table_builder.py
@@ -86,12 +86,11 @@ class BaseTableBuilder(ABC):
             )
             for query in self.queries:
                 try:
-                    if manifest:
-                        if manifest.get_dedicated_schema():
-                            query = query.replace(
-                                f"`{manifest.get_study_prefix()}__",
-                                "`",
-                            )
+                    if manifest and manifest.get_dedicated_schema():
+                        query = query.replace(
+                            f"`{manifest.get_study_prefix()}__",
+                            "`",
+                        )
                     with base_utils.query_console_output(
                         verbose, query, progress, task
                     ):

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 
 from rich import progress
 
-from cumulus_library import databases
+from cumulus_library import databases, study_parser
 
 
 @dataclasses.dataclass
@@ -114,6 +114,17 @@ def zip_dir(read_path, write_path, archive_name):
             f.write(file, file.relative_to(read_path))
             file.unlink()
         shutil.rmtree(read_path)
+
+
+def update_query_if_schema_specified(
+    query: str, manifest: study_parser.StudyManifestParser
+):
+    if manifest and manifest.get_dedicated_schema():
+        query = query.replace(
+            f"{manifest.get_study_prefix()}__",
+            f"{manifest.get_dedicated_schema()}.",
+        )
+    return query
 
 
 def unzip_file(file_path: pathlib.Path, write_path: pathlib.Path):

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -64,12 +64,10 @@ class StudyManifestParser:
     def get_dedicated_schema(self) -> str | None:
         """Reads the contents of the dedicated schema in the options dict
 
-        :returns: A dictionay of objects, or None if not found
+        :returns: A dictionary of objects, or None if not found
         """
-        if options := self._study_config.get("options"):
-            if schema := options.get("use_dedicated_schema"):
-                return schema
-        return None
+        options = self._study_config.get("advanced_options", {})
+        return options.get("dedicated_schema")
 
     def get_sql_file_list(self, continue_from: str | None = None) -> list[str] | None:
         """Reads the contents of the sql_config array from the manifest

--- a/cumulus_library/study_parser.py
+++ b/cumulus_library/study_parser.py
@@ -61,6 +61,16 @@ class StudyManifestParser:
         """
         return self._study_config.get("study_prefix")
 
+    def get_dedicated_schema(self) -> str | None:
+        """Reads the contents of the dedicated schema in the options dict
+
+        :returns: A dictionay of objects, or None if not found
+        """
+        if options := self._study_config.get("options"):
+            if schema := options.get("use_dedicated_schema"):
+                return schema
+        return None
+
     def get_sql_file_list(self, continue_from: str | None = None) -> list[str] | None:
         """Reads the contents of the sql_config array from the manifest
 

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -47,6 +47,7 @@ study_prefix = "my_study"
 # build tables, you can provide a list of files implementing BaseTableBuilder.
 # See the core study for examples of this pattern. These run before
 # any SQL execution
+
 # [table_builder_config]
 # file_names = [
 #     "my_table_builder.py",
@@ -54,11 +55,14 @@ study_prefix = "my_study"
 
 # The following section describes all tables that should be generated directly
 # from SQL files.
+
 [sql_config]
+
 # 'file_names' defines a list of sql files to execute, in order, in this folder.
 # Recommended order: Any ancillary config (like a list of condition codes),
 # tables/view selecting subsets of data from FHIR data, tables/views creating 
 # summary statistics.
+
 file_names = [
     "setup.sql",
     "lab_observations.sql",
@@ -69,9 +73,12 @@ file_names = [
 
 # The following section defines parameters related to exporting study data from
 # your athena database
+
 [export_config]
+
 # The following tables will be output to disk when an export is run. In most cases,
 # only count tables should be output in this way.
+
 export_list = [
     "my_study__count_influenza_test_month",
 ]
@@ -81,6 +88,7 @@ export_list = [
 # queries for you. We use this pattern for generating the core tables, as well
 # other studies authored inside BCH. These will always be run after any other
 # SQL queries have been generated
+
 # [counts_builder_config]
 # file_names = [
 #    "count.py"
@@ -92,11 +100,30 @@ export_list = [
 # supported approaches.
 # These will run last, so all the data in your study will exist by the time these
 # are invoked.
+
 # [statistics_config]
 # file_names = 
 # [
 #    "psm_config.toml"
 # ]
+
+# The following section is for advanced/unusual study use cases
+
+# [options]
+
+# If you want to override the default schema name to an explicit one, you can define
+# the name of this schema here. 99% of the time, this is not the behavior you want -
+# you want library data to be in the same schema as your data source, since this allows
+# you to keep track of where your source data for a given study run came from.
+#
+# The intended use case for this is for static/slow moving data sets that are external
+# to your EHR data - this is typically things like coding systems.
+#
+# These should be read only use cases - if you want to do additional iterations with
+# the contents of one of these reference sets, do it in the study, not in the reference
+# itself.
+
+# use_dedicated_schema="alternate_schema_name"
 
 ```
 

--- a/tests/test_data/study_dedicated_schema/manifest.toml
+++ b/tests/test_data/study_dedicated_schema/manifest.toml
@@ -1,0 +1,13 @@
+study_prefix = "study_dedicated_schema"
+
+[table_builder_config]
+file_names = ["module1.py", "module1.py", "module2.py"]
+
+[sql_config]
+file_names = ["test.sql"]
+
+[export_config]
+export_list = ["study_dedicated_schema__table_raw_sql"]
+
+[options]
+use_dedicated_schema="dedicated"

--- a/tests/test_data/study_dedicated_schema/manifest.toml
+++ b/tests/test_data/study_dedicated_schema/manifest.toml
@@ -9,5 +9,5 @@ file_names = ["test.sql"]
 [export_config]
 export_list = ["study_dedicated_schema__table_raw_sql"]
 
-[options]
-use_dedicated_schema="dedicated"
+[advanced_options]
+dedicated_schema="dedicated"

--- a/tests/test_data/study_dedicated_schema/module1.py
+++ b/tests/test_data/study_dedicated_schema/module1.py
@@ -1,0 +1,10 @@
+from cumulus_library.base_table_builder import BaseTableBuilder
+
+
+class ModuleOneRunner(BaseTableBuilder):
+    display_text = "module1"
+
+    def prepare_queries(self, cursor: object, schema: str, *args, **kwargs):
+        self.queries.append(
+            "CREATE TABLE IF NOT EXISTS study_dedicated_schema__table (test int);"
+        )

--- a/tests/test_data/study_dedicated_schema/module1.py
+++ b/tests/test_data/study_dedicated_schema/module1.py
@@ -6,5 +6,5 @@ class ModuleOneRunner(BaseTableBuilder):
 
     def prepare_queries(self, cursor: object, schema: str, *args, **kwargs):
         self.queries.append(
-            "CREATE TABLE IF NOT EXISTS study_dedicated_schema__table (test int);"
+            "CREATE TABLE IF NOT EXISTS study_dedicated_schema__table_1 (test int);"
         )

--- a/tests/test_data/study_dedicated_schema/module2.py
+++ b/tests/test_data/study_dedicated_schema/module2.py
@@ -1,0 +1,10 @@
+from cumulus_library.base_table_builder import BaseTableBuilder
+
+
+class ModuleTwoRunner(BaseTableBuilder):
+    display_text = "module2"
+
+    def prepare_queries(self, cursor: object, schema: str, *args, **kwargs):
+        self.queries.append(
+            "CREATE TABLE IF NOT EXISTS study_dedicated_schema__table_2 (test int);"
+        )

--- a/tests/test_data/study_dedicated_schema/test.sql
+++ b/tests/test_data/study_dedicated_schema/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE study_dedicated_schema__table_raw_sql (test int);

--- a/tests/test_data/study_valid/manifest.toml
+++ b/tests/test_data/study_valid/manifest.toml
@@ -1,7 +1,13 @@
 study_prefix = "study_valid"
 
 [sql_config]
-file_names = ["test.sql"]
+file_names = [
+    "test.sql",
+    "test2.sql"
+]
 
 [export_config]
-export_list = ["study_valid__table"]
+export_list = [
+    "study_valid__table",
+    "study_valid__table2"
+]

--- a/tests/test_data/study_valid/test2.sql
+++ b/tests/test_data/study_valid/test2.sql
@@ -1,0 +1,1 @@
+CREATE TABLE study_valid__table2 (test int);

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -227,7 +227,7 @@ def test_pyarrow_types_from_sql(db, data, expected, raises):
     "args,expected_type, raises",
     [
         (
-            {**{"db_type": "duckdb", "schema_name": "test"}, **DUCKDB_KWARGS},
+            {**{"db_type": "duckdb", "schema_name": ":memory:"}, **DUCKDB_KWARGS},
             databases.DuckDatabaseBackend,
             does_not_raise(),
         ),

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -11,26 +11,40 @@ from tests.test_data.parser_mock_data import get_mock_toml, mock_manifests
 
 
 @pytest.mark.parametrize(
-    "manifest_path,raises",
+    "manifest_path,expected,raises",
     [
-        ("test_data/study_valid", does_not_raise()),
-        (None, does_not_raise()),
+        (
+            "test_data/study_valid",
+            (
+                "{'study_prefix': 'study_valid', 'sql_config': {'file_names': "
+                "['test.sql', 'test2.sql']}, 'export_config': {'export_list': "
+                "['study_valid__table', 'study_valid__table2']}}"
+            ),
+            does_not_raise(),
+        ),
+        (None, "{}", does_not_raise()),
         (
             "test_data/study_missing_prefix",
+            "{}",
             pytest.raises(errors.StudyManifestParsingError),
         ),
-        ("test_data/study_wrong_type", pytest.raises(errors.StudyManifestParsingError)),
-        ("", pytest.raises(errors.StudyManifestFilesystemError)),
-        (".", pytest.raises(errors.StudyManifestFilesystemError)),
+        (
+            "test_data/study_wrong_type",
+            "{}",
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+        ("", "{}", pytest.raises(errors.StudyManifestFilesystemError)),
+        (".", "{}", pytest.raises(errors.StudyManifestFilesystemError)),
     ],
 )
-def test_load_manifest(manifest_path, raises):
+def test_load_manifest(manifest_path, expected, raises):
     with raises:
         if manifest_path is not None:
             path = f"{pathlib.Path(__file__).resolve().parents[0]}/{manifest_path}"
         else:
             path = None
-        study_parser.StudyManifestParser(path)
+        manifest = study_parser.StudyManifestParser(path)
+        assert str(manifest) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR makes the following changes:
- Allows a study to specify an explict schema
  - Auto transforms table names if this is done - so 'study__table' becomes just 'table', so reverting this is a config-only change
- adds tests for --continue and --builder CLI args, fixing one bug with the former.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [] Update template repo if there are changes to study configuration