### PR TITLE
Quote local parquet CTAS queries

### DIFF
--- a/cumulus_library/template_sql/ctas_from_parquet.sql.jinja
+++ b/cumulus_library/template_sql/ctas_from_parquet.sql.jinja
@@ -2,10 +2,12 @@
 {%- if db_type == 'athena' -%}
 CREATE EXTERNAL TABLE IF NOT EXISTS `{{ schema_name }}`.`{{ table_name }}` (
 {%-  elif db_type == 'duckdb' -%}
-CREATE TABLE IF NOT EXISTS {{ table_name }} AS SELECT  
+CREATE TABLE IF NOT EXISTS "{{ table_name }}" AS SELECT  
 {%- endif %}
 {%- for col in table_cols %}
-    {{ col }}{% if db_type == 'athena' %} {{ remote_table_cols_types[loop.index0] }}{%- endif -%}
+    {%- if db_type == 'athena' %} {{ col }} {{ remote_table_cols_types[loop.index0] }}
+    {%- elif db_type == 'duckdb' %} "{{ col }}"
+    {%- endif -%}
     {{- syntax.comma_delineate(loop) }}
 {%- endfor %}   
 {%- if db_type == 'athena' %}

--- a/tests/test_base_templates.py
+++ b/tests/test_base_templates.py
@@ -545,9 +545,7 @@ def test_ctas_empty_query_creation(expected, schema, table, cols, types):
     "expected,db_type,schema,table,cols,remote_types",
     [
         (
-            """CREATE EXTERNAL TABLE IF NOT EXISTS `test_athena`.`remote_table` (
-    a String,
-    b Int
+            """CREATE EXTERNAL TABLE IF NOT EXISTS `test_athena`.`remote_table` ( a String, b Int
 )
 STORED AS PARQUET
 LOCATION 's3://bucket/data/'
@@ -559,9 +557,7 @@ tblproperties ("parquet.compression"="SNAPPY");""",
             ["String", "Int"],
         ),
         (
-            """CREATE TABLE IF NOT EXISTS local_table AS SELECT
-    a,
-    b
+            """CREATE TABLE IF NOT EXISTS "local_table" AS SELECT "a", "b"
 FROM read_parquet('./tests/test_data/*.parquet')""",
             "duckdb",
             "test_duckdb",


### PR DESCRIPTION
This PR quote-escapes local parquet create table statements, in case those statements contain reserved sql words.

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`