### PR TITLE
example_nlp: add JSON schema generator, to move it out of the ETL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ MRCONSO.RRF
 coverage.xml
 valueset_data/
 pyarrow_cache.parquet
+/cumulus_library/studies/example_nlp/age.json
 
 # parquet and csv files show up during an export, which devs might do a fair bit in odd places.
 # So for safety, ignore them both here, except in the tests dir where we use them for test data.

--- a/cumulus_library/studies/example_nlp/generate_schemas.py
+++ b/cumulus_library/studies/example_nlp/generate_schemas.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+"""Define schemas for the example_nlp study"""
+
+import json
+import os
+
+import pydantic
+
+
+class AgeMention(pydantic.BaseModel):
+    has_mention: bool | None = pydantic.Field(None)
+    spans: list[str] = pydantic.Field(default_factory=list, description="Supporting text spans")
+    age: int | None = pydantic.Field(None, description="The age of the patient")
+
+
+if __name__ == "__main__":
+    basedir = os.path.dirname(__file__)
+
+    with open(f"{basedir}/age.json", "w", encoding="utf8") as f:
+        json.dump(AgeMention.model_json_schema(), f, indent=2)


### PR DESCRIPTION
As part of moving to configs, we can now move the pydantic models and schema generation to studies, where it belongs.

Eventually, we'll move the rest of the NLP config, but this is a beginning. (makes more sense for other studies which already have pydantic models and we are currently hosting two copies in two repos - for example_nlp, the pydantic models were always in the ETL and never here. But this is a good pattern to follow) 

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json