### PR TITLE
Allow core__encounter to have non-fhir class values

### DIFF
--- a/cumulus_library/studies/core/core_templates/encounter.sql.jinja
+++ b/cumulus_library/studies/core/core_templates/encounter.sql.jinja
@@ -28,6 +28,7 @@ temp_encounter_nullable AS (
                     'status',
                     ('class', 'code', 'class_code'),
                     ('class', 'system', 'class_system'),
+                    ('class', 'display', 'class_display'),
                     ('subject', 'reference', 'subject_ref'),
                 ], 
                 schema
@@ -70,6 +71,7 @@ temp_encounter AS (
         e.status,
         e.class_code,
         e.class_system,
+        e.class_display,
         e.subject_ref,
         e.period_start,
         e.period_start_day,
@@ -104,8 +106,12 @@ temp_encounter AS (
 SELECT DISTINCT
     e.id,
     e.status,
+{#-
     ac.code AS class_code,
     ac.display AS class_display,
+#}
+    COALESCE (ac.code, e.class_code) AS class_code,
+    COALESCE (ac.display, e.class_display) AS class_display,
     e.type_code,
     e.type_system,
     e.type_display,

--- a/tests/core/test_core_encounters.py
+++ b/tests/core/test_core_encounters.py
@@ -21,5 +21,5 @@ def test_core_enc_class(tmp_path):
     assert rows == [
         {"id": "o", "class_code": "AMB", "class_display": "ambulatory"},
         {"id": "obsenc", "class_code": "OBSENC", "class_display": "observation encounter"},
-        {"id": "unsupported", "class_code": None, "class_display": None},
+        {"id": "unsupported", "class_code": "?", "class_display": None},
     ]


### PR DESCRIPTION
This switches the class-related fields in the encounter table to a coalesce, so we will in order take 1) a fhir field with its display value, or 2) whatever is present in the EHR (targeted at EPIC's custom class implementation).

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json