### PR TITLE
fix: avoid memory bottlenecks when flattening tables

### DIFF
--- a/cumulus_library/studies/core/reference_sql/builder_condition.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_condition.sql
@@ -10,13 +10,19 @@ CREATE TABLE core__condition_dn_category AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."category"
-        FROM
-            condition AS t,
-            UNNEST(t."category") AS r ("category")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."category", 1) AS row,
+                UNNEST(t."category") AS "category" -- must unnest in SELECT here
+            FROM condition AS t
+        )
+        SELECT
+            id,
+            row,
+            "category"
+        FROM data_and_row_num
     ),
 
     system_category_0 AS (

--- a/cumulus_library/studies/core/reference_sql/builder_diagnosticreport.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_diagnosticreport.sql
@@ -10,13 +10,19 @@ CREATE TABLE core__diagnosticreport_dn_category AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."category"
-        FROM
-            diagnosticreport AS t,
-            UNNEST(t."category") AS r ("category")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."category", 1) AS row,
+                UNNEST(t."category") AS "category" -- must unnest in SELECT here
+            FROM diagnosticreport AS t
+        )
+        SELECT
+            id,
+            row,
+            "category"
+        FROM data_and_row_num
     ),
 
     system_category_0 AS (
@@ -166,13 +172,19 @@ WITH temp_diagnosticreport AS (
 ),
 
 temp_result AS (
-    SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."reference"
-        FROM
-            diagnosticreport AS t,
-            UNNEST(t."result") AS parent (r)
+    WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."result", 1) AS row,
+                UNNEST(t."result") AS data -- must unnest in SELECT here
+            FROM diagnosticreport AS t
+        )
+        SELECT
+            id,
+            row,
+            data."reference"
+        FROM data_and_row_num
 )
 
 SELECT

