### PR TITLE
Added network arg to upload command

### DIFF
--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -23,6 +23,9 @@ def upload_data(
     c = rich.get_console()
     progress_bar.update(file_upload_progress, description=f"Uploading {study}/{file_name}")
     data_package = file_name.split(".")[0]
+    url = args["url"]
+    if args["network"]:
+        url += args["network"]
     prefetch_res = requests.post(
         args["url"],
         json={

--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -25,7 +25,8 @@ def upload_data(
     data_package = file_name.split(".")[0]
     url = args["url"]
     if args["network"]:
-        url += args["network"]
+        # coercion to handle optional presence of trailing slash in the url
+        url = url.rstrip("/") + "/" + args["network"]
     prefetch_res = requests.post(
         args["url"],
         json={

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -418,6 +418,7 @@ def main(cli_args=None):
         ("umls_key", "UMLS_API_KEY"),
         ("url", "CUMULUS_AGGREGATOR_URL"),
         ("user", "CUMULUS_AGGREGATOR_USER"),
+        ("network", "CUMULUS_AGGREGATOR_NETWORK"),
         ("work_group", "CUMULUS_LIBRARY_WORKGROUP"),
     )
     read_env_vars = []

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -274,6 +274,12 @@ following order of preference is used to select credentials:
         ),
         default="https://aggregator.smartcumulus.org/",
     )
+    upload.add_argument(
+        "--network",
+        help=(
+            "Network name. Reach out to your aggregator administrator for the appropriate value."
+        ),
+    )
     upload.add_argument("--user", help="Cumulus user. Default is value of CUMULUS_AGGREGATOR_USER")
 
     # Generate a study's template-driven sql

--- a/docs/sharing-data.md
+++ b/docs/sharing-data.md
@@ -56,6 +56,7 @@ We recommend configuring the following environment variables for using this scri
 
 - `CUMULUS_AGGREGATOR_USER`
 - `CUMULUS_AGGREGATOR_ID`
+- `CUMULUS_AGGREGATOR_NETWORK`
 
 The administrator of your Aggregator instance can help you with generating the values for
 these variables; reach out to them for more details.


### PR DESCRIPTION
This allows a user to specify a network as part of an aggregator upload target.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`