### PR TITLE
Exempt discovery from meta_date requirement

### DIFF
--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -81,12 +81,13 @@ def upload_files(args: dict):
         file_paths = filtered_paths
         if len(file_paths) == 0:
             sys.exit("No files found for upload. Is your data path/target specified correctly?")
-        if not any(f"{target}__meta_date.meta.parquet" == x.name for x in file_paths):
-            sys.exit(
-                f"Study '{target}' does not contain a {target}__meta_date table.\n"
-                "See the documentation for more information about this required table.\n"
-                "https://docs.smarthealthit.org/cumulus/library/creating-studies.html#metadata-tables"
-            )
+        if target != "discovery":
+            if not any(f"{target}__meta_date.meta.parquet" == x.name for x in file_paths):
+                sys.exit(
+                    f"Study '{target}' does not contain a {target}__meta_date table.\n"
+                    "See the documentation for more information about this required table.\n"
+                    "https://docs.smarthealthit.org/cumulus/library/creating-studies.html#metadata-tables"
+                )
         try:
             meta_version = next(
                 filter(lambda x: str(x).endswith("__meta_version.meta.parquet"), file_paths)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -461,6 +461,7 @@ def do_upload(
     version: str = "12345.0",
     call_count: int = 2,
     data_path: pathlib.Path | None = pathlib.Path.cwd() / "tests/test_data/upload/",
+    study: str = "upload",
 ):
     url = "https://upload.url.test/"
     if network:
@@ -475,10 +476,10 @@ def do_upload(
                 match=[
                     matchers.json_params_matcher(
                         {
-                            "study": "upload",
-                            "data_package": "upload__meta_version",
+                            "study": study,
+                            "data_package": f"{study}__meta_version",
                             "data_package_version": int(float(version)),
-                            "filename": f"{user}_upload__meta_version.meta.parquet",
+                            "filename": f"{user}_{study}__meta_version.meta.parquet",
                         }
                     )
                 ],
@@ -490,10 +491,10 @@ def do_upload(
                 match=[
                     matchers.json_params_matcher(
                         {
-                            "study": "upload",
-                            "data_package": "upload__meta_date",
+                            "study": study,
+                            "data_package": f"{study}__meta_date",
                             "data_package_version": int(float(version)),
-                            "filename": f"{user}_upload__meta_date.meta.parquet",
+                            "filename": f"{user}_{study}__meta_date.meta.parquet",
                         }
                     )
                 ],
@@ -505,10 +506,10 @@ def do_upload(
                 match=[
                     matchers.json_params_matcher(
                         {
-                            "study": "upload",
-                            "data_package": "upload__count_synthea_patient",
+                            "study": study,
+                            "data_package": f"{study}__count_synthea_patient",
                             "data_package_version": int(float(version)),
-                            "filename": f"{user}_upload__count_synthea_patient.cube.parquet",
+                            "filename": f"{user}_{study}__count_synthea_patient.cube.parquet",
                         }
                     ),
                 ],
@@ -518,7 +519,7 @@ def do_upload(
             "data_path": data_path,
             "id": id_token,
             "preview": preview,
-            "target": ["upload"],
+            "target": [study],
             "network": network,
             "url": "https://upload.url.test/",
             "user": user,
@@ -604,6 +605,15 @@ def test_upload_data_no_meta_date(tmp_path):
         dest.mkdir()
         shutil.copy(src, dest)
         do_upload(data_path=dest, version="0", call_count=1)
+
+
+@responses.activate
+def test_upload_discovery(tmp_path):
+    src = pathlib.Path.cwd() / "tests/test_data/upload/upload__count_synthea_patient.cube.parquet"
+    dest = pathlib.Path(tmp_path) / "discovery/discovery__count_synthea_patient.cube.parquet"
+    dest.parent.mkdir()
+    shutil.copyfile(src, dest)
+    do_upload(data_path=dest.parent, version="0", call_count=1, study="discovery")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Since discovery is kind of a special case, we'll just skip the requirement for a `meta_date` table check on upload.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`