### PR TITLE
duckdb: don't preserve order, which should help with memory

### DIFF
--- a/cumulus_library/databases/duckdb.py
+++ b/cumulus_library/databases/duckdb.py
@@ -41,6 +41,9 @@ class DuckDatabaseBackend(base.DatabaseBackend):
         # Aliasing Athena's as_pandas to duckDB's df cast
         duckdb.DuckDBPyConnection.as_pandas = duckdb.DuckDBPyConnection.df
 
+        # Ignore order of NDJSON that we load in. It saves memory and order doesn't matter for us.
+        self.connection.execute("SET preserve_insertion_order = false;")
+
         # Paper over some syntax differences between Athena and DuckDB
         self.connection.create_function(
             # DuckDB's version is array_to_string -- seems there is no standard here.
@@ -144,9 +147,6 @@ class DuckDatabaseBackend(base.DatabaseBackend):
                 return datetime.datetime(int(pieces[0]), 1, 1)
             else:
                 return datetime.datetime(int(pieces[0]), int(pieces[1]), 1)
-
-        # Until we depend on Python 3.11+, manually handle Z
-        value = value.replace("Z", "+00:00")
 
         # TODO: return timezone-aware datetimes, like Athena does
         #       (this currently generates naive datetimes, in UTC local time)

--- a/cumulus_library/studies/core/core_templates/core_utils.jinja
+++ b/cumulus_library/studies/core/core_templates/core_utils.jinja
@@ -64,20 +64,20 @@ targets is an array expecting a data type of the following:
         {#- depth one nested column-#}
         {%- if col is not string and col|length ==3%}
         {%- if schema[table][col[0]][col[1]] %}
-        date(from_iso8601_timestamp({{ alias }}.{{ col[0] }}.{{ col[1] }})) AS {{ col[2] }}
+        cast(from_iso8601_timestamp({{ alias }}.{{ col[0] }}.{{ col[1] }}) AS date) AS {{ col[2] }}
         {%- else %}
         cast(NULL AS date) AS {{ col[1] }}
         {% endif %}
         {#- depth two nested column -#}
         {%- elif col is not string and col|length ==4%}
         {%- if schema[table][col[0]][col[1]][col[2]] %}
-        date(from_iso8601_timestamp({{ alias }}.{{ col[0] }}.{{ col[1] }}.{{ col[2] }})) AS {{col[3]}}
+        cast(from_iso8601_timestamp({{ alias }}.{{ col[0] }}.{{ col[1] }}.{{ col[2] }}) AS date) AS {{col[3]}}
         {%- else %}
         cast(NULL AS date) AS {{ col[3] }}
         {%- endif %}
         {#- SQL primitive column column-#}
         {%- elif schema[table][col] %}
-        date(from_iso8601_timestamp({{ alias }}.{{ col }})) AS {{ col }}
+        cast(from_iso8601_timestamp({{ alias }}.{{ col }}) AS date) AS {{ col }}
         {%- else %}
         cast(NULL AS date) AS {{ col }}
         {%- endif %}    
@@ -96,7 +96,7 @@ targets is assumed to be a list of tuples of one of the following format:
         {%- for col in targets %}
         {%- if col is not string and col|length ==4%}
         {%- if schema[table][col[0]][col[1]] %}
-        date_trunc('{{ col[3] }}', date(from_iso8601_timestamp({{ alias }}."{{ col[0] }}"."{{ col[1] }}")))
+        date_trunc('{{ col[3] }}', cast(from_iso8601_timestamp({{ alias }}."{{ col[0] }}"."{{ col[1] }}") AS date))
             AS {{ col[2] }}
         {%- else %}
         cast(NULL AS date) AS {{col[2]}}
@@ -104,14 +104,14 @@ targets is assumed to be a list of tuples of one of the following format:
         {#- depth two nested column -#}
         {%- elif col is not string and col|length ==5%}
         {%- if schema[table][col[0]][col[1]][col[2]] %}
-        date_trunc('{{ col[4] }}', date(from_iso8601_timestamp({{ alias }}."{{ col[0] }}"."{{ col[1] }}"."{{col[2]}}")))
+        date_trunc('{{ col[4] }}', cast(from_iso8601_timestamp({{ alias }}."{{ col[0] }}"."{{ col[1] }}"."{{col[2]}}") AS date))
             AS {{ col[3] }}
         {%- else %}
         cast(NULL AS date) AS {{col[3]}}
         {%- endif %}
         {#- SQL primitive column column-#}
         {%- elif schema[table][col[0]] %}
-        date_trunc('{{ col[1] }}', date(from_iso8601_timestamp({{ alias }}."{{ col[0] }}")))
+        date_trunc('{{ col[1] }}', cast(from_iso8601_timestamp({{ alias }}."{{ col[0] }}") AS date))
             AS {{ col[0] }}_{{ col[1] }}
         {%- else %}
         cast(NULL AS date) AS {{ col[0] }}_{{ col[1] }}

--- a/cumulus_library/studies/core/core_templates/encounter.sql.jinja
+++ b/cumulus_library/studies/core/core_templates/encounter.sql.jinja
@@ -121,7 +121,7 @@ SELECT DISTINCT
     e.dischargeDisposition_code,
     e.dischargeDisposition_system,
     e.dischargeDisposition_display,
-    date_diff('year', date(p.birthdate), e.period_start_day) AS age_at_visit,
+    date_diff('year', cast(p.birthdate AS date), e.period_start_day) AS age_at_visit,
     p.gender,
     p.race_display,
     p.ethnicity_display,


### PR DESCRIPTION
Also, drop & avoid some date parsing python code.

These changes were not the result of careful profiling, but just educated advice.
- the not-preserving-order change is just a recommendation from the DuckDB docs
- the manually handling of `Z` timezones is an obvious but tiny improvement
- for `date` -> `cast(x as date)`, I'm just assuming that DuckDB not having to call out to a python udf is going to be faster than their built-in cast. (I'm still keeping the udf around, so we don't need to adjust old studies)

### Checklist
- [ ] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [ ] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml`