### PR TITLE
better handling of non-integer versions

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -17,4 +17,4 @@ from cumulus_library.template_sql.base_templates import get_template
 # is all code level. See template_sql for more information.
 
 __all__ = ["BaseTableBuilder", "CountsBuilder", "StudyConfig", "StudyManifest", "get_template"]
-__version__ = "4.3.0"
+__version__ = "4.3.1"

--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -28,7 +28,7 @@ def upload_data(
         json={
             "study": study,
             "data_package": data_package,
-            "data_package_version": version,
+            "data_package_version": int(float(version)),
             "filename": f"{args['user']}_{file_name}",
         },
         auth=(args["user"], args["id"]),

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -459,7 +459,7 @@ def do_upload(
                         {
                             "study": "upload",
                             "data_package": "upload__meta_version",
-                            "data_package_version": version,
+                            "data_package_version": int(float(version)),
                             "filename": f"{user}_upload__meta_version.meta.parquet",
                         }
                     )
@@ -474,7 +474,7 @@ def do_upload(
                         {
                             "study": "upload",
                             "data_package": "upload__count_synthea_patient",
-                            "data_package_version": version,
+                            "data_package_version": int(float(version)),
                             "filename": f"{user}_upload__count_synthea_patient.cube.parquet",
                         }
                     ),


### PR DESCRIPTION
This addresses #306 by casting meta version numbers being of a non-integer numeric type by casting them through floats, then ints, to get them into the expected format for the aggregator.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`