### PR TITLE
Suggest cases where a non-initialized DB may cause errors

### DIFF
--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -459,7 +459,14 @@ def _query_error(
     rich.print(query_and_filename[0], file=sys.stderr)
     rich.print("--------", file=sys.stderr)
     log_utils.log_transaction(config=config, manifest=manifest, status=enums.LogStatuses.ERROR)
-    sys.exit(exit_message)
+    rich.print(exit_message)
+
+    if any(init_error in exit_message for init_error in config.db.init_errors()):
+        rich.print(
+            "Have you initialized your database?\n"
+            "https://docs.smarthealthit.org/cumulus/etl/setup/initialization.html"
+        )
+    sys.exit()
 
 
 def _execute_build_queries(

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -34,6 +34,9 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         self.schema_name = schema_name
         self.connection = None
 
+    def init_errors(self):  # pragma: no cover
+        return ["COLUMN_NOT_FOUND", "TABLE_NOT_FOUND"]
+
     def connect(self):
         # the profile may not be required, provided the above three AWS env vars
         # are set. If both are present, the env vars take precedence

--- a/cumulus_library/databases/base.py
+++ b/cumulus_library/databases/base.py
@@ -121,6 +121,10 @@ class DatabaseBackend(abc.ABC):
         self.db_type = None
 
     @abc.abstractmethod
+    def init_errors(self) -> list:
+        """A list of errors indicating a database may not have been initialized with the ETL"""
+
+    @abc.abstractmethod
     def connect(self):
         """Initiates connection configuration of the database"""
 

--- a/cumulus_library/databases/duckdb.py
+++ b/cumulus_library/databases/duckdb.py
@@ -29,6 +29,9 @@ class DuckDatabaseBackend(base.DatabaseBackend):
         self.db_file = db_file
         self.connection = None
 
+    def init_errors(self):
+        return ["Binder Error", "Catalog Error"]
+
     def connect(self):
         """Connects to the local duckdb database"""
         # As of the 1.0 duckdb release, local scopes, where schema names can be provided

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,6 +1,7 @@
 import builtins
 import contextlib
 import datetime
+import io
 import pathlib
 import shutil
 import zipfile
@@ -434,6 +435,18 @@ def test_import_study(tmp_path, mock_db_config):
         importer.import_archive(
             config=mock_db_config, archive_path=tmp_path / "archive/no_dunder.zip"
         )
+
+
+def test_builder_init_error(mock_db_config):
+    manifest = study_manifest.StudyManifest(pathlib.Path(__file__).parent / "test_data/study_valid")
+    builder.run_protected_table_builder(config=mock_db_config, manifest=manifest)
+    console_output = io.StringIO()
+    with pytest.raises(SystemExit):
+        with contextlib.redirect_stdout(console_output):
+            builder._query_error(
+                mock_db_config, manifest, ["mock query", "mock_file.txt"], "Catalog Error"
+            )
+    assert "https://docs.smarthealthit.org/" in console_output.getvalue()
 
 
 def do_upload(


### PR DESCRIPTION
In cases where an error :might: be related to a database not being initialized by the etl, we'll point out the documentation. Addresses #354 

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`