### PR TITLE
Added alternate targets to CountsAnnotation

### DIFF
--- a/cumulus_library/builders/counts.py
+++ b/cumulus_library/builders/counts.py
@@ -76,6 +76,9 @@ class CountsBuilder(BaseTableBuilder):
             (default: 10)
         :keyword fhir_resource: The type of FHIR resource to count (see
             builders/statistics_templates/count_templates.CountableFhirResource)
+        :keyword patient_link:
+        :keyword annotation: A CountsAnnotation object describing a table to use as
+            a metadata annotation source
         """
         if not table_name or not source_table or not table_cols:
             raise errors.CountsBuilderError(

--- a/cumulus_library/builders/statistics_templates/count.sql.jinja
+++ b/cumulus_library/builders/statistics_templates/count.sql.jinja
@@ -191,6 +191,15 @@ CREATE TABLE {{ table_name }} AS (
     )
 
     SELECT
+    {%- if annotation is not none and annotation.alt_target is not none %}
+        {%- if tertiary %}
+        sum(t.cnt_{{ tertiary }}) AS cnt,
+        {%- elif secondary %}
+        sum(s.cnt_{{ secondary }}) AS cnt,
+        {%- else %}
+        sum(p.cnt_subject_ref) AS cnt
+        {%- endif %}
+    {%- else %}   
         {%- if tertiary %}
         t.cnt_{{ tertiary }} AS cnt,
         {%- elif secondary %}
@@ -202,10 +211,11 @@ CREATE TABLE {{ table_name }} AS (
         p."{{ column_or_alias(col) }}"
         {{- syntax.comma_delineate(loop) }}
         {%- endfor %}
-        {%- if fhir_resource in ('documentreference', 'observation' ) -%},
+    {%- endif %}
+    {%- if fhir_resource in ('documentreference', 'observation' ) -%},
         p.class_display
-        {%- endif %}
-        {%- if annotation is not none %},
+    {%- endif %}
+    {%- if annotation is not none %},
         {%- for col in annotation.columns %}
         {%- if col[1] is not none %}
         j."{{ col[0] }}" AS "{{ col[1] }}"
@@ -214,7 +224,7 @@ CREATE TABLE {{ table_name }} AS (
         {%- endif %}
         {{- syntax.comma_delineate(loop) }}
         {%- endfor %}
-        {%- endif %}
+    {%- endif %}
     FROM powerset AS p
     {%- if secondary %}
     JOIN secondary_powerset AS s on s.id = p.id 
@@ -239,6 +249,13 @@ CREATE TABLE {{ table_name }} AS (
     {%- if tertiary %}
         AND t.cnt_{{ tertiary }} >= {{ min_subject }}
     {%- endif %}
-
+    {%- endif %}
+    {%- if annotation is not none and annotation.alt_target is not none %}
+    GROUP BY
+    {%- for col in annotation.columns %}
+        j."{{ col[0] }}"
+        {{- syntax.comma_delineate(loop) }}
+    {%- endfor %}
+    ORDER BY {{ annotation.alt_target }} ASC
     {%- endif %}
 );

--- a/cumulus_library/builders/statistics_templates/counts_templates.py
+++ b/cumulus_library/builders/statistics_templates/counts_templates.py
@@ -46,6 +46,8 @@ class CountAnnotation:
     :keyword join_field: the column in the table to join on
     :keyword list: a list of tuples like ('column_name', 'alias' or None) to
         define columns to add to your dataset.
+    :keyword alt_target: if present, a column to use from the annotation table
+        instead of the one defined in `field` as the primary countable target
 
     """
 
@@ -53,6 +55,7 @@ class CountAnnotation:
     join_table: str
     join_field: str
     columns: list[tuple[str, str | None]]
+    alt_target: str | None = None
 
 
 def get_count_query(
@@ -81,7 +84,6 @@ def get_count_query(
         else:
             table_col_classed.append(CountColumn(name=item, db_type="varchar", alias=None))
     table_cols = table_col_classed
-
     query = base_templates.get_template(
         "count",
         path,

--- a/cumulus_library/studies/core/core_templates/encounter.sql.jinja
+++ b/cumulus_library/studies/core/core_templates/encounter.sql.jinja
@@ -106,10 +106,6 @@ temp_encounter AS (
 SELECT DISTINCT
     e.id,
     e.status,
-{#-
-    ac.code AS class_code,
-    ac.display AS class_display,
-#}
     COALESCE (ac.code, e.class_code) AS class_code,
     COALESCE (ac.display, e.class_display) AS class_display,
     e.type_code,

--- a/docs/api.md
+++ b/docs/api.md
@@ -220,7 +220,7 @@ class MyBuilder(CountsBuilder):
 This would count instances of condition codes by year.
 
 ## CountAnnotation
-*field: str, join_table: str, join_field: str, columns: list\[tuple\[str, str | None]]*
+*field: str, join_table: str, join_field: str, columns: list\[tuple\[str, str | None]],alt_target: str | None*
 
 A CountAnnotation object can be supplied to a `count[resource]` function to indicate
 a table that should be joined to it post-counting. The intended purpose of this is
@@ -235,6 +235,9 @@ In detail, the expected arguments are as follows:
 - *columns* A list of tuples, describing column to join from *join_table*. 
   The first value in the tuple is the name of the column or a string literal,
   and the second value, if supplied, is the alias to use for that column.
+- *alt_target* Optionally, a column, which should be in *columns*, to be the new target for counting,
+  causing *field* to only be used for joining. Multiple values for *field* will be
+  summed based on the value in *alt_target*.
 
 Using our example from `CountsBuilder` above, here's an example of how we'd use this
 to annotate data:

--- a/tests/test_counts_templates.py
+++ b/tests/test_counts_templates.py
@@ -282,6 +282,90 @@ from cumulus_library.builders.statistics_templates import counts_templates
                 ),
             },
         ),
+        (
+            """CREATE TABLE test_table AS (
+    WITH
+    null_replacement AS (
+        SELECT
+            subject_ref,
+            encounter_ref,
+            coalesce(
+                cast(age AS varchar),
+                'cumulus__none'
+            ) AS age,
+            coalesce(
+                cast(sex AS varchar),
+                'cumulus__none'
+            ) AS sex
+        FROM test_source
+        
+    ),
+    secondary_powerset AS (
+        SELECT
+            count(DISTINCT encounter_ref) AS cnt_encounter_ref,
+            "age",
+            "sex",
+            concat_ws(
+                '-',
+                COALESCE("age",''),
+                COALESCE("sex",'')
+            ) AS id
+        FROM null_replacement
+        WHERE encounter_ref IS NOT NULL
+        GROUP BY
+            cube(
+            "age",
+            "sex"
+            )
+    ),
+
+    powerset AS (
+        SELECT
+            count(DISTINCT subject_ref) AS cnt_subject_ref,
+            "age",
+            "sex",
+            concat_ws(
+                '-',
+                COALESCE("age",''),
+                COALESCE("sex",'')
+            ) AS id
+        FROM null_replacement
+        GROUP BY
+            cube(
+            "age",
+            "sex"
+            )
+    )
+
+    SELECT
+        sum(s.cnt_encounter_ref) AS cnt,,
+        j."A",
+        j."B" AS "y"
+    FROM powerset AS p
+    JOIN secondary_powerset AS s on s.id = p.id
+        JOIN other_table j ON p.code = j.other_field
+    WHERE 
+        p.cnt_subject_ref >= None
+        AND s.cnt_encounter_ref >= None
+    GROUP BY
+        j."A",
+        j."B"
+    ORDER BY A ASC
+);""",
+            {
+                "filter_resource": False,
+                "where_clauses": None,
+                "fhir_resource": "encounter",
+                "min_subject": None,
+                "annotation": CountAnnotation(
+                    field="code",
+                    join_table="other_table",
+                    join_field="other_field",
+                    columns=[("A", None), ("B", "y")],
+                    alt_target="A",
+                ),
+            },
+        ),
     ],
 )
 def test_count_query(expected, kwargs):


### PR DESCRIPTION
This update to CountsAnnotation allows you to change the value by which to count to a column from the metadata table. This is a little obtuse, so here's an example:

Counted table:
|  A |  B | count|
|---|---|---|
|a|x|1|
|a|y|2|
|b|z|3|
|b|zz|4|

metadata table:
|field|label|
|----|-----|
|a|foo|
|b|bar|

Using `A=field` as the joined column, no other columns from the counted table with `label` as the alternate target, you'd get the following:
|field|label|count|
|----|-----|------|
|a|foo|3|
|b|bar|7|

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json