### PR TITLE
Added catalog to module allowlist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,4 @@
 - [ ] If you've updated the `core` or `discovery` tables, regenerate the reference sql
 - [ ] Consider if tests should be added
 - [ ] Update template repo if there are changes to study configuration in `manifest.toml`
+- [ ] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json

--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -8,6 +8,7 @@
         "cumulus_library_opioid",
         "cumulus_library_rxnorm",
         "cumulus_library_suicidality_los",
-        "cumulus_library_umls"
+        "cumulus_library_umls",
+        "cumulus_library_catalog"
     ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -178,7 +178,7 @@ The `CountsBuilder` makes the following assumptions:
   - Document references, encounters, and observations will count their own associated IDs
   - All other resources will count patients
 
-# count_\[resource]
+## count_\[resource]
 *self, table_name: str, source_table: str, table_cols: list, where_clauses: list | None = None, min_subject: int | None = None, annotation: counts_templates.CountAnnotation | None = None,) -> str*
 
 Every cumulus-supported resource has a similarly structured count generator function.


### PR DESCRIPTION
- Adds `cumulus_library_catalog` to the module allowlist
- Fixes a tiny layout issue in the API docs

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`