### PR TITLE
feat: switch to cumulus-fhir-support's ndjson reading code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,20 @@ pre-commit install
 This will install dependencies & build tools,
 as well as set up an auto-formatter commit hook.
 
+## Running tests
+
+Tests can be run with `pytest` like you might expect,
+but you'll first want to set up a fake `test` AWS profile.
+
+1. Edit `~/.aws/credentials`
+2. Add a block like:
+```
+[test]
+aws_access_key_id = test
+aws_secret_access_key = test
+```
+3. Then run `pytest`
+
 ## Adding new resources
 
 Things to keep in mind:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cumulus-library"
 requires-python = ">= 3.10"
 dependencies = [
     "ctakesclient >= 1.3",
-    "cumulus-fhir-support >= 1.1",
+    "cumulus-fhir-support >= 1.2",
     "duckdb >= 0.9",
     "fhirclient >= 4.1",
     "Jinja2 > 3",

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -74,11 +74,8 @@ def test_duckdb_from_iso8601_timestamp(timestamp, expected):
 
 def test_duckdb_load_ndjson_dir(tmp_path):
     filenames = {
-        "A.Patient.ndjson": False,
-        "1.Patient.ndjson": True,
-        "Patient.ndjson": True,
-        "Patient.hello.bye.ndjson": True,
-        "Patient.nope": False,
+        "blarg.ndjson": True,
+        "blarg.nope": False,
         "patient/blarg.ndjson": True,
         "patient/blarg.meta": False,
     }
@@ -86,7 +83,7 @@ def test_duckdb_load_ndjson_dir(tmp_path):
     for index, (filename, valid) in enumerate(filenames.items()):
         with open(f"{tmp_path}/{filename}", "w", encoding="utf8") as f:
             row_id = f"Good{index}" if valid else f"Bad{index}"
-            f.write(f'{{"id":"{row_id}"}}')
+            f.write(f'{{"id":"{row_id}", "resourceType": "Patient"}}')
 
     db = databases.create_db_backend(
         {
@@ -115,6 +112,7 @@ def test_duckdb_table_schema():
         with open(f"{tmpdir}/observation/test.ndjson", "w", encoding="utf8") as ndjson:
             json.dump(
                 {
+                    "resourceType": "Observation",
                     "id": "test",
                     "component": [
                         {


### PR DESCRIPTION
We now load any ndjson files that cumulus-fhir-support says to.

Depends on https://github.com/smart-on-fhir/cumulus-fhir-support/pull/3

### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration