### PR TITLE
Template/manifest updates for vocab

### DIFF
--- a/cumulus_library/.sqlfluff
+++ b/cumulus_library/.sqlfluff
@@ -26,6 +26,7 @@ load_macros_from_path = cumulus_library/template_sql/shared_macros,cumulus_libra
 
 [sqlfluff:templater:jinja:context]
 code_systems = ["http://snomed.info/sct", "http://hl7.org/fhir/sid/icd-10-cm"]
+column_aliases = {'a.foo': 'foobar', 'b.bar' : 'foobaz'}
 col_type_list = ["a string","b string"]
 columns = ['a','b']
 cc_columns = 
@@ -81,6 +82,8 @@ filter_resource = True
 fhir_extension = condition
 fhir_resource = patient
 id = 'id'
+join_clauses = ['a.foo = b.foo','a.bar = b.bar']
+join_columns = ['a.foo', 'b.foo', 'a.bar', 'b.bar']
 join_cols_by_table = 
     { 
         "join_table": { 
@@ -89,6 +92,8 @@ join_cols_by_table =
         }
     }
 join_id = subject_ref
+join_tables = ['table_a','table_b']
+join_table_aliases = ['a','b']
 local_location = /var/study/data/
 neg_source_table = neg_source_table
 output_table_name = 'created_table'
@@ -217,6 +222,7 @@ table_cols = ["a","b"]
 table_cols_types = ["varchar", "varchar"]
 table_name = test_table
 table_names = ["test_table"]
+tables = ["test_a", "test_b"]
 table_suffix = 2024_01_01_11_11_11
 target_col_prefix = prefix
 target_table = target_table

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -2,7 +2,6 @@
 
 import dataclasses
 import datetime
-import json
 import pathlib
 import shutil
 import zipfile
@@ -54,20 +53,9 @@ def get_schema(config: StudyConfig, manifest: study_manifest.StudyManifest):
     return config.schema
 
 
-def get_prefix_with_seperator(manifest: study_manifest.StudyManifest):
-    if dedicated := manifest.get_dedicated_schema():
-        return f"{dedicated}."
-    return f"{manifest.get_study_prefix()}__"
-
-
 def load_text(path: str) -> str:
     with open(path, encoding="UTF-8") as fp:
         return fp.read()
-
-
-def load_json(path: str) -> dict:
-    with open(path, encoding="UTF-8") as fp:
-        return json.load(fp)
 
 
 def parse_sql(sql_text: str) -> list[str]:

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -54,6 +54,12 @@ def get_schema(config: StudyConfig, manifest: study_manifest.StudyManifest):
     return config.schema
 
 
+def get_prefix_with_seperator(manifest: study_manifest.StudyManifest):
+    if dedicated := manifest.get_dedicated_schema():
+        return f"{dedicated}."
+    return f"{manifest.get_study_prefix()}__"
+
+
 def load_text(path: str) -> str:
     with open(path, encoding="UTF-8") as fp:
         return fp.read()

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -133,3 +133,9 @@ class StudyManifest:
             + self.get_counts_builder_file_list()
             + self.get_statistics_file_list()
         )
+
+    def get_prefix_with_seperator(self) -> str:
+        """Convenience method for getting the appropriate prefix for tables"""
+        if dedicated := self.get_dedicated_schema():
+            return f"{dedicated}."
+        return f"{self.get_study_prefix()}__"

--- a/cumulus_library/template_sql/base_templates.py
+++ b/cumulus_library/template_sql/base_templates.py
@@ -6,7 +6,7 @@ import pathlib
 import jinja2
 import pandas
 
-from cumulus_library import db_config
+from cumulus_library import db_config, errors
 from cumulus_library.template_sql import sql_utils
 
 
