### PR TITLE
Counting status for docrefs is now optional

### DIFF
--- a/cumulus_library/builders/counts.py
+++ b/cumulus_library/builders/counts.py
@@ -79,6 +79,8 @@ class CountsBuilder(BaseTableBuilder):
         :keyword patient_link:
         :keyword annotation: A CountsAnnotation object describing a table to use as
             a metadata annotation source
+        :keyword skip_status_filter: Skips status/docStatus fields in docrefs (see
+            count_documentference for context)
         """
         if not table_name or not source_table or not table_cols:
             raise errors.CountsBuilderError(
@@ -93,6 +95,7 @@ class CountsBuilder(BaseTableBuilder):
                 "filter_resource",
                 "patient_link",
                 "annotation",
+                "skip_status_filter",
             ]:
                 raise errors.CountsBuilderError(f"count_query received unexpected key: {key}")
         if "min_subject" in kwargs and kwargs["min_subject"] is None:
@@ -201,6 +204,7 @@ class CountsBuilder(BaseTableBuilder):
         where_clauses: list | None = None,
         min_subject: int | None = None,
         annotation: counts_templates.CountAnnotation | None = None,
+        skip_status_filter: bool | None = False,
     ) -> str:
         """wrapper method for constructing documentreference counts tables
 
@@ -211,6 +215,11 @@ class CountsBuilder(BaseTableBuilder):
         :param min_subject: An integer setting the minimum bin size for inclusion
             (default: 10)
         :param annotation: A CountAnnotation definining an external annotation source
+        :param skip_status_filter: Skips the normal filtering of status/docstatus fields.
+            Note: documentrefs often have cancelled/entered in error statuses, which
+            we normally filter out for counting. When setting this flag, we assume
+            you have taken some action to properly select documents within the context
+            of a study ahead of counting.
         """
         return self.get_count_query(
             table_name,
@@ -221,6 +230,7 @@ class CountsBuilder(BaseTableBuilder):
             fhir_resource="documentreference",
             filter_resource=True,
             annotation=annotation,
+            skip_status_filter=skip_status_filter,
         )
 
     def count_encounter(

--- a/cumulus_library/builders/statistics_templates/count.sql.jinja
+++ b/cumulus_library/builders/statistics_templates/count.sql.jinja
@@ -101,8 +101,10 @@ CREATE TABLE {{ table_name }} AS (
         {%- endif -%}
         {#- resource specific filtering conditions -#}
         {%- if fhir_resource == 'documentreference' %}
+        {%- if skip_status_filter is false %}
         WHERE (s.status = 'current')
         AND (s.docStatus IS null OR s.docStatus IN ('final', 'amended'))
+        {%- endif%}
         {%- elif fhir_resource == 'encounter' %}
         WHERE s.status = 'finished'
         {%- elif fhir_resource == 'observation' %}

--- a/cumulus_library/builders/statistics_templates/counts_templates.py
+++ b/cumulus_library/builders/statistics_templates/counts_templates.py
@@ -71,6 +71,7 @@ def get_count_query(
     filter_resource: bool | None = True,
     patient_link: str = "subject_ref",
     annotation: CountAnnotation | None = None,
+    skip_status_filter: bool | None = False,
 ) -> str:
     """Generates count tables for generating study outputs"""
     path = Path(__file__).parent
@@ -99,6 +100,7 @@ def get_count_query(
         filter_resource=filter_resource,
         patient_link=patient_link,
         annotation=annotation,
+        skip_status_filter=skip_status_filter,
     )
     # workaround for conflicting sqlfluff enforcement
     return query.replace("-- noqa: disable=LT02\n", "")

--- a/tests/test_counts_builder.py
+++ b/tests/test_counts_builder.py
@@ -229,6 +229,18 @@ def test_count_wrappers(
         assert call_kwargs["min_subject"] == min_subject
 
 
+def test_exclude_docstatus():
+    manifest = study_manifest.StudyManifest()
+    manifest._study_prefix = TEST_PREFIX
+    builder = counts.CountsBuilder(manifest=manifest)
+    query = builder.count_documentreference("table", "source", ["col_a"])
+    assert "s.docStatus" in query
+    assert "s.status" in query
+    query = builder.count_documentreference("table", "source", ["col_a"], skip_status_filter=True)
+    assert "s.docStatus" not in query
+    assert "s.status" not in query
+
+
 def test_null_study_prefix():
     with pytest.raises(errors.CountsBuilderError):
         counts.CountsBuilder()


### PR DESCRIPTION
This allows a user to control whether they have already preprocessed documentreferences before counting as part of their study. Addresses #396 

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json