### PR TITLE
Manifest export modularization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,11 @@ cumulus-library generate-md --target core [database args pointing at your athena
 Then take the contents of `cumulus_library/studies/core/core_generated.md`
 and paste them into `docs/core-study-details.md`
 (being careful to not erase any manually entered descriptions).
+
+# Restrictions on generative AI usage
+
+At this time we are not accepting code contributions from generative AI due to
+potential licensing issues and the increased burden of review on maintainers.
+
+We also ask that generative AI not be used to write content in issues/PRs, and reserve
+the right to close issues without response in cases where it has been obviously applied.

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -70,8 +70,10 @@ def build_study(
 
     for stage in stages:
         for action in manifest.get_stage(stage):
+            if not action.get("type", "").startswith("build:"):
+                continue
             query_count = 0
-            if action.get("action_type") == "parallel":
+            if action.get("type") == enums.ManifestActions.PARALLEL.value:
                 parallel = True
             else:
                 parallel = False

--- a/cumulus_library/actions/exporter.py
+++ b/cumulus_library/actions/exporter.py
@@ -48,12 +48,12 @@ def export_study(
     if archive:
         table_query = base_templates.get_show_tables(config.schema, prefix)
         result = config.db.cursor().execute(table_query).fetchall()
-        table_list = manifest.get_export_table_list()
+        table_list = manifest.get_export_table_list(config.build_type)
         for row in result:
             if row[0] not in table_list:
                 table_list.append(study_manifest.ManifestExport(name=row[0], export_type="archive"))
     else:
-        table_list = manifest.get_export_table_list()
+        table_list = manifest.get_export_table_list(config.build_type)
     path = pathlib.Path(f"{data_path}/{manifest.get_study_prefix()}/")
     path.mkdir(parents=True, exist_ok=True)
     for table in track(

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -253,6 +253,7 @@ AWS Athena, the following order of preference is used to select credentials:
     # Database export
 
     export = actions.add_parser("export", help="Generates files on disk from Athena tables/views")
+    add_build_type_argument(export)
     add_custom_option(export)
     add_target_argument(export)
     add_study_dir_argument(export)

--- a/cumulus_library/enums.py
+++ b/cumulus_library/enums.py
@@ -44,3 +44,15 @@ class StatisticsTypes(enum.Enum):
     """A subset of workflows that create statistics sampling artifacts"""
 
     PSM = "psm"
+
+
+class ManifestActions(enum.StrEnum):
+    """The types of actions you can use in a manifest"""
+
+    SERIAL = "build:serial"
+    PARALLEL = "build:parallel"
+    SUBMANIFEST = "submanifest"
+    COUNTS = "export:counts"
+    ANNOTATED = "export:annotated_counts"
+    FLAT = "export:flat"
+    META = "export:meta"

--- a/cumulus_library/studies/core/manifest.toml
+++ b/cumulus_library/studies/core/manifest.toml
@@ -6,7 +6,7 @@ files = [
     "fhir_lookup_tables.sql",
     "fhir_mapping_tables.sql",
 ]
-action_type = "parallel"
+type = "build:parallel"
 [[stages.build_core]]
 description = "FHIR nested resource flattening"
 files =[
@@ -24,11 +24,13 @@ files =[
     "builder_practitionerrole_prereq.py",
     "builder_procedure_prereq.py",
 ]
+type = "build:serial"
 [[stages.build_core]]
 description = "Patient"
 files =[
     "builder_patient.py",
 ]
+type = "build:serial"
 [[stages.build_core]]
 description= "Other FHIR resource tables"
 files=[
@@ -45,21 +47,21 @@ files=[
     "builder_practitionerrole.py",
     "builder_procedure.py",
 ]
-action_type = "parallel"
+type = "build:parallel"
 [[stages.build_core]]
 description = "Tables derived from FHIR resource tables"
 files = [
     "observation_type.sql",
     "meta_date.sql"
 ]
-action_type = "parallel"
+type = "build:parallel"
 [[stages.build_core]]
 description = "Summary counts of FHIR resources"
 files = ["count_core.py"]
-action_type = "parallel"
+type = "build:parallel"
 
-[export_config]
-count_list = [
+[[stages.build_core]]
+tables = [
     "core__count_allergyintolerance_month",
     "core__count_condition_month",
     "core__count_diagnosticreport_month",
@@ -75,7 +77,10 @@ count_list = [
     "core__count_patient",
     "core__count_procedure_month",
 ]
-meta_list = [
+type = "export:counts"
+[[stages.build_core]]
+tables = [
     "core__meta_date",
     "core__meta_version",
 ]
+type = "export:meta"

--- a/cumulus_library/studies/discovery/manifest.toml
+++ b/cumulus_library/studies/discovery/manifest.toml
@@ -5,22 +5,23 @@ description= "code detection"
 files = [
     "code_detection.py",
 ]
-action_type="parallel"
+type="build:parallel"
 [[stages.build_discovery]]
 description = "code union"
 files= [
     "code_union.py"
 ]
-action_type="parallel"
+type="build:parallel"
 [[stages.build_discovery]]
 description = "temp data cleanup"
 files = [
     "cleanup_tmp.py"
 ]
-action_type="parallel"
+type="build:parallel"
 
 
-[export_config]
-count_list = [
+[[stages.build_discovery]]
+tables = [
     "discovery__code_sources",
 ]
+type = "export:counts"

--- a/cumulus_library/studies/example_nlp/manifest.toml
+++ b/cumulus_library/studies/example_nlp/manifest.toml
@@ -8,3 +8,4 @@ description = "Range calculation"
 files = [
     "calculate_ranges.py",
 ]
+type = "build:serial"

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -9,7 +9,7 @@ import sys
 
 import msgspec
 
-from cumulus_library import errors
+from cumulus_library import enums, errors
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -22,9 +22,10 @@ class ManifestExport:
 
 
 class ManifestAction(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    type: str
     description: str | None = None
-    action_type: str | None = None
     files: list[str] | None = None
+    tables: list[str] | None = None
 
 
 class ManifestAdvancedOptions(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
@@ -32,19 +33,11 @@ class ManifestAdvancedOptions(msgspec.Struct, forbid_unknown_fields=True, omit_d
     dynamic_study_prefix: str | None = None
 
 
-class ManifestExportConfig(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
-    count_list: list[str] | None = None
-    flat_list: list[str] | None = None
-    meta_list: list[str] | None = None
-    annotated_count_list: list[str] | None = None
-
-
 class ManifestConfig(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
     study_prefix: str | None = None
     description: str | None = None
     build_types: dict[str, list[str]] | None = None
     stages: dict[str, list[ManifestAction]] | None = None
-    export_config: ManifestExportConfig | None = None
     advanced_options: ManifestAdvancedOptions | None = None
 
 
@@ -108,11 +101,11 @@ class StudyManifest:
             )
 
     def _validate_action(self, action, source):
-        action_type = action.get("action_type")
-        if action_type is not None and action_type not in self.VALID_ACTIONS:
+        action_type = action.get("type")
+        if action_type is not None and action_type not in [e.value for e in enums.ManifestActions]:
             raise errors.StudyManifestParsingError(
                 f"Action type '{action_type}' in {source} is not a valid action.\n"
-                f"Valid action types: {', '.join(self.VALID_ACTIONS)}."
+                f"Valid action types: {', '.join(enums.ManifestActions)}."
             )
 
     ### toml parsing helper functions
@@ -147,11 +140,13 @@ class StudyManifest:
         # if build types are not supplied, we'll assume that we should run everything in order
         else:
             config["build_types"] = {"default": defined_stages}
-        # if we're importing from submanifest, let's do that now to keep the builder logic cleaner
+        # If we're importing from submanifest, we'll do an inline swap out of the submanifest for
+        # the actions defined in the submanifest.
+        # This means we can assume everywhere else that we don't need to worry about submanifests.
         for stage in defined_stages:
             actions = []
             for action in config["stages"][stage]:
-                if action.get("action_type") == "submanifest":
+                if action.get("type") == "submanifest":
                     for submanifest in action.get("files", []):
                         subconfig = self._read_toml(
                             study_path.parent / submanifest, SubmanifestConfig
@@ -228,11 +223,13 @@ class StudyManifest:
         for stage_name in stages:
             stage = self.get_stage(stage_name)
             for action in stage:
+                if not action.get("type", "").startswith("build:"):
+                    continue
                 if continue_from and not found_continue_point:
                     file_stems = [x.split(".", 1)[0] for x in action["files"]]
                     if continue_from.split(".", 1)[0] in file_stems:
                         found_continue_point = True
-                        if action.get("action_type") == "parallel":
+                        if action.get("type") == enums.ManifestActions.PARALLEL.value:
                             files = files + action["files"]
                         else:
                             pos = file_stems.index(continue_from.split(".", 1)[0])
@@ -243,38 +240,50 @@ class StudyManifest:
             raise errors.StudyManifestParsingError(f"No files matching '{continue_from}' found")
         return files
 
-    def get_export_table_list(self) -> list[ManifestExport] | None:
-        """Reads the contents of the export_list array from the manifest
+    def get_export_table_list(self, build_type: str | None = None) -> list[ManifestExport] | None:
+        """Reads the exportable tables from the manifest
 
+        :param build_type: if present, just search the stages defined in the build_type list
         :returns: An array of tuples (table, export type) to export from the manifest,
         or None if not found.
         """
-        export_config = self._study_config.get("export_config", {})
         export_table_list = []
+        if build_type:
+            builds = self._study_config.get("build_types", {})
+            build = builds.get(build_type)
+            stages = {}
+            for stage in build:
+                stages[stage] = self._study_config.get("stages", {}).get(stage)
+        else:
+            stages = self._study_config.get("stages", {})
 
-        for section in [
-            ("count_list", "cube"),
-            ("flat_list", "flat"),
-            ("meta_list", "meta"),
-            ("annotated_count_list", "annotated_cube"),
-        ]:
-            section_list = export_config.get(section[0], []) or []
-            for table in section_list:
-                if table.startswith(f"{self.get_study_prefix()}__"):
-                    export_table_list.append(ManifestExport(name=table, export_type=section[1]))
-                elif "__" in table:  # has a prefix, just the wrong one
-                    raise errors.StudyManifestParsingError(
-                        f"{table} in export list does not start with prefix "
-                        f"{self.get_study_prefix()}__ - check your manifest file."
-                    )
-                else:
-                    # Add the prefix for them (helpful in dynamic prefix cases where the prefix
-                    # is not known ahead of time)
-                    export_table_list.append(
-                        ManifestExport(
-                            name=f"{self.get_study_prefix()}__{table}", export_type=section[1]
+        for stage in stages.keys():
+            for action in stages[stage]:
+                if not action.get("type", "").startswith("export:"):
+                    continue
+                export_type = action["type"].split(":")[1]
+                if export_type == "counts":
+                    # the aggregator is looking for the cube keyword, so we'll swap it out
+                    export_type = "cube"
+                for table in action.get("tables", []):
+                    if table.startswith(f"{self.get_study_prefix()}__"):
+                        export_table_list.append(
+                            ManifestExport(name=table, export_type=export_type)
                         )
-                    )
+                    elif "__" in table:  # has a prefix, just the wrong one
+                        raise errors.StudyManifestParsingError(
+                            f"{table} in export list does not start with prefix "
+                            f"{self.get_study_prefix()}__ - check your manifest file."
+                        )
+                    else:
+                        # Add the prefix for them (helpful in dynamic prefix cases where the prefix
+                        # is not known ahead of time)
+                        export_table_list.append(
+                            ManifestExport(
+                                name=f"{self.get_study_prefix()}__{table}", export_type=export_type
+                            )
+                        )
+
         found_name = set()
         for export in export_table_list:
             if export.name in found_name:

--- a/docs/creating-studies.md
+++ b/docs/creating-studies.md
@@ -98,12 +98,20 @@ counts = ['count_cohorts']
 
 # Actions can have the following fields:
 #   - 'description', which will be displayed in the CLI while the action is being run
-#   - 'files', which is a list of files to process (raw sql, python builders, or toml workflows)
-#   - 'action_type', which determines what the action does. Valid types:
-#      - 'serial' (default if action_type is not specified) runs the files in order, one at a time
-#      - 'parallel' will run the files concurrently, which is faster but assumes no interdependencies
-#      - 'submanifest' loads a list of actions from another file. Those actions use the
-#        same format as those from the main manifest
+#   - 'type', which determines what the action does, and which parts of the library CLI the
+#     action is invoked by. Valid types:
+#      - 'build:serial' (default if action_type is not specified) runs the files in order, one at a time
+#      - 'build:parallel' will run the files concurrently, which is faster but assumes no interdependencies
+#      - 'export:counts' will export a set of tables to disk, tagging them as cube tables
+#      - 'export:annotated_counts' will export a set of tables to disk, tagging them as cube tables
+#         with additional metadata columns
+#      - 'export:flat' will export a set tables to disk, tagging them as flat statistics tables
+#      - 'export:meta' will export a set tables to disk, tagging them as metadata tables
+#      - 'submanifest' loads a list of actions from another file. A submanifest can contain
+#        any of the above action types
+# There are some action fields that are only used by certain action types:
+# - build & submanifest actions have a field, 'files', which is a list of files to process (raw sql, python builders, or toml workflows, submanifests)
+# - export actions have a field, 'tables', which is a list of tables to export to disk
 
 # This double bracket defines a new array inside of stages, define_population
 [[stages.define_population]]
@@ -115,6 +123,7 @@ files = [
 # to the end of the define_population list.
 [[stages.define_population]]
 description = 'Select patients by characteristics'
+type= 'build:serial'
 files = [
   'select_patients.sql',
 ]
@@ -123,37 +132,44 @@ description = 'Define cohorts'
 files = [
   'cohort_submanifest.toml'
 ]
-action_type = "submanifest"
+type = "submanifest"
 [[stages.count_cohorts]]
 description = 'Define cohorts'
 files = [
   'cohort_by_age.py',
   'cohort_by_gender.py'
 ]
-action_type = "parallel"
+type = "build:parallel"
 
-[export_config]
+# Most cumulus exports should be count tables, created as powerset cubes for deid binning
+# purposes.
 
-# The following tables will be exported and labeled as aggregate count tables.
-# In most cases, tables should go in this list.
-
-count_list = [
+[[stages.count_cohorts]]
+description = 'Export patient counts'
+type = 'export:counts'
+tables = [
     "my_study__count_influenza_test_month",
 ]
 
 # In some cases, you may want to annotate count data with metadata from another
 # source. Most commonly, this is used to add data related to a code (like its
-# display value or code system) from another source. These tables should go
-# in this section.
+# display value or code system) from another source.
 
-annotated_count_list = [
+[[stages.count_cohorts]]
+description = 'Export patient symptoms w/ LOINC codes'
+type = 'export:annotated_counts'
+tables = [
     "my_study__count_influenza_test_month_annotated",
 ]
 
 # Some specific tables (like those produced by data metrics) are a special type
-# of tables, that are flat summary statistics tables. They should go in this list.
+# of tables, that are flat summary statistics tables, typically used for true/false
+# categorization
 
-flat_list = [
+[[stages.count_cohorts]]
+description = 'Export summary statistics'
+type = 'export:flat'
+tables = [
     "my_study__q_influenza",
 ]
 
@@ -164,7 +180,10 @@ flat_list = [
 # your export tables changes. See the core study for examples of how to structure
 # these tables.
 
-meta_list = [
+[[stages.count_cohorts]]
+description = 'Export metadata'
+type = 'export:metadata'
+tables = [
   "my_study__meta_date",
   "my_study__meta_version",
 ]
@@ -205,11 +224,17 @@ Here's an example submanifest (note that this is optional and you don't have to 
 [[actions]]
 description = "Select cohorts by age"
 files = ['age_cohort.sql']
-action_type = 'serial'
+type = 'serial'
 [[actions]]
 description = "Create cohorts by medications"
 files = ['cohort_rx_1.py', 'cohort_rx_2.py']
-action_type = 'parallel'
+type = 'parallel'
+[[actions]]
+description = 'Export patient medication counts'
+type = 'export:counts'
+tables = [
+    "my_study__count_patient_rx",
+]
 # Note that you cannot recursively add a submanifest from another submanifest
 ```
 

--- a/tests/actions/test_builder.py
+++ b/tests/actions/test_builder.py
@@ -241,7 +241,7 @@ def test_builder_init_error(mock_db_config):
 def test_invalid_file_in_manifest(mock_db_config, tmp_path):
     manifest_dict = {
         "study_prefix": "invalid_file_type",
-        "stages": {"stage_1": [{"files": ["data.nsf"]}]},
+        "stages": {"stage_1": [{"files": ["data.nsf"], "type": "build:serial"}]},
     }
     conftest.write_toml(tmp_path, manifest_dict, "manifest.toml")
     manifest = study_manifest.StudyManifest(tmp_path)

--- a/tests/studies/core/test_core.py
+++ b/tests/studies/core/test_core.py
@@ -107,8 +107,11 @@ def test_core_count_missing_data(tmp_path):
 def test_core_counts_exported(mock_db_core):
     with open(f"{conftest.LIBRARY_ROOT}/studies/core/manifest.toml", "rb") as f:
         manifest = tomllib.load(f)
-    manifest["export_config"]["meta_list"].remove("core__meta_version")
-    manifest["export_config"]["meta_list"].remove("core__meta_date")
+    actions = manifest["stages"]["build_core"]
+    expected_count_tables = []
+    for action in actions:
+        if action["type"] == "export:counts":
+            expected_count_tables = expected_count_tables + action["tables"]
     count_tables = (
         mock_db_core.cursor()
         .execute(
@@ -118,7 +121,7 @@ def test_core_counts_exported(mock_db_core):
         .fetchall()
     )
     count_tables = [x[0] for x in count_tables]
-    assert set(manifest["export_config"]["count_list"]) == set(count_tables)
+    assert set(expected_count_tables) == set(count_tables)
 
 
 def test_core_empty_database(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import shutil
 import sys
-import tomllib
 import zipfile
 from contextlib import contextmanager
 from contextlib import nullcontext as does_not_raise
@@ -22,7 +21,7 @@ import requests
 import responses
 import time_machine
 
-from cumulus_library import __version__, cli, databases, errors
+from cumulus_library import StudyManifest, __version__, cli, databases, errors
 from tests.conftest import duckdb_args
 
 FHIR_RESOURCE_TABLE_COUNT = 19
@@ -533,7 +532,7 @@ def test_clean(tmp_path, args, expected, raises):
                 "tests/test_data/study_invalid_unsupported_file/",
             ],
             3,
-            pytest.raises(SystemExit),
+            pytest.raises(errors.StudyManifestParsingError),
             [],
         ),
     ],
@@ -569,14 +568,12 @@ def test_cli_executes_queries(
             else:
                 manifest_dir = cli.get_study_dict([cli.get_abs_path(build_args[4])])[build_args[2]]
 
-            with open(f"{manifest_dir}/manifest.toml", "rb") as file:
-                config = tomllib.load(file)
+            config = StudyManifest(f"{manifest_dir}/manifest.toml")
             csv_files = glob.glob(f"{tmp_path}/export/{build_args[2]}/*.csv")
-            export_config = config["export_config"]
-            for export_list in export_config.values():
-                for export_table in export_list:
-                    if export_table not in expected_missing:
-                        assert any(export_table in x for x in csv_files)
+            export_list = [t.name for t in config.get_export_table_list()]
+            for export_table in export_list:
+                if export_table not in expected_missing:
+                    assert any(export_table in x for x in csv_files)
 
 
 @mock.patch.dict(

--- a/tests/test_data/file_upload/manifest.toml
+++ b/tests/test_data/file_upload/manifest.toml
@@ -1,4 +1,5 @@
 study_prefix = "file_upload"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["workflow.toml"]

--- a/tests/test_data/psm/manifest.toml
+++ b/tests/test_data/psm/manifest.toml
@@ -1,5 +1,6 @@
 study_prefix = "psm_test"
 
 [[stages.stage_1]]
+type="build:serial"
 files = ["psm_cohort.sql","psm_config.toml"]
 

--- a/tests/test_data/study_dedicated_schema/manifest.toml
+++ b/tests/test_data/study_dedicated_schema/manifest.toml
@@ -1,10 +1,12 @@
 study_prefix = "study_dedicated_schema"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["module1.py", "module1.py", "module2.py", "test.sql"]
 
-[export_config]
-count_list = ["study_dedicated_schema__table_raw_sql"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["study_dedicated_schema__table_raw_sql"]
 
 [advanced_options]
 dedicated_schema="dedicated"

--- a/tests/test_data/study_different_dir/manifest.toml
+++ b/tests/test_data/study_different_dir/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "study_different_name"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["study_different_name__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["study_different_name__table"]

--- a/tests/test_data/study_dynamic_prefix/manifest.toml
+++ b/tests/test_data/study_dynamic_prefix/manifest.toml
@@ -1,13 +1,15 @@
 
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "meta.py",
     "counts.py",
 ]
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "counts",
     "meta_version",
 ]

--- a/tests/test_data/study_invalid_bad_query/manifest.toml
+++ b/tests/test_data/study_invalid_bad_query/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "study_invalid_bad_query"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["study_invalid_bad_query__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["study_invalid_bad_query__table"]

--- a/tests/test_data/study_invalid_bad_query_parallel/manifest.toml
+++ b/tests/test_data/study_invalid_bad_query_parallel/manifest.toml
@@ -5,7 +5,8 @@ files = [
     "valid.sql",
     "invalid.sql",
 ]
-action_type = 'parallel'
+type = 'build:parallel'
 
-[export_config]
-count_list = ["study_invalid_bad_query__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["study_invalid_bad_query__table"]

--- a/tests/test_data/study_invalid_duplicate_exports/manifest.toml
+++ b/tests/test_data/study_invalid_duplicate_exports/manifest.toml
@@ -1,19 +1,26 @@
 study_prefix = "study_invalid_duplicate_exports"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "test.sql",
     "test2.sql"
 ]
 
-[export_config]
-
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_invalid_duplicate_exports__table"
 ]
-flat_list = [
+
+[[stages.stage_1]]
+type = "export:flat"
+tables = [
     "study_invalid_duplicate_exports__table2"
 ]
-meta_list = [
+
+[[stages.stage_1]]
+type = "export:meta"
+tables = [
     "study_invalid_duplicate_exports__table2"
 ]

--- a/tests/test_data/study_invalid_no_dunder/manifest.toml
+++ b/tests/test_data/study_invalid_no_dunder/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "test"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test_table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test_table"]

--- a/tests/test_data/study_invalid_reserved_word/manifest.toml
+++ b/tests/test_data/study_invalid_reserved_word/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "test"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test__etl_table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test__etl_table"]

--- a/tests/test_data/study_invalid_two_dunder/manifest.toml
+++ b/tests/test_data/study_invalid_two_dunder/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "test"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test__table__name"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test__table__name"]

--- a/tests/test_data/study_invalid_unsupported_file/manifest.toml
+++ b/tests/test_data/study_invalid_unsupported_file/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "study_invalid_unsupported_file"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.txt"]
 
-[export_config]
-export_list = ["study_invalid_unsupported_file__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["study_invalid_unsupported_file__table"]

--- a/tests/test_data/study_missing_prefix/manifest.toml
+++ b/tests/test_data/study_missing_prefix/manifest.toml
@@ -1,6 +1,8 @@
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test__table"]

--- a/tests/test_data/study_python_counts_valid/manifest.toml
+++ b/tests/test_data/study_python_counts_valid/manifest.toml
@@ -1,6 +1,7 @@
 study_prefix = "study_python_counts_valid"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "module1.py", "module1.py", "module2.py"
 ]

--- a/tests/test_data/study_python_local_template/manifest.toml
+++ b/tests/test_data/study_python_local_template/manifest.toml
@@ -1,4 +1,5 @@
 study_prefix = "study_python_local_template"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["module1.py"]

--- a/tests/test_data/study_python_no_subclass/manifest.toml
+++ b/tests/test_data/study_python_no_subclass/manifest.toml
@@ -1,5 +1,6 @@
 study_prefix = "test_python"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["module1.py", "module2.py"]
 

--- a/tests/test_data/study_python_s3/manifest.toml
+++ b/tests/test_data/study_python_s3/manifest.toml
@@ -1,9 +1,11 @@
 study_prefix = "study_python_s3"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["module1.py", "module2.py"]
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
         "study_python_s3__count_table"
 ]

--- a/tests/test_data/study_python_valid/manifest.toml
+++ b/tests/test_data/study_python_valid/manifest.toml
@@ -1,9 +1,11 @@
 study_prefix = "study_python_valid"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["module1.py", "module1.py", "module2.py"]
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_python_valid__count_table"
 ]

--- a/tests/test_data/study_python_valid_parallel/manifest.toml
+++ b/tests/test_data/study_python_valid_parallel/manifest.toml
@@ -2,13 +2,14 @@ study_prefix = "study_python_valid_parallel"
 
 [[stages.stage_1]]
 files = ["module1.py", "module2.py"]
-action_type = "parallel"
+type = "build:parallel"
 
 [[stages.stage_2]]
 files = ["module3.py"]
-action_type = "parallel"
+type = "build:parallel"
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_python_valid_parallel__table"
 ]

--- a/tests/test_data/study_static_file/manifest.toml
+++ b/tests/test_data/study_static_file/manifest.toml
@@ -1,11 +1,13 @@
 study_prefix = "study_static_file"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "static_file_builder.py",
 ]
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_static_file__table"
 ]

--- a/tests/test_data/study_valid/manifest.toml
+++ b/tests/test_data/study_valid/manifest.toml
@@ -1,13 +1,15 @@
 study_prefix = "study_valid"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "test.sql",
     "test2.sql"
 ]
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_valid__table",
     "study_valid__table2"
 ]

--- a/tests/test_data/study_valid_all_exports/manifest.toml
+++ b/tests/test_data/study_valid_all_exports/manifest.toml
@@ -1,20 +1,25 @@
 study_prefix = "study_valid_all_exports"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "testcount.sql",
     "testflat.sql",
     "testmeta.sql"
 ]
 
-[export_config]
-
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_valid_all_exports__tablecount"
 ]
-flat_list = [
+[[stages.stage_1]]
+type = "export:flat"
+tables = [
     "study_valid_all_exports__tableflat"
 ]
-meta_list = [
+[[stages.stage_1]]
+type = "export:meta"
+tables = [
     "study_valid_all_exports__tablemeta"
 ]

--- a/tests/test_data/study_valid_parallel/manifest.toml
+++ b/tests/test_data/study_valid_parallel/manifest.toml
@@ -9,17 +9,18 @@ files = [
     "test.sql",
     "test2.sql"
 ]
-action_type = "parallel"
+type = "build:parallel"
 
 [[stages.stage_2]]
 description = 'Stage 2'
 files = [
     "test3.sql"
 ]
-action_type = "parallel"
+type = "build:parallel"
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "study_valid_parallel__table",
     "study_valid_parallel__table2",
     "study_valid_parallel__table3"

--- a/tests/test_data/study_wrong_prefix/manifest.toml
+++ b/tests/test_data/study_wrong_prefix/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = "test"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test__table"]

--- a/tests/test_data/study_wrong_type/manifest.toml
+++ b/tests/test_data/study_wrong_type/manifest.toml
@@ -1,7 +1,9 @@
 study_prefix = ["test"]
 
 [[stages.stage_1]]
+type = "build:serial"
 files = ["test.sql"]
 
-[export_config]
-count_list = ["test__table"]
+[[stages.stage_1]]
+type = "export:counts"
+tables = ["test__table"]

--- a/tests/test_data/upload/manifest.toml
+++ b/tests/test_data/upload/manifest.toml
@@ -1,7 +1,8 @@
 study_prefix = "upload"
 
 
-[export_config]
-count_list = [
+[[stages.stage_1]]
+type = "export:counts"
+tables = [
     "upload__count_synthea_patient",
 ]

--- a/tests/test_data/valueset/manifest.toml
+++ b/tests/test_data/valueset/manifest.toml
@@ -1,6 +1,7 @@
 study_prefix = "test"
 
 [[stages.stage_1]]
+type = "build:serial"
 files = [
     "valueset.toml"
 ]

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -18,8 +18,15 @@ from tests import conftest
                 {
                     "study_prefix": "study_valid",
                     "build_types": {"default": ["stage_1"], "all": ["stage_1"]},
-                    "stages": {"stage_1": [{"files": ["test.sql", "test2.sql"]}]},
-                    "export_config": {"count_list": ["study_valid__table", "study_valid__table2"]},
+                    "stages": {
+                        "stage_1": [
+                            {"type": "build:serial", "files": ["test.sql", "test2.sql"]},
+                            {
+                                "type": "export:counts",
+                                "tables": ["study_valid__table", "study_valid__table2"],
+                            },
+                        ]
+                    },
                 }
             ),
             does_not_raise(),
@@ -63,7 +70,10 @@ def test_get_prefix_with_seperator(manifest_path, prefix):
 
 
 def test_custom_pathing(tmp_path):
-    manifest_dict = {"study_prefix": "custom", "stages": {"stage_1": [{"files": ["bar"]}]}}
+    manifest_dict = {
+        "study_prefix": "custom",
+        "stages": {"stage_1": [{"type": "build:serial", "files": ["bar"]}]},
+    }
     conftest.write_toml(tmp_path, manifest_dict, "custom.toml")
     with pytest.raises(errors.StudyManifestFilesystemError):
         manifest = study_manifest.StudyManifest(tmp_path)
@@ -84,21 +94,23 @@ def test_submanifests(tmp_path):
         "stages": {
             "stage_1": [
                 {
+                    "type": "build:serial",
                     "description": "action 1",
                     "files": ["foo", "bar"],
                 },
                 {
+                    "type": "build:serial",
                     "description": "action 2",
                     "files": ["baz"],
                 },
             ],
-            "stage_2": [{"action_type": "submanifest", "files": ["file.submanifest"]}],
+            "stage_2": [{"type": "submanifest", "files": ["file.submanifest"]}],
         },
     }
     conftest.write_toml(tmp_path, manifest_dict)
     conftest.write_toml(
         tmp_path,
-        {"actions": [{"description": "subaction 1", "files": ["foobar"]}]},
+        {"actions": [{"type": "build:serial", "description": "subaction 1", "files": ["foobar"]}]},
         "file.submanifest",
     )
     manifest = study_manifest.StudyManifest(tmp_path)
@@ -107,10 +119,12 @@ def test_submanifests(tmp_path):
         "build_types": {"default": ["stage_1", "stage_2"], "all": ["stage_1", "stage_2"]},
         "stages": {
             "stage_1": [
-                {"description": "action 1", "files": ["foo", "bar"]},
-                {"description": "action 2", "files": ["baz"]},
+                {"description": "action 1", "type": "build:serial", "files": ["foo", "bar"]},
+                {"description": "action 2", "type": "build:serial", "files": ["baz"]},
             ],
-            "stage_2": [{"description": "subaction 1", "files": ["foobar"]}],
+            "stage_2": [
+                {"description": "subaction 1", "type": "build:serial", "files": ["foobar"]}
+            ],
         },
     }
 
@@ -125,7 +139,11 @@ def test_copy_manifest(tmp_path):
 
 def test_wrong_export_prefix(tmp_path):
     conftest.write_toml(
-        tmp_path, {"study_prefix": "foo", "export_config": {"count_list": ["bar__table"]}}
+        tmp_path,
+        {
+            "study_prefix": "foo",
+            "stages": {"stage_1": [{"type": "export:counts", "tables": ["bar__table"]}]},
+        },
     )
     manifest = study_manifest.StudyManifest(tmp_path)
     with pytest.raises(errors.StudyManifestParsingError):
@@ -152,7 +170,7 @@ def test_missing_action(tmp_path):
             "study_prefix": "foo",
             "build_types": {"default": ["stage_1"]},
             "stages": {
-                "stage_1": [{"description": "action 1", "files": ["foo"], "action_type": "invalid"}]
+                "stage_1": [{"description": "action 1", "files": ["foo"], "type": "invalid"}]
             },
         },
     )


### PR DESCRIPTION
This PR makes exports into another type of action, and does some additional reformatting of how the new manifest is structured as a result.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml` <- will do before v6.0 release
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json