### PR TITLE
Use python import machinery to find known studies

### DIFF
--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -1,11 +1,13 @@
 {
     "desc" : 
         "this dict maps pip installable studies to expected paths inside site-packages",
-    "allowlist" : {
-        "covid_symptom" : "cumulus_library_covid",
-        "data_metrics" : "cumulus_library_data_metrics",
-        "rxnorm" : "cumulus_library_rxnorm",
-        "umls" : "cumulus_library_umls"
-
-    }
+    "allowlist" : [
+        "cumulus_library_covid",
+        "cumulus_library_data_metrics",
+        "cumulus_library_hypertension",
+        "cumulus_library_opioid",
+        "cumulus_library_rxnorm",
+        "cumulus_library_suicidality_los",
+        "cumulus_library_umls"
+    ]
 }

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -461,9 +461,7 @@ def test_upload_data(user, id_token, status, preview, login_error, raises):
 @pytest.mark.parametrize(
     "study,external", [("study_python_valid", False), ("study_python_s3", True)]
 )
-@mock.patch("sysconfig.get_path")
-def test_generate_sql(mock_path, mock_db_config, tmp_path, study, external):
-    mock_path.return_value = [f"{tmp_path}/{study}/"]
+def test_generate_sql(mock_db_config, tmp_path, study, external):
     with does_not_raise():
         shutil.copytree(
             f"{Path(__file__).resolve().parents[0]}/test_data/{study}",
@@ -486,9 +484,7 @@ def test_generate_sql(mock_path, mock_db_config, tmp_path, study, external):
             assert "bucket/db_path" in query
 
 
-@mock.patch("sysconfig.get_path")
-def test_generate_md(mock_path, mock_db_config, tmp_path):
-    mock_path.return_value = f"{tmp_path}/study_python_valid/"
+def test_generate_md(mock_db_config, tmp_path):
     with does_not_raise():
         shutil.copytree(
             f"{Path(__file__).resolve().parents[0]}/test_data/study_python_valid",


### PR DESCRIPTION
Previously, we assumed they'd be directories inside site-packages.

But in some cases (like pip install -e . in linux), that installs a .pth file that points at the real location.

So let's just ask Python where these known modules are.

Fixes #290 

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`