### PR TITLE
Ignore customer specific Epic OID

### DIFF
--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -17,4 +17,4 @@ from cumulus_library.template_sql.base_templates import get_template
 # is all code level. See template_sql for more information.
 
 __all__ = ["BaseTableBuilder", "CountsBuilder", "StudyConfig", "StudyManifest", "get_template"]
-__version__ = "4.5.0"
+__version__ = "4.5.1"

--- a/cumulus_library/studies/discovery/discovery_templates/code_system_pairs.sql.jinja
+++ b/cumulus_library/studies/discovery/discovery_templates/code_system_pairs.sql.jinja
@@ -36,6 +36,7 @@ UNNEST(col_{{ index }}.{{ table.column_hierarchy[index][0].split('.')[0] }}) as 
 {%- elif table.column_hierarchy[index][1].__name__ == 'dict' and index +1 == table.column_hierarchy|length -%},
 UNNEST(col_{{ index }}.{{ table.column_hierarchy[index][0].split('.')[0] }}.coding) as table_{{ index +1 }} (col_{{ index +1 }})
 {%- endif %}
+WHERE REGEXP_LIKE({{ get_source_col(table.column_hierarchy) }}.code, '^((?!1.2.840.1.114350).)*$')
 {%- endfor %}
 {%- else %}
 SELECT *


### PR DESCRIPTION
This forces `discovery` to exclude all the potential PHI data in the customer specific OID EPIC uses for individual deployments.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`