### PR TITLE
moved docref/observation code check to core counts

### DIFF
--- a/cumulus_library/builders/statistics_templates/count.sql.jinja
+++ b/cumulus_library/builders/statistics_templates/count.sql.jinja
@@ -26,9 +26,6 @@ logic at the statistics/counts.py level -#}
             "{{ column_or_alias(col) }}"
             {{- syntax.comma_delineate(loop) }}
             {%- endfor %}
-            {%- if fhir_resource in ('documentreference', 'observation' ) -%},
-            class_display
-            {% endif %}
 {%- endmacro -%}
 
 {#- This macro handles making sure that we don't pass a null to concat_ws,
@@ -38,9 +35,6 @@ which will drop nulls, resulting in potentially non-unique keys -#}
                 COALESCE("{{ column_or_alias(col) }}",'')
                 {{- syntax.comma_delineate(loop) }}
                 {%- endfor %}
-                {%- if fhir_resource in ('documentreference', 'observation' ) -%},
-                COALESCE(class_display,'')
-                {% endif %}
 {%- endmacro -%}
 
 
@@ -71,9 +65,6 @@ CREATE TABLE {{ table_name }} AS (
             {%- if tertiary %}
             s.{{ tertiary }},
             {%- endif -%}
-            {%- if fhir_resource in ('documentreference', 'observation') %}
-            e.class_display,
-            {%- endif %}
             {#- these exceptions deal with table aliasing related to
             single table queries, where this may be a multitable query
             depending on context #}
@@ -120,12 +111,6 @@ CREATE TABLE {{ table_name }} AS (
             {%- endif -%}
             {%- if tertiary %}
             {{ tertiary }},
-            {%- endif -%}
-            {%- if fhir_resource in ('documentreference', 'observation' )%}
-            coalesce(
-                cast(class_display AS varchar), 
-                '{{ missing_null }}'
-            ) AS class_display,
             {%- endif -%}
             {%- for col in table_cols %}
             coalesce(
@@ -213,9 +198,6 @@ CREATE TABLE {{ table_name }} AS (
         p."{{ column_or_alias(col) }}"
         {{- syntax.comma_delineate(loop) }}
         {%- endfor %}
-    {%- endif %}
-    {%- if fhir_resource in ('documentreference', 'observation' ) -%},
-        p.class_display
     {%- endif %}
     {%- if annotation is not none %},
         {%- for col in annotation.columns %}

--- a/cumulus_library/studies/core/count_core.py
+++ b/cumulus_library/studies/core/count_core.py
@@ -49,6 +49,7 @@ class CoreCountsBuilder(cumulus_library.CountsBuilder):
         cols = [
             ["type_display", "varchar", None],
             [f"author_{duration}", "date", None],
+            ["class_display", "varchar", None],
         ]
         return self.count_documentreference(table_name, from_table, cols, filter_status=True)
 
@@ -121,6 +122,7 @@ class CoreCountsBuilder(cumulus_library.CountsBuilder):
             f"effectiveDateTime_{duration}",
             "observation_code",
             "valueCodeableConcept_display",
+            "class_display",
         ]
         return self.count_observation(table_name, from_table, cols, filter_status=True)
 


### PR DESCRIPTION
Since not all cases will want the code display, we'll move this check to be specific to the core tables.

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json