### PR TITLE
Add an advanced dynamic_study_prefix field to manifests.

### DIFF
--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -48,7 +48,7 @@ def _load_and_execute_builder(
     :keyword filename: filename of a module implementing a TableBuilder
     :keyword db_parser: an object implementing DatabaseParser for the target database
     :keyword write_reference_sql: if true, writes sql to disk inside a study's directory
-    :keyword doc_string: A string to insert between queries written to disk
+    :keyword doc_str: A string to insert between queries written to disk
     """
 
     # Since we have to support arbitrary user-defined python files here, we

--- a/cumulus_library/studies/core/count_core.py
+++ b/cumulus_library/studies/core/count_core.py
@@ -115,6 +115,7 @@ class CoreCountsBuilder(cumulus_library.CountsBuilder):
         return self.count_patient(table_name, from_table, cols)
 
     def prepare_queries(self, *args, **kwargs):
+        super().prepare_queries(*args, **kwargs)
         self.queries = [
             self.count_core_allergyintolerance(duration="month"),
             self.count_core_condition(duration="month"),

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -1,6 +1,9 @@
 """Class for loading study configuration data from manifest.toml files"""
 
 import pathlib
+import re
+import subprocess
+import sys
 import tomllib
 
 from cumulus_library import errors
@@ -9,42 +12,43 @@ from cumulus_library import errors
 class StudyManifest:
     """Handles interactions with study directories and manifest files"""
 
+    PREFIX_REGEX = re.compile(r"[a-zA-Z][a-zA-Z0-9_]*")
+
     def __init__(
         self,
         study_path: pathlib.Path | None = None,
         data_path: pathlib.Path | None = None,
+        *,
+        options: dict[str, str] | None = None,
     ):
         """Instantiates a StudyManifest.
 
         :param study_path: A Path object pointing to the dir of the manifest, optional
         :param data_path: A Path object pointing to the dir to save/load ancillary files from,
             optional
+        :param options: Command line study-specific options for dynamic manifest values, optional
         """
+        self._study_prefix = None
         self._study_path = None
         self._study_config = {}
         if study_path is not None:
-            self.load_study_manifest(study_path)
+            self._load_study_manifest(study_path, options or {})
         self.data_path = data_path
 
     def __repr__(self):
         return str(self._study_config)
 
     ### toml parsing helper functions
-    def load_study_manifest(self, study_path: pathlib.Path) -> None:
+    def _load_study_manifest(self, study_path: pathlib.Path, options: dict[str, str]) -> None:
         """Reads in a config object from a directory containing a manifest.toml
 
         :param study_path: A pathlib.Path object pointing to a study directory
+        :param options: Command line study-specific options (--option=A:B)
         :raises StudyManifestParsingError: the manifest.toml is malformed or missing.
         """
         try:
             with open(f"{study_path}/manifest.toml", "rb") as file:
                 config = tomllib.load(file)
-                if not config.get("study_prefix") or not isinstance(config["study_prefix"], str):
-                    raise errors.StudyManifestParsingError(
-                        f"Invalid prefix in manifest at {study_path}"
-                    )
-                self._study_config = config
-            self._study_path = study_path
         except FileNotFoundError as e:
             raise errors.StudyManifestFilesystemError(
                 f"Missing or invalid manifest found at {study_path}"
@@ -53,12 +57,24 @@ class StudyManifest:
             # just unify the error classes for convenience of catching them
             raise errors.StudyManifestParsingError(str(e)) from e
 
+        self._study_config = config
+        self._study_path = study_path
+
+        if dynamic_study_prefix := config.get("dynamic_study_prefix"):
+            self._study_prefix = self._run_dynamic_script(dynamic_study_prefix, options)
+        elif config.get("study_prefix") and isinstance(config["study_prefix"], str):
+            self._study_prefix = config["study_prefix"]
+
+        if not self._study_prefix or not re.fullmatch(self.PREFIX_REGEX, self._study_prefix):
+            raise errors.StudyManifestParsingError(f"Invalid prefix in manifest at {study_path}")
+        self._study_prefix = self._study_prefix.lower()
+
     def get_study_prefix(self) -> str | None:
         """Reads the name of a study prefix from the in-memory study config
 
         :returns: A string of the prefix in the manifest, or None if not found
         """
-        return self._study_config.get("study_prefix")
+        return self._study_prefix
 
     def get_dedicated_schema(self) -> str | None:
         """Reads the contents of the dedicated schema in the options dict
@@ -117,13 +133,20 @@ class StudyManifest:
         :returns: An array of tables to export from the manifest, or None if not found.
         """
         export_config = self._study_config.get("export_config", {})
-        export_table_list = export_config.get("export_list", []) or []
-        for table in export_table_list:
-            if not table.startswith(f"{self.get_study_prefix()}__"):
+        export_table_list = []
+        for table in export_config.get("export_list") or []:
+            if table.startswith(f"{self.get_study_prefix()}__"):
+                export_table_list.append(table)
+            elif "__" in table:  # has a prefix, just the wrong one
                 raise errors.StudyManifestParsingError(
                     f"{table} in export list does not start with prefix "
                     f"{self.get_study_prefix()}__ - check your manifest file."
                 )
+            else:
+                # Add the prefix for them (helpful in dynamic prefix cases where the prefix
+                # is not known ahead of time)
+                export_table_list.append(f"{self.get_study_prefix()}__{table}")
+
         return export_table_list
 
     def get_all_generators(self) -> list[str]:
@@ -139,3 +162,19 @@ class StudyManifest:
         if dedicated := self.get_dedicated_schema():
             return f"{dedicated}."
         return f"{self.get_study_prefix()}__"
+
+    ### Dynamic Python code support
+
+    def _run_dynamic_script(self, filename: str, options: dict[str, str]) -> str:
+        if not sys.executable:
+            raise RuntimeError("Unknown Python executable, dynamic manifest values not supported")
+
+        full_path = f"{self._study_path}/{filename}"
+        option_args = [f"--{key}={value}" for key, value in options.items()]
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, full_path, *option_args],
+            check=True,
+            capture_output=True,
+        )
+
+        return result.stdout.decode("utf8").strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,7 @@ def mock_db_core(tmp_path, mock_db):  # pylint: disable=redefined-outer-name
     builder = cli.StudyRunner(config, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
         pathlib.Path(__file__).parent.parent / "cumulus_library/studies/core",
+        options={},
     )
     yield mock_db
 
@@ -256,6 +257,7 @@ def mock_db_stats(tmp_path):
     builder = cli.StudyRunner(config, data_path=f"{tmp_path}/data_path")
     builder.clean_and_build_study(
         pathlib.Path(__file__).parent.parent / "cumulus_library/studies/core",
+        options={},
     )
     yield db
 

--- a/tests/test_athena.py
+++ b/tests/test_athena.py
@@ -99,12 +99,12 @@ def test_create_schema(mock_client):
     assert mock_clientobj.create_database.called
 
 
-def test_dedicated_schema_namespacing():
-    manifest = study_manifest.StudyManifest()
-    manifest._study_config = manifest._study_config = {
-        "study_prefix": "foo",
-        "advanced_options": {"dedicated_schema": "foo"},
-    }
+def test_dedicated_schema_namespacing(tmp_path):
+    with open(f"{tmp_path}/manifest.toml", "w", encoding="utf8") as f:
+        f.write('study_prefix="foo"\n')
+        f.write("[advanced_options]\n")
+        f.write('dedicated_schema="foo"\n')
+    manifest = study_manifest.StudyManifest(tmp_path)
     query = "CREATE TABLE foo__bar"
     result = base_utils.update_query_if_schema_specified(query, manifest)
     assert result == "CREATE TABLE foo.bar"

--- a/tests/test_counts_builder.py
+++ b/tests/test_counts_builder.py
@@ -199,9 +199,10 @@ def test_count_wrappers(
         assert call_kwargs["min_subject"] == min_subject
 
 
-def test_null_initialization():
+def test_null_study_prefix():
+    builder = counts.CountsBuilder()
     with pytest.raises(errors.CountsBuilderError):
-        counts.CountsBuilder()
+        builder.get_table_name("table")  # needs study_prefix to work
 
 
 def test_write_queries(tmp_path):

--- a/tests/test_data/study_dynamic_prefix/counts.py
+++ b/tests/test_data/study_dynamic_prefix/counts.py
@@ -1,0 +1,8 @@
+import cumulus_library
+
+
+class DynamicCounts(cumulus_library.CountsBuilder):
+    def prepare_queries(self, *args, **kwargs):
+        super().prepare_queries(*args, **kwargs)
+        table_name = self.get_table_name("counts")
+        self.queries.append(f"CREATE TABLE IF NOT EXISTS {table_name} (test int);")

--- a/tests/test_data/study_dynamic_prefix/gen_prefix.py
+++ b/tests/test_data/study_dynamic_prefix/gen_prefix.py
@@ -1,0 +1,7 @@
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--prefix", default="dynamic")
+args, _rest = parser.parse_known_args()
+
+print(args.prefix)

--- a/tests/test_data/study_dynamic_prefix/manifest.toml
+++ b/tests/test_data/study_dynamic_prefix/manifest.toml
@@ -1,0 +1,17 @@
+dynamic_study_prefix = "gen_prefix.py"
+
+[table_builder_config]
+file_names = [
+    "meta.py",
+]
+
+[counts_builder_config]
+file_names = [
+    "counts.py"
+]
+
+[export_config]
+export_list = [
+    "counts",
+    "meta_version",
+]

--- a/tests/test_data/study_dynamic_prefix/meta.py
+++ b/tests/test_data/study_dynamic_prefix/meta.py
@@ -1,0 +1,11 @@
+"""Sets study metadata"""
+
+import cumulus_library
+
+
+class DynamicMeta(cumulus_library.BaseTableBuilder):
+    def prepare_queries(self, *args, manifest: cumulus_library.StudyManifest, **kwargs):
+        prefix = manifest.get_study_prefix()
+        self.queries.append(
+            f"CREATE TABLE {prefix}__meta_version AS SELECT 1 AS data_package_version;"
+        )

--- a/tests/test_dynamic_manifest.py
+++ b/tests/test_dynamic_manifest.py
@@ -1,0 +1,95 @@
+"""tests for using dynamic values in study manifests"""
+
+import builtins
+import os
+import pathlib
+import shutil
+from contextlib import nullcontext as does_not_raise
+from pathlib import Path
+from unittest import mock
+
+import duckdb
+import pytest
+
+from cumulus_library import cli, errors, study_manifest
+from tests.conftest import duckdb_args
+
+STUDY_ARGS = [
+    f"--study-dir={Path(__file__).parent}/test_data/study_dynamic_prefix",
+    "--target=dynamic",
+]
+
+
+@pytest.mark.parametrize(
+    "options,result",
+    [
+        ({"prefix": "my_study"}, "my_study"),  # simply happy path
+        ({"prefix": "STUDY"}, "study"),  # lowercased
+        ({"prefix": ""}, pytest.raises(errors.StudyManifestParsingError)),  # empty prefix
+        ({"prefix": "..."}, pytest.raises(errors.StudyManifestParsingError)),  # bad prefix
+        ({"prefix": "123"}, pytest.raises(errors.StudyManifestParsingError)),  # bad prefix
+    ],
+)
+def test_manifest_with_dynamic_prefix(options, result):
+    if isinstance(result, str):
+        raises = does_not_raise()
+    else:
+        raises = result
+    with raises:
+        path = pathlib.Path("tests/test_data/study_dynamic_prefix")
+        manifest = study_manifest.StudyManifest(path, options=options)
+        assert manifest.get_study_prefix() == result
+
+
+@mock.patch("sys.executable", new=None)
+def test_manifest_with_dynamic_prefix_and_no_executable():
+    """sys.executable must be valid for us to run a Python script"""
+    with pytest.raises(RuntimeError):
+        study_manifest.StudyManifest(pathlib.Path("tests/test_data/study_dynamic_prefix"))
+
+
+def test_cli_clean_with_dynamic_prefix(tmp_path):
+    cli.main(cli_args=duckdb_args(["build", *STUDY_ARGS, "--option=prefix:dynamic2"], tmp_path))
+    cli.main(cli_args=duckdb_args(["build", *STUDY_ARGS], tmp_path))
+
+    # Confirm that both prefixes got built
+    db = duckdb.connect(f"{tmp_path}/duck.db")
+    tables = {row[0] for row in db.cursor().execute("show tables").fetchall()}
+    assert "dynamic__meta_version" in tables
+    assert "dynamic2__meta_version" in tables
+
+    # Clean 2nd table
+    with mock.patch.object(builtins, "input", lambda _: "y"):
+        cli.main(cli_args=duckdb_args(["clean", *STUDY_ARGS, "--option=prefix:dynamic2"], tmp_path))
+
+    db = duckdb.connect(f"{tmp_path}/duck.db")
+    tables = {row[0] for row in db.cursor().execute("show tables").fetchall()}
+    assert "dynamic__meta_version" in tables
+    assert "dynamic2__meta_version" not in tables
+
+
+def test_cli_export_with_dynamic_prefix(tmp_path):
+    cli.main(cli_args=duckdb_args(["build", *STUDY_ARGS, "--option=prefix:abc"], tmp_path))
+    cli.main(cli_args=duckdb_args(["export", *STUDY_ARGS, "--option=prefix:abc"], tmp_path))
+    assert set(os.listdir(f"{tmp_path}/export")) == {"abc"}
+    assert set(os.listdir(f"{tmp_path}/export/abc")) == {
+        "abc__counts.csv",
+        "abc__counts.parquet",
+        "abc__meta_version.csv",
+        "abc__meta_version.parquet",
+    }
+
+
+def test_cli_generate_sql_with_dynamic_prefix(tmp_path):
+    shutil.copytree(
+        pathlib.Path(__file__).parent / "test_data/study_dynamic_prefix",
+        tmp_path,
+        dirs_exist_ok=True,
+    )
+    study_args = [f"--study-dir={tmp_path}", "--target=dynamic"]
+    cli.main(cli_args=duckdb_args(["generate-sql", *study_args, "--option=prefix:abc"], tmp_path))
+    assert set(os.listdir(f"{tmp_path}/reference_sql")) == {"counts.sql", "meta.sql"}
+
+    with open(f"{tmp_path}/reference_sql/meta.sql", encoding="utf8") as f:
+        sql = f.readlines()
+    assert sql[-1] == "CREATE TABLE abc__meta_version AS SELECT 1 AS data_package_version;\n"

--- a/tests/testbed_utils.py
+++ b/tests/testbed_utils.py
@@ -245,5 +245,6 @@ class LocalTestbed:
         builder = cli.StudyRunner(config, data_path=str(self.path))
         builder.clean_and_build_study(
             Path(__file__).parent.parent / "cumulus_library/studies" / study,
+            options={},
         )
         return duckdb.connect(db_file)

--- a/tests/valueset/test_umls.py
+++ b/tests/valueset/test_umls.py
@@ -12,10 +12,11 @@ from cumulus_library.builders.valueset import umls, valueset_utils
     os.environ,
     clear=True,
 )
-def test_umls_lookup(mock_db_config_rxnorm, prefix):
+def test_umls_lookup(mock_db_config_rxnorm, prefix, tmp_path):
+    with open(f"{tmp_path}/manifest.toml", "w", encoding="utf8") as f:
+        f.write('study_prefix="test"')
     cursor = mock_db_config_rxnorm.db.cursor()
-    manifest = StudyManifest()
-    manifest._study_config = {"study_prefix": "test"}
+    manifest = StudyManifest(tmp_path)
     mock_db_config_rxnorm.options = {"umls_stewards": "medrt"}
     valueset_config = valueset_utils.ValuesetConfig(
         umls_stewards={"medrt": {"sab": "MED-RT", "search_terms": ["Opioid"]}}


### PR DESCRIPTION
This will allow a study to provide a Python file that accepts study options and generates an appropriate study prefix.

It's largely targeted at the data_metrics study, but might have application elsewhere.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`