### PR TITLE
Handle empty target arguments

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -15,6 +15,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
 
+    - name: Set version from tag
+      run: |
+        VERSION=$(echo $GITHUB_REF_NAME | sed 's/^v//')
+        sed -i "s/1\!0\.0\.0/$VERSION/w changes.txt" cumulus_library/__init__.py
+        [ -s changes.txt ] || exit 1  # validate that we successfully set the version
+
     - name: Build
       run: python -m build
 

--- a/cumulus_library/__init__.py
+++ b/cumulus_library/__init__.py
@@ -17,4 +17,4 @@ from cumulus_library.template_sql.base_templates import get_template
 # is all code level. See template_sql for more information.
 
 __all__ = ["BaseTableBuilder", "CountsBuilder", "StudyConfig", "StudyManifest", "get_template"]
-__version__ = "4.5.0"
+__version__ = "1!0.0.0"

--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -70,15 +70,13 @@ def upload_files(args: dict):
     """Wrapper to prep files & console output"""
     if args["data_path"] is None:
         sys.exit("No data directory provided - please provide a path to your study export folder.")
-    if not args["target"]:
-        sys.exit("Please specify one or more studies to upload using '--target [NAME]'")
     file_paths = list(args["data_path"].glob("**/*.parquet"))
     filtered_paths = []
     if not args["user"] or not args["id"]:
         sys.exit("user/id not provided, please pass --user and --id")
     for target in args["target"]:
         for path in file_paths:
-            if any(path.parent.name == target and path.name.startswith(f"{target}__")):
+            if path.parent.name == target and path.name.startswith(f"{target}__"):
                 filtered_paths.append(path)
         file_paths = filtered_paths
         if len(file_paths) == 0:

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -288,7 +288,7 @@ def get_studies_by_manifest_path(path: pathlib.Path) -> dict[str, pathlib.Path]:
 def run_cli(args: dict):
     """Controls which library tasks are run based on CLI arguments"""
     console = rich.get_console()
-    if args["action"] != "import" and args.get("target") is None:
+    if args["action"] != "import" and not args.get("target"):
         sys.exit("Please specify one or more studies with `-t [study_name]`.")
     if args["action"] == "upload":
         try:

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -288,6 +288,8 @@ def get_studies_by_manifest_path(path: pathlib.Path) -> dict[str, pathlib.Path]:
 def run_cli(args: dict):
     """Controls which library tasks are run based on CLI arguments"""
     console = rich.get_console()
+    if args["action"] != "import" and args.get("target") is None:
+        sys.exit("Please specify one or more studies with `-t [study_name]`.")
     if args["action"] == "upload":
         try:
             uploader.upload_files(args)

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -71,12 +71,6 @@ class StudyRunner:
         :param options: The dictionary of study-specific options
         :keyword prefix: If True, does a search by string prefix in place of study name
         """
-        if targets is None:
-            sys.exit(
-                "Explicit targets for cleaning not provided. "
-                "Provide one or more explicit study prefixes to remove."
-            )
-
         for target in targets:
             if prefix:
                 manifest = study_manifest.StudyManifest(options=options)

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -287,7 +287,7 @@ def run_cli(args: dict):
     if args["action"] == "upload":
         try:
             uploader.upload_files(args)
-        except requests.RequestException as e:
+        except requests.RequestException as e:  # pragma: no cover
             rich.print(str(e))
             sys.exit()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">= 3.11"
 dependencies = [
     "awswrangler >= 3.11, < 4",
     "cumulus-fhir-support >= 1.3.1",  # 1.3.1 fixes a "load all rows into memory" bug
-    "duckdb >= 1.1.3",
+    "duckdb >= 1.1.3, <1.3", # 1.3 has an issue that is breaking our unit tests
     "Jinja2 > 3",
     "pandas <3, >=2.1.3",
     "psmpy <1, >=0.3.13",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,7 @@ def test_cli_early_exit(args):
             "study_python_valid__count_table",
         ),
         (["build", "-t", "wrong"], pytest.raises(SystemExit), None),
+        (["build"], pytest.raises(SystemExit), None),
         (
             [
                 "build",
@@ -749,10 +750,14 @@ def test_cli_umls_parsing(mock_config, mode, tmp_path):
     with pytest.raises(ZeroDivisionError):
         match mode:
             case "cli":
-                cli.main(cli_args=duckdb_args(["build", "--umls-key=MY-KEY"], tmp_path))
+                cli.main(
+                    cli_args=duckdb_args(
+                        ["build", "--umls-key=MY-KEY", "-t", "study_valid"], tmp_path
+                    )
+                )
             case "env":
                 with mock.patch.dict(os.environ, {"UMLS_API_KEY": "MY-KEY"}):
-                    cli.main(cli_args=duckdb_args(["build"], tmp_path))
+                    cli.main(cli_args=duckdb_args(["build", "-t", "study_valid"], tmp_path))
 
     assert mock_config.call_args[1]["umls_key"] == "MY-KEY"
 


### PR DESCRIPTION
This addresses #372 by more gracefully exiting when a --target argument is expected.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`