@@ -79,10 +79,10 @@ def get_codeable_concept_denormalize_query(
         parent_field=None
         if len(config.column_hierarchy) == 1
         else config.column_hierarchy[0][0],
-        is_array=(config.column_hierarchy[0][1] == list),
+        is_array=(config.column_hierarchy[0][1] is list),
         child_is_array=False
         if len(config.column_hierarchy) == 1
-        else config.column_hierarchy[1][1] == list,
+        else config.column_hierarchy[1][1] is list,
         target_table=config.target_table,
         filter_priority=config.filter_priority,
         code_systems=config.code_systems,
@@ -139,6 +139,23 @@ def get_column_datatype_query(
     )
 
 
+def get_create_table_from_union(
+    *, table_name: str, tables: list[str], columns: list[str]
+) -> str:
+    """Generates a create union table query
+
+    :keyword table_name: the name of the resulting table
+    :keyword tables: A list of length two for the source tables for the join
+    :keyword columns: a list of cols to add to the view. Prepend with the table
+        or the alias."""
+    return get_base_template(
+        "create_table_from_union",
+        table_name=table_name,
+        tables=tables,
+        columns=columns,
+    )
+
+
 def get_create_view_query(
     view_name: str, dataset: list[list[str]], view_cols: list[str]
 ) -> str:
@@ -153,6 +170,47 @@ def get_create_view_query(
         view_name=view_name,
         dataset=dataset,
         view_cols=view_cols,
+    )
+
+
+def get_create_view_from_tables(
+    *,
+    view_name: str,
+    tables: list,
+    columns: list,
+    join_clauses: list,
+    table_aliases: list | None = None,
+    column_aliases: dict | None = None,
+) -> str:
+    """Generates a create view query from tables in the database
+
+    :keyword view_name: the name of the resulting view
+    :keyword tables: A list of length two for the source tables for the join
+    :keyword columns: a list of columns to add to the view. Prepend with the table
+        or the alias.
+    :keyword join_clauses: a list of valid SQL join statements
+    :keyword table_aliases: A list of length two of aliases for the source tables.
+        ["a","b"] used if not supplied
+    :keyword column_aliases: A dict of aliases to apply, like {'a_col': 'alias'}
+    """
+    if table_aliases is None:
+        table_aliases = ["a", "b"]
+    if column_aliases is None:
+        column_aliases = {}
+    for list_arg in [tables, table_aliases]:
+        if len(list_arg) != 2:
+            raise errors.CumulusLibraryError(
+                f"Error generating view {view_name}: "
+                f"Expected {','.join(list_arg)} to be of length two."
+            )
+    return get_base_template(
+        "create_view_from_tables",
+        view_name=view_name,
+        join_tables=tables,
+        join_table_aliases=table_aliases,
+        join_columns=columns,
+        column_aliases=column_aliases,
+        join_clauses=join_clauses,
     )
 
 

--- a/cumulus_library/template_sql/create_table_from_union.sql.jinja
+++ b/cumulus_library/template_sql/create_table_from_union.sql.jinja
@@ -1,0 +1,12 @@
+{%- import 'syntax.sql.jinja' as syntax -%}
+
+CREATE TABLE {{ table_name }} AS
+{%- for table in tables %}
+SELECT 
+{%- for col in columns %}
+{{ col }}
+{{- syntax.comma_delineate(loop) }}
+{%- endfor %}
+FROM {{ table }}
+{{ syntax.union_delineate(loop) }}
+{%- endfor %}

--- a/cumulus_library/template_sql/create_view_from_tables.sql.jinja
+++ b/cumulus_library/template_sql/create_view_from_tables.sql.jinja
@@ -1,0 +1,14 @@
+{%- import 'syntax.sql.jinja' as syntax -%}
+CREATE OR REPLACE VIEW {{ view_name }} AS
+SELECT 
+{%- for col in join_columns %}
+    {{ col }}
+    {%- if col in column_aliases.keys() 
+    %} AS {{ column_aliases[col] }}{%- endif -%}{{ syntax.comma_delineate(loop) }}
+{%- endfor %}
+FROM {{ join_tables[0] }} AS {{ join_table_aliases[0] }},
+    {{ join_tables[1] }} AS {{ join_table_aliases[1] }}
+WHERE
+    {%- for clause in join_clauses %}
+    {{ syntax.and_delineate(loop) }}{{ clause }}
+    {%- endfor %}

--- a/cumulus_library/template_sql/shared_macros/syntax.sql.jinja
+++ b/cumulus_library/template_sql/shared_macros/syntax.sql.jinja
@@ -18,6 +18,21 @@ UNION
 {%- endif -%}
 {%- endmacro -%}
 
+{# Note that this delineation is meant to be at the front of the string in
+a loop - this is to enable formatting in a WHERE statement like this:
+---
+WHERE
+    b.bar = a.foo
+    AND b.baz != a.foo
+---
+This is slightly easier to work with when debugging queries (and also
+conforms better to the mozilla style guide)
+#}
+{%- macro and_delineate(loop) -%}
+{%- if not loop.first -%}AND {% endif -%}
+{%- endmacro -%}
+
+
 {#- The intent of this macro is to convert sql wildcard format to regex syntax.
  So for example, a value of macro_string like:
 

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from cumulus_library import base_utils, errors, study_manifest
+from cumulus_library import errors, study_manifest
 from tests.test_data.parser_mock_data import get_mock_toml, mock_manifests
 
 
@@ -100,4 +100,4 @@ def test_manifest_data(mock_load, mock_open, manifest_key, raises):
 def test_get_prefix_with_seperator(manifest_path, prefix):
     path = f"{pathlib.Path(__file__).resolve().parents[0]}/{manifest_path}"
     manifest = study_manifest.StudyManifest(path)
-    assert prefix == base_utils.get_prefix_with_seperator(manifest)
+    assert prefix == manifest.get_prefix_with_seperator()

--- a/tests/test_study_parser.py
+++ b/tests/test_study_parser.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from cumulus_library import errors, study_manifest
+from cumulus_library import base_utils, errors, study_manifest
 from tests.test_data.parser_mock_data import get_mock_toml, mock_manifests
 
 
@@ -88,3 +88,16 @@ def test_manifest_data(mock_load, mock_open, manifest_key, raises):
                 )
         else:
             assert manifest.get_export_table_list() == []
+
+
+@pytest.mark.parametrize(
+    "manifest_path,prefix",
+    [
+        ("test_data/study_valid", "study_valid__"),
+        ("test_data/study_dedicated_schema", "dedicated."),
+    ],
+)
+def test_get_prefix_with_seperator(manifest_path, prefix):
+    path = f"{pathlib.Path(__file__).resolve().parents[0]}/{manifest_path}"
+    manifest = study_manifest.StudyManifest(path)
+    assert prefix == base_utils.get_prefix_with_seperator(manifest)


### PR DESCRIPTION
This PR makes the following changes:
- Adds two new generic templates (view/union generation)
- Adds a convenience method for getting the appropriate prefix string for a table.

### Checklist
- [X] Consider if documentation (like in `docs/`) needs to be updated
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration