### PR TITLE
Loosen requirements for workgroup encryption

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -111,11 +111,13 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         s3_path = wg_conf["OutputLocation"]
         bucket = "/".join(s3_path.split("/")[2:3])
         key_prefix = "/".join(s3_path.split("/")[3:])
-        encryption_type = wg_conf.get("EncryptionConfiguration", {}).get("EncryptionOption", {})
-        if encryption_type != "SSE_KMS":
+        encryption_type = wg_conf.get("EncryptionConfiguration", {}).get("EncryptionOption")
+        if encryption_type is None:
             raise errors.AWSError(
-                f"Bucket {bucket} has unexpected encryption type {encryption_type}."
-                "AWS KMS encryption is expected for Cumulus buckets"
+                f"The workgroup {self.work_group} is not reporting an encrypted status. "
+                f"Either bucket {bucket} is not encrypted, or the workgroup is overriding the "
+                "bucket's default encryption. Please confirm the encryption status of both. "
+                "Cumulus requires encryption as part of ensuring safety for limited data sets"
             )
         kms_arn = wg_conf.get("EncryptionConfiguration", {}).get("KmsKey", None)
         s3_key = f"{key_prefix}cumulus_user_uploads/{self.schema_name}/{study}/{topic}"

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -163,6 +163,19 @@ def test_create_db_backend(args, expected_type, raises):
             "SSE-S3",
             0,
             "s3://test_bucket/test_location/cumulus_user_uploads/test/study/table",
+            does_not_raise(),
+        ),
+        (
+            {
+                "file": pathlib.Path(__file__).resolve(),
+                "study": "study",
+                "topic": "table",
+                "remote_filename": None,
+                "force_upload": False,
+            },
+            None,
+            0,
+            "s3://test_bucket/test_location/cumulus_user_uploads/test/study/table",
             pytest.raises(errors.AWSError),
         ),
         (


### PR DESCRIPTION
Instead of requiring a bucket/workgroup to use KMS encryption, we'll now allow any valid encryption option, and only throw an error if something is reporting back as unencrypted.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json