### PR TITLE
Fix Athena's ability to export "decimal" types

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -105,6 +105,8 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                     output.append((column[0], pyarrow.int64()))
                 case "double":
                     output.append((column[0], pyarrow.float64()))
+                case "decimal":
+                    output.append((column[0], pyarrow.decimal128(column[4], column[5])))
                 case "boolean":
                     output.append((column[0], pyarrow.bool_()))
                 case "date":
@@ -113,7 +115,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                     output.append((column[0], pyarrow.timestamp("s")))
                 case _:
                     raise errors.CumulusLibraryError(
-                        output.append(f"Unsupported SQL type '{column}' found.")
+                        f"Unsupported SQL type '{column[1]}' found."
                     )
         return output
 

--- a/cumulus_library/databases/duckdb.py
+++ b/cumulus_library/databases/duckdb.py
@@ -90,8 +90,10 @@ class DuckDatabaseBackend(base.DatabaseBackend):
 
     @staticmethod
     def _compat_array_join(
-        value: list[str | None], delimiter: str | None
+        value: list[str | None] | None, delimiter: str | None
     ) -> str | None:
+        if value is None:
+            return None
         if delimiter is None or delimiter == "None":
             # This is exercised locally on unit tests but is not in CI. Not sure why,
             # and not sure it's worth debugging


### PR DESCRIPTION
Also, fix a small NULL handling issue with array_join in duckdb.


### Checklist
- [x] Consider if documentation (like in `docs/`) needs to be updated
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration