### PR TITLE
Schema handling for external tables

### DIFF
--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -134,10 +134,19 @@ def update_query_if_schema_specified(
     query: str, manifest: study_manifest.StudyManifest
 ):
     if manifest and manifest.get_dedicated_schema():
-        query = query.replace(
-            f"{manifest.get_study_prefix()}__",
-            f"{manifest.get_dedicated_schema()}.",
-        )
+        # External queries in athena require a schema to be specified, so we
+        # just trim the prefix here.
+        # TODO: Move this to be a database defined function.
+        if "CREATE EXTERNAL" in query:
+            query = query.replace(
+                f"{manifest.get_study_prefix()}__",
+                "",
+            )
+        else:
+            query = query.replace(
+                f"{manifest.get_study_prefix()}__",
+                f"{manifest.get_dedicated_schema()}.",
+            )
     return query
 
 

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -134,8 +134,10 @@ def update_query_if_schema_specified(
     query: str, manifest: study_manifest.StudyManifest
 ):
     if manifest and manifest.get_dedicated_schema():
-        # External queries in athena require a schema to be specified, so we
-        # just trim the prefix here.
+        # External queries in athena require a schema to be specified already, so
+        # rather than splitting and ending up with a table name like
+        # `schema`.`schema.table`, we just remove the `schema__` chunk from the
+        # table name.
         # TODO: Move this to be a database defined function.
         if "CREATE EXTERNAL" in query:
             query = query.replace(

--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -15,7 +15,6 @@ import os
 import pathlib
 import re
 import sys
-from pathlib import Path
 from typing import Any, Protocol
 
 import boto3
@@ -649,7 +648,7 @@ class DuckDbParser(DatabaseParser):
         return parsed
 
 
-def _read_rows_for_resource(path: Path, resource: str) -> list[dict]:
+def _read_rows_for_resource(path: pathlib.Path, resource: str) -> list[dict]:
     rows = []
 
     # Support any ndjson files from the target folder directly
@@ -690,7 +689,7 @@ def read_ndjson_dir(path: str) -> dict[str, pyarrow.Table]:
     ]
     for resource in resources:
         table_name = resource.lower()
-        rows = _read_rows_for_resource(Path(path), resource)
+        rows = _read_rows_for_resource(pathlib.Path(path), resource)
 
         # Make a pyarrow table with full schema from the data
         schema = cumulus_fhir_support.pyarrow_schema_from_rows(resource, rows)

--- a/cumulus_library/log_utils.py
+++ b/cumulus_library/log_utils.py
@@ -73,7 +73,6 @@ def _log_table(
     manifest: study_manifest.StudyManifest,
     dataset: list[list],
 ):
-    print(type(config))
     if manifest and manifest.get_dedicated_schema():
         db_schema = manifest.get_dedicated_schema()
         table_name = table.name

--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -4,6 +4,8 @@
     "allowlist" : {
         "covid_symptom" : "cumulus_library_covid/covid_symptom",
         "data_metrics" : "cumulus_library_data_metrics",
+        "rxnorm" : "cumulus_library_umls/rxnorm",
         "umls" : "cumulus_library_umls/umls"
+
     }
 }

--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -4,7 +4,7 @@
     "allowlist" : {
         "covid_symptom" : "cumulus_library_covid/covid_symptom",
         "data_metrics" : "cumulus_library_data_metrics",
-        "rxnorm" : "cumulus_library_umls/rxnorm",
+        "rxnorm" : "cumulus_library_rxnorm",
         "umls" : "cumulus_library_umls/umls"
 
     }

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import botocore
 
-from cumulus_library import databases
+from cumulus_library import base_utils, databases, study_manifest
 
 
 def test_schema_parsing():
@@ -97,3 +97,17 @@ def test_create_schema(mock_client):
 
     db.create_schema("test_new")
     assert mock_clientobj.create_database.called
+
+
+def test_dedicated_schema_namespacing():
+    manifest = study_manifest.StudyManifest()
+    manifest._study_config = manifest._study_config = {
+        "study_prefix": "foo",
+        "advanced_options": {"dedicated_schema": "foo"},
+    }
+    query = "CREATE TABLE foo__bar"
+    result = base_utils.update_query_if_schema_specified(query, manifest)
+    assert result == "CREATE TABLE foo.bar"
+    query = "CREATE EXTERNAL TABLE foo.foo__bar"
+    result = base_utils.update_query_if_schema_specified(query, manifest)
+    assert result == "CREATE EXTERNAL TABLE foo.bar"


### PR DESCRIPTION
This PR makes the following changes:
- Updates 3.0 schema handling for external tables in athena
- Adds `rxnorm` as a target
- cleanup: one irritating print statement, module-based import

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration