### PR TITLE
Gracefully migrate transactions

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -1,3 +1,7 @@
 """Package metadata"""
 
+from .base_utils import StudyConfig
+from .study_manifest import StudyManifest
+
+__all__ = ["StudyConfig", "StudyManifest"]
 __version__ = "3.0.0"

--- a/cumulus_library/databases.py
+++ b/cumulus_library/databases.py
@@ -274,7 +274,7 @@ class AthenaDatabaseBackend(DatabaseBackend):
         return AthenaParser()
 
     def operational_errors(self) -> tuple[Exception]:
-        return (pyathena.OperationalError,)  # pragma: no cover
+        return (pyathena.OperationalError,)
 
     def col_parquet_types_from_pandas(self, field_types: list) -> list:
         output = []
@@ -609,7 +609,10 @@ class DuckDatabaseBackend(DatabaseBackend):
         return DuckDbParser()
 
     def operational_errors(self) -> tuple[Exception]:
-        return (duckdb.OperationalError,)  # pragma: no cover
+        return (
+            duckdb.OperationalError,
+            duckdb.BinderException,
+        )
 
     def create_schema(self, schema_name):
         """Creates a new schema object inside the database"""

--- a/cumulus_library/log_utils.py
+++ b/cumulus_library/log_utils.py
@@ -90,7 +90,7 @@ def _log_table(
     cursor = config.db.cursor()
     try:
         cursor.execute(query)
-    except Exception as e:
+    except config.db.operational_errors() as e:
         # Migrating logging tables
         if "lib_transactions" in table_name:
             cols = cursor.execute(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,7 @@ from contextlib import nullcontext as does_not_raise
 from datetime import datetime
 from unittest import mock
 
+import pyathena
 import pytest
 from freezegun import freeze_time
 
@@ -138,7 +139,7 @@ def test_migrate_transactions_athena(mock_pyathena):
         ],
     ]
     mock_pyathena.return_value.cursor.return_value.execute.side_effect = [
-        Exception,
+        pyathena.OperationalError,
         mock_fetchall,
         None,
         None,


### PR DESCRIPTION
This PR addresses #259 by altering a given lib_transaction table if an error is raised.

Also added manifest/config to the external API.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration