### PR TITLE
update kidney study name in allowlist

### DIFF
--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -6,7 +6,7 @@
         "cumulus_library_covid",
         "cumulus_library_data_metrics",
         "cumulus_library_hypertension",
-        "cumulus_library_irae",
+        "cumulus_library_kidney_transplant",
         "cumulus_library_loinc",
         "cumulus_library_opioid",
         "cumulus_library_rxnorm",


### PR DESCRIPTION
This updates the installation name of the kidney study in the allow list to line up with the pypi package name

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json