--- a/cumulus_library/studies/core/reference_sql/builder_documentreference.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_documentreference.sql
@@ -49,13 +49,19 @@ CREATE TABLE core__documentreference_dn_category AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."category"
-        FROM
-            documentreference AS t,
-            UNNEST(t."category") AS r ("category")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."category", 1) AS row,
+                UNNEST(t."category") AS "category" -- must unnest in SELECT here
+            FROM documentreference AS t
+        )
+        SELECT
+            id,
+            row,
+            "category"
+        FROM data_and_row_num
     ),
 
     system_category_0 AS (

--- a/cumulus_library/studies/core/reference_sql/builder_encounter.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_encounter.sql
@@ -10,13 +10,19 @@ CREATE TABLE core__encounter_dn_type AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."type"
-        FROM
-            encounter AS t,
-            UNNEST(t."type") AS r ("type")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."type", 1) AS row,
+                UNNEST(t."type") AS "type" -- must unnest in SELECT here
+            FROM encounter AS t
+        )
+        SELECT
+            id,
+            row,
+            "type"
+        FROM data_and_row_num
     ),
 
     system_type_0 AS (
@@ -317,13 +323,19 @@ CREATE TABLE core__encounter_dn_reasoncode AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."reasoncode"
-        FROM
-            encounter AS t,
-            UNNEST(t."reasoncode") AS r ("reasoncode")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."reasoncode", 1) AS row,
+                UNNEST(t."reasoncode") AS "reasoncode" -- must unnest in SELECT here
+            FROM encounter AS t
+        )
+        SELECT
+            id,
+            row,
+            "reasoncode"
+        FROM data_and_row_num
     ),
 
     system_reasoncode_0 AS (

--- a/cumulus_library/studies/core/reference_sql/builder_medicationrequest.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_medicationrequest.sql
@@ -73,13 +73,19 @@ CREATE TABLE core__medicationrequest_dn_category AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."category"
-        FROM
-            medicationrequest AS t,
-            UNNEST(t."category") AS r ("category")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."category", 1) AS row,
+                UNNEST(t."category") AS "category" -- must unnest in SELECT here
+            FROM medicationrequest AS t
+        )
+        SELECT
+            id,
+            row,
+            "category"
+        FROM data_and_row_num
     ),
 
     system_category_0 AS (

--- a/cumulus_library/studies/core/reference_sql/builder_observation.sql
+++ b/cumulus_library/studies/core/reference_sql/builder_observation.sql
@@ -10,13 +10,19 @@ CREATE TABLE core__observation_dn_category AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."category"
-        FROM
-            observation AS t,
-            UNNEST(t."category") AS r ("category")
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."category", 1) AS row,
+                UNNEST(t."category") AS "category" -- must unnest in SELECT here
+            FROM observation AS t
+        )
+        SELECT
+            id,
+            row,
+            "category"
+        FROM data_and_row_num
     ),
 
     system_category_0 AS (
@@ -99,13 +105,19 @@ CREATE TABLE core__observation_component_code AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."code"
-        FROM
-            observation AS t,
-            UNNEST(t."component") AS parent (r)
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."component", 1) AS row,
+                UNNEST(t."component") AS data -- must unnest in SELECT here
+            FROM observation AS t
+        )
+        SELECT
+            id,
+            row,
+            data."code"
+        FROM data_and_row_num
     ),
 
     system_code_0 AS (
@@ -149,13 +161,19 @@ CREATE TABLE core__observation_component_dataabsentreason AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."dataabsentreason"
-        FROM
-            observation AS t,
-            UNNEST(t."component") AS parent (r)
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."component", 1) AS row,
+                UNNEST(t."component") AS data -- must unnest in SELECT here
+            FROM observation AS t
+        )
+        SELECT
+            id,
+            row,
+            data."dataabsentreason"
+        FROM data_and_row_num
     ),
 
     system_dataabsentreason_0 AS (
@@ -199,13 +217,19 @@ CREATE TABLE core__observation_component_interpretation AS (
     WITH
 
     flattened_rows AS (
-        SELECT DISTINCT
-            t.id AS id,
-            ROW_NUMBER() OVER (PARTITION BY id) AS row,
-            r."interpretation"
-        FROM
-            observation AS t,
-            UNNEST(t."component") AS parent (r)
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.id AS id,
+                generate_subscripts(t."component", 1) AS row,
+                UNNEST(t."component") AS data -- must unnest in SELECT here
+            FROM observation AS t
+        )
+        SELECT
+            id,
+            row,
+            data."interpretation"
+        FROM data_and_row_num
     ),
 
     child_flattened_rows AS (

--- a/cumulus_library/template_sql/base_templates.py
+++ b/cumulus_library/template_sql/base_templates.py
@@ -42,7 +42,8 @@ def get_template(filename_stem: str, path: pathlib.Path | None = None, **kwargs:
             macro_paths.append(path)
         loader = jinja2.FileSystemLoader(macro_paths)
         env = jinja2.Environment(loader=loader).from_string(template)  # noqa: S701
-        return env.render(**kwargs, db_type=db_config.db_type)
+        env.globals["db_type"] = db_config.db_type
+        return env.render(**kwargs)
 
 
 # All remaining functions are context-specific calls aimed at providing

--- a/cumulus_library/template_sql/shared_macros/unnest_utils.jinja
+++ b/cumulus_library/template_sql/shared_macros/unnest_utils.jinja
@@ -1,16 +1,42 @@
 {# Flattens an array into multiple rows, with ordinality #}
 
 {%- macro flatten(table, field, parent_field = null, source_id = 'id', extra_fields = null) -%}
-        SELECT DISTINCT
+{%- if db_type == 'duckdb' %}
+        {#-
+            DuckDB does not yet have WITH ORDINALITY, which is a bit simpler than this branch.
+            TODO: remove this branch once the following PR lands:
+                https://github.com/duckdb/duckdb/pull/9014
+            But first make sure that it does not run out of memory on lots (>=5GB?) of data.
+        -#}
+        WITH
+        data_and_row_num AS (
+            SELECT
+                t.{{ source_id }} AS id,
+                {%- if parent_field %}
+                generate_subscripts(t."{{ parent_field }}", 1) AS row,
+                UNNEST(t."{{ parent_field }}") AS data -- must unnest in SELECT here
+                {%- else %}
+                generate_subscripts(t."{{ field }}", 1) AS row,
+                UNNEST(t."{{ field }}") AS "{{ field }}" -- must unnest in SELECT here
+                {%- endif %}
+            FROM {{ table }} AS t
+        )
+        SELECT
+            id,
+            row,
+            {%- if parent_field %}
+            {% for extra_field in (extra_fields or []) -%}
+            data."{{ extra_field[0] }}" AS "{{ extra_field[1] }}",
+            {% endfor -%}
+            data."{{ field }}"
+            {%- else %}
+            "{{ field }}"
+            {%- endif %}
+        FROM data_and_row_num
+{%- else -%}
+        SELECT
             t.{{ source_id }} AS id,
-            {#-
-                TODO: switch to using WITH ORDINALITY once this PR lands:
-                    https://github.com/duckdb/duckdb/pull/9014
-                Because ordering with this approach is not 100% guaranteed,
-                even though in practice, a SQL engine would be real rude to
-                give us back unnested rows in an arbitrary order.
-            #}
-            ROW_NUMBER() OVER (PARTITION BY {{ source_id }}) AS row,
+            row,
             {% for extra_field in (extra_fields or []) -%}
             r."{{ extra_field[0] }}" AS "{{ extra_field[1] }}",
             {% endfor -%}
@@ -18,8 +44,9 @@
         FROM
             {{ table }} AS t,
             {%- if parent_field %}
-            UNNEST(t."{{ parent_field }}") AS parent (r)
+            UNNEST(t."{{ parent_field }}") WITH ORDINALITY AS parent (r, row)
             {%- else %}
-            UNNEST(t."{{ field }}") AS r ("{{ field }}")
+            UNNEST(t."{{ field }}") WITH ORDINALITY AS r ("{{ field }}", row)
             {%- endif %}
+{%- endif %}
 {%- endmacro -%}


### PR DESCRIPTION
With DuckDB, row_number() over an unnested field seems to blow up the memory usage, rather than spilling over onto the disk.

So instead, this commit switches the flatten() macro into two branches:
- DuckDB branch: switch to generate_subscripts() which Athena does not have. This is memory-performant.
- Fallback/Athena branch: switch to WITH ORDINALITY which DuckDB does not have. This is simpler code, and DuckDB will hopefully one day support WITH ORDINALITY.

This also fixes a bug where the order of rows was not guaranteed by the SQL engine. This seemed to only affect DuckDB. Now both branches guarantee proper ordering.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`