### PR TITLE
Better handling for dedicated schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cumulus-library"
 requires-python = ">= 3.11"
 dependencies = [
     "cumulus-fhir-support >= 1.2",
-    "duckdb >= 1.1",
+    "duckdb >= 1.1.3",
     "Jinja2 > 3",
     "pandas <3, >=2.1.3",
     "psmpy <1, >=0.3.13",

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -35,6 +35,7 @@ from cumulus_library.template_sql import base_templates, sql_utils
         (None, None, None, False, "study_valid__etl_table", does_not_raise()),
         (None, None, None, False, "study_valid__nlp_table", does_not_raise()),
         (None, None, None, False, "study_valid__lib_table", does_not_raise()),
+        (None, None, None, False, "study_valid__lib", does_not_raise()),
         (None, "foo", "y", False, "foo_table", does_not_raise()),
         (None, "foo", "n", False, "foo_table", pytest.raises(SystemExit)),
         (True, None, "y", True, "study_valid__table", does_not_raise()),
@@ -121,7 +122,6 @@ def test_clean_dedicated_schema(mock_db_config):
             .execute("select distinct(table_name) from information_schema.tables")
             .fetchall()
         )
-        print(remaining_tables)
         assert (f"{enums.ProtectedTables.TRANSACTIONS.value}",) in remaining_tables
         assert ("table_1",) not in remaining_tables
         assert ("view_2",) not in remaining_tables

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -35,7 +35,6 @@ from cumulus_library.template_sql import base_templates, sql_utils
         (None, None, None, False, "study_valid__etl_table", does_not_raise()),
         (None, None, None, False, "study_valid__nlp_table", does_not_raise()),
         (None, None, None, False, "study_valid__lib_table", does_not_raise()),
-        (None, None, None, False, "study_valid__lib", does_not_raise()),
         (None, "foo", "y", False, "foo_table", does_not_raise()),
         (None, "foo", "n", False, "foo_table", pytest.raises(SystemExit)),
         (True, None, "y", True, "study_valid__table", does_not_raise()),
@@ -101,6 +100,31 @@ def test_clean_study(mock_db_config, verbose, prefix, confirm, stats, target, ra
                 assert ("study_valid__123",) in remaining_tables
             if not prefix:
                 assert ("study_valid__456",) not in remaining_tables
+
+
+def test_clean_dedicated_schema(mock_db_config):
+    with mock.patch.object(builtins, "input", lambda _: False):
+        mock_db_config.schema = "dedicated"
+        manifest = study_manifest.StudyManifest("./tests/test_data/study_dedicated_schema/")
+        mock_db_config.db.cursor().execute("CREATE SCHEMA dedicated")
+        builder.run_protected_table_builder(
+            config=mock_db_config,
+            manifest=manifest,
+        )
+        mock_db_config.db.cursor().execute("CREATE TABLE dedicated.table_1 (test int)")
+        mock_db_config.db.cursor().execute(
+            "CREATE VIEW dedicated.view_2 AS SELECT * FROM dedicated.table_1"
+        )
+        cleaner.clean_study(config=mock_db_config, manifest=manifest)
+        remaining_tables = (
+            mock_db_config.db.cursor()
+            .execute("select distinct(table_name) from information_schema.tables")
+            .fetchall()
+        )
+        print(remaining_tables)
+        assert (f"{enums.ProtectedTables.TRANSACTIONS.value}",) in remaining_tables
+        assert ("table_1",) not in remaining_tables
+        assert ("view_2",) not in remaining_tables
 
 
 def test_clean_throws_error_on_missing_params(mock_db_config):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -822,7 +822,7 @@ def test_dedicated_schema(tmp_path):
     )
     for table in [
         ("dedicated", "table_1"),
-        ("dedicated", "table_2"),
+        ("dedicated", "view_2"),
         ("dedicated", "table_raw_sql"),
         ("main", "core__condition"),
     ]:

--- a/tests/test_data/study_dedicated_schema/module2.py
+++ b/tests/test_data/study_dedicated_schema/module2.py
@@ -5,4 +5,7 @@ class ModuleTwoRunner(cumulus_library.BaseTableBuilder):
     display_text = "module2"
 
     def prepare_queries(self, *args, **kwargs):
-        self.queries.append("CREATE VIEW IF NOT EXISTS study_dedicated_schema__view_2 (test int);")
+        self.queries.append(
+            """CREATE VIEW IF NOT EXISTS study_dedicated_schema__view_2 AS 
+            SELECT * FROM dedicated.table_1;"""
+        )

--- a/tests/test_data/study_dedicated_schema/module2.py
+++ b/tests/test_data/study_dedicated_schema/module2.py
@@ -5,6 +5,4 @@ class ModuleTwoRunner(cumulus_library.BaseTableBuilder):
     display_text = "module2"
 
     def prepare_queries(self, *args, **kwargs):
-        self.queries.append(
-            "CREATE TABLE IF NOT EXISTS study_dedicated_schema__table_2 (test int);"
-        )
+        self.queries.append("CREATE VIEW IF NOT EXISTS study_dedicated_schema__view_2 (test int);")


### PR DESCRIPTION
- Updates the version of duckDB to 1.1.3, which fixes some edge cases in parquet handling that the UMLS study was hitting
- Adds better handling for differences between different DROP statement quote handling in athena vs duckdb

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`