### PR TITLE
Added obsservation component code detection

### DIFF
--- a/cumulus_library/studies/discovery/code_definitions.py
+++ b/cumulus_library/studies/discovery/code_definitions.py
@@ -115,6 +115,11 @@ code_list = [
     },
     {
         "table_name": "observation",
+        "column_hierarchy": [("component", list), ("code", dict), ("coding", dict)],
+        "expected": {"code": sql_utils.CODEABLE_CONCEPT},
+    },
+    {
+        "table_name": "observation",
         "column_hierarchy": [("interpretation", list), ("coding", list)],
     },
     {

--- a/cumulus_library/studies/discovery/discovery_templates/code_system_pairs.sql.jinja
+++ b/cumulus_library/studies/discovery/discovery_templates/code_system_pairs.sql.jinja
@@ -32,6 +32,9 @@ UNNEST({{ table.column_hierarchy[0][0] }}) AS table_1 (col_1)
 {%- for index in range(1,table.column_hierarchy|length) %}
 {%- if table.column_hierarchy[index][1].__name__ == 'list' -%},
 UNNEST(col_{{ index }}.{{ table.column_hierarchy[index][0].split('.')[0] }}) as table_{{ index +1 }} (col_{{ index +1 }})
+{#- Does the last element in the list contain a bare coding? -#}
+{%- elif table.column_hierarchy[index][1].__name__ == 'dict' and index +1 == table.column_hierarchy|length -%},
+UNNEST(col_{{ index }}.{{ table.column_hierarchy[index][0].split('.')[0] }}.coding) as table_{{ index +1 }} (col_{{ index +1 }})
 {%- endif %}
 {%- endfor %}
 {%- else %}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -103,6 +103,18 @@ FROM bare
 
 UNION ALL
 
+SELECT DISTINCT
+    'bare_nested_coding' AS table_name,
+    'dcol.code' AS column_name,
+    table_2.col_2.code,
+    table_2.col_2.display,
+    table_2.col_2.system
+FROM bare_nested_coding,
+UNNEST(dcol) AS table_1 (col_1),
+UNNEST(col_1.code.coding) as table_2 (col_2)
+
+UNION ALL
+
 SELECT *
 FROM (
     VALUES (
@@ -133,6 +145,11 @@ FROM (
             {
                 "table_name": "bare",
                 "column_hierarchy": [("bcol", dict), ("coding", dict)],
+                "has_data": True,
+            },
+            {
+                "table_name": "bare_nested_coding",
+                "column_hierarchy": [("dcol", list), ("code", dict), ("coding", dict)],
                 "has_data": True,
             },
             {


### PR DESCRIPTION
This addresses #361 by adding a new field, `observation.component`, to discovery, and a check for 'do we have a coding that's not in an array'.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`