### PR TITLE
If no --option is given, provide a bare {} dictionary

### DIFF
--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -424,17 +424,17 @@ def main(cli_args=None):
         console = rich.console.Console()
         console.print(table)
 
-    if arglist := args.get("options", []):
-        options = {}
-        for c_arg in arglist:
-            c_arg = c_arg.split(":", 2)
-            if len(c_arg) == 1:
-                sys.exit(
-                    f"Custom argument '{c_arg}' is not validly formatted.\n"
-                    "Custom arguments should be of the form 'argname:value'."
-                )
-            options[c_arg[0]] = c_arg[1]
-        args["options"] = options
+    options = {}
+    cli_options = args.get("options") or []
+    for c_arg in cli_options:
+        c_arg = c_arg.split(":", 2)
+        if len(c_arg) == 1:
+            sys.exit(
+                f"Custom argument '{c_arg}' is not validly formatted.\n"
+                "Custom arguments should be of the form 'argname:value'."
+            )
+        options[c_arg[0]] = c_arg[1]
+    args["options"] = options
 
     if args.get("data_path"):
         args["data_path"] = get_abs_path(args["data_path"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -708,6 +708,26 @@ def test_cli_custom_args(mock_config, tmp_path, option, raises):
 
 
 @mock.patch.dict(os.environ, clear=True)
+@mock.patch("cumulus_library.base_utils.StudyConfig")
+def test_cli_no_custom_args_yields_empty_dict(mock_config, tmp_path):
+    mock_config.return_value.stats_clean = False
+    cli.main(
+        cli_args=duckdb_args(
+            [
+                "build",
+                "-t",
+                "study_valid",
+                "-s",
+                f"{Path(__file__).resolve().parents[0]}/test_data/study_valid",
+            ],
+            tmp_path,
+        )
+    )
+    called_options = mock_config.call_args[1]["options"]
+    assert {} == called_options
+
+
+@mock.patch.dict(os.environ, clear=True)
 def test_cli_import_study(tmp_path):
     test_data = {"string": ["a", "b", None]}
     df = pandas.DataFrame(test_data)


### PR DESCRIPTION
This allows consumers to not need to check for None - they can just do options.get().


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration