### PR TITLE
Add `build --notes-dir` argument to pass notes in and filter on them

### DIFF
--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -21,6 +21,7 @@ from cumulus_library import (
     enums,
     errors,
     log_utils,
+    note_utils,
     study_manifest,
 )
 from cumulus_library.builders import (
@@ -45,6 +46,7 @@ def build_study(
     file_list: list | None = None,
     prepare: bool = False,
     data_path: pathlib.Path | None = None,
+    notes: note_utils.NoteSource | None = None,
 ) -> None:
     """Creates tables in the schema by iterating through the stages in the specified build type
 
@@ -55,6 +57,7 @@ def build_study(
     :keyword file_list: If provided, a list of files to build; otherwise pulled from manifest
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
+    :keyword notes: Source to read notes from (for NLP)
     """
     if prepare:
         _check_if_preparable(manifest.get_study_prefix())
@@ -111,6 +114,7 @@ def build_study(
                     manifest=manifest,
                     filename=file,
                     data_path=data_path,
+                    notes=notes,
                     prepare=prepare,
                     parallel=parallel,
                     query_count=query_count,
@@ -163,6 +167,7 @@ def build_matching_files(
     db_parser: databases.DatabaseParser = None,
     prepare: bool,
     data_path: pathlib.Path,
+    notes: note_utils.NoteSource | None = None,
 ):
     """targets all table builders matching a target string for running
 
@@ -172,6 +177,7 @@ def build_matching_files(
     :keyword db_parser: an object implementing DatabaseParser for the target database
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
+    :keyword notes: Source to read notes from (for NLP)
     """
     if prepare:
         _check_if_preparable(manifest.get_study_prefix())  # pragma: no cover
@@ -193,6 +199,7 @@ def build_matching_files(
         file_list=matches,
         prepare=prepare,
         data_path=data_path,
+        notes=notes,
     )
 
 
@@ -527,6 +534,7 @@ def _run_workflow(
     prepare: str,
     data_path: pathlib.Path,
     query_count: int,
+    notes: note_utils.NoteSource | None = None,
     parallel: bool = False,
 ) -> tuple[list[str], bool]:
     """Loads workflow config from toml definitions and executes workflow
@@ -536,6 +544,7 @@ def _run_workflow(
     :keyword filename: Filename of the workflow config
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
+    :keyword notes: Source to read notes from (for NLP)
     :keyword query_count: if prepare is true, the number of queries already rendered
     :keyword stage_name: the stage in the build currently being processed
     :keyword parallel; If true, execute queries in parallel if workflow allows
@@ -581,6 +590,7 @@ def _run_workflow(
             builder = nlp_builder.NlpBuilder(
                 manifest=manifest,
                 toml_config_path=toml_path,
+                notes=notes or note_utils.NoteSource(),
             )
         case "psm":
             existing_stats = []

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -2,10 +2,12 @@
 
 import pathlib
 import sys
+from collections.abc import Callable
 
 import msgspec
+import rich
 
-from cumulus_library import BaseTableBuilder
+from cumulus_library import BaseTableBuilder, note_utils
 
 # NLP is driven by a workflow config. See docs/workflows/nlp.md for more details
 # on syntax and expectations.
@@ -13,12 +15,12 @@ from cumulus_library import BaseTableBuilder
 
 class NlpShared(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
     system_prompt: str | None = None
-    user_prompt: str = "%CLINICAL-NOTE%"
-    select_by_word: list[str] = msgspec.field(default_factory=list)
-    select_by_regex: list[str] = msgspec.field(default_factory=list)
-    select_by_athena_table: str = ""
-    reject_by_word: list[str] = msgspec.field(default_factory=list)
-    reject_by_regex: list[str] = msgspec.field(default_factory=list)
+    user_prompt: str | None = None
+    select_by_word: list[str] | None = None
+    select_by_regex: list[str] | None = None
+    select_by_table: str | None = None  # TODO
+    reject_by_word: list[str] | None = None
+    reject_by_regex: list[str] | None = None
 
 
 class NlpTask(NlpShared):
@@ -37,30 +39,101 @@ class NlpBuilder(BaseTableBuilder):
     def __init__(
         self,
         *args,
-        toml_config_path: pathlib.Path | None = None,
+        toml_config_path: pathlib.Path,
+        notes: note_utils.NoteSource,
         **kwargs,
     ):
         super().__init__()
 
-        if toml_config_path:
-            try:
-                with open(toml_config_path, "rb") as file:
-                    file_bytes = file.read()
-                    self._workflow_config = msgspec.toml.decode(file_bytes, type=NlpWorkflow)
+        try:
+            with open(toml_config_path, "rb") as file:
+                file_bytes = file.read()
+                self._workflow_config = msgspec.toml.decode(file_bytes, type=NlpWorkflow)
 
-            except msgspec.ValidationError as e:
-                sys.exit(
-                    f"The NLP workflow at {toml_config_path!s} contains an unexpected param: \n{e}"
-                )
+        except Exception as e:
+            sys.exit(f"The NLP workflow at {toml_config_path!s} is invalid: \n{e}")
 
-        else:
-            self._workflow_config = None
+        self._flatten_config()
+
+        self._notes = notes
+        if not self._notes:
+            sys.exit(
+                "NLP workflow requested, but there are no notes to work with. "
+                "Pass --note-dir to provide a folder with FHIR resources like DiagnosticReport "
+                "or DocumentReference with inlined clinical notes."
+            )
+
+    def _flatten_config(self) -> None:
+        """Takes any non-specified task values from the [shared] table"""
+        fields = [x.name for x in msgspec.inspect.type_info(NlpShared).fields]
+        for task in self._workflow_config.task:
+            for field in fields:
+                if getattr(task, field) is None:
+                    shared_val = getattr(self._workflow_config.shared, field)
+                    setattr(task, field, shared_val)
+
+    def _make_note_filter(self, task: NlpTask) -> Callable[[dict, str], bool]:
+        return note_utils.make_note_filter(
+            reject_by_regex=task.reject_by_regex,
+            reject_by_word=task.reject_by_word,
+            select_by_regex=task.select_by_regex,
+            select_by_word=task.select_by_word,
+        )
+
+    def _print_note_stats(
+        self,
+        *,
+        names: list[str],
+        available: int,
+        had_text: int,
+        considered: list[int],
+        got_response: list[int],
+    ) -> None:
+        rich.print(" Notes processed:")
+        table = rich.table.Table("", "", box=None, show_header=False)
+        table.add_row(" Available:", f"{available:,}")
+        table.add_row(" Had text:", f"{had_text:,}")
+        for idx, name in enumerate(names):
+            suffix = f" ({name})" if name else ""
+            table.add_row(f" Considered{suffix}:", f"{considered[idx]:,}")
+            table.add_row(f" Got response{suffix}:", f"{got_response[idx]:,}")
+        rich.get_console().print(table)
 
     def prepare_queries(
         self,
         *args,
         **kwargs,
     ):
-        if not self._workflow_config:
-            return
-        # TODO: the actual NLP :D
+        # Set up some stat counters
+        available = 0
+        had_text = 0
+        considered = [0] * len(self._workflow_config.task)
+        got_response = [0] * len(self._workflow_config.task)
+
+        note_filters = [self._make_note_filter(task) for task in self._workflow_config.task]
+
+        # Go through notes one by one and run NLP on them
+        for note_res in self._notes.progress_iter("Running NLP..."):
+            available += 1
+
+            try:
+                text = note_utils.get_text_from_note_res(note_res)
+            except Exception:  # noqa: S112
+                continue
+            had_text += 1
+
+            for idx, task in enumerate(self._workflow_config.task):
+                if not note_filters[idx](note_res, text):
+                    continue
+                considered[idx] += 1
+
+                # TODO: the actual NLP :D
+
+        # Print stat block, because that's interesting feedback
+        self._print_note_stats(
+            names=[t.name for t in self._workflow_config.task],
+            available=available,
+            had_text=had_text,
+            considered=considered,
+            got_response=got_response,
+        )

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -19,6 +19,7 @@ from cumulus_library import (
     enums,
     errors,
     log_utils,
+    note_utils,
     study_manifest,
 )
 from cumulus_library.actions import (
@@ -89,6 +90,7 @@ class StudyRunner:
         continue_from: str | None = None,
         prepare: bool = False,
         data_path: pathlib.Path | None = None,
+        notes: note_utils.NoteSource | None = None,
     ) -> None:
         """Recreates study views/tables
 
@@ -97,6 +99,7 @@ class StudyRunner:
         :keyword continue_from: Restart a run from a specific sql file (for dev only)
         :keyword prepare: If true, will render query instead of executing
         :keyword data_path: If prepare is true, the path to write rendered data to
+        :keyword notes: Source to read notes from (for NLP)
         """
         manifest = study_manifest.StudyManifest(target, self.data_path, options=options)
         try:
@@ -126,6 +129,7 @@ class StudyRunner:
                 manifest=manifest,
                 continue_from=continue_from,
                 data_path=data_path,
+                notes=notes,
                 prepare=prepare,
             )
             if not prepare:
@@ -156,6 +160,7 @@ class StudyRunner:
         options: dict[str, str],
         prepare: bool = False,
         data_path: pathlib.Path,
+        notes: note_utils.NoteSource,
     ) -> None:
         """Runs a single table builder
 
@@ -164,6 +169,7 @@ class StudyRunner:
         :keyword options: The dictionary of study-specific options
         :keyword prepare: If true, will render query instead of executing
         :keyword data_path: If prepare is true, the path to write rendered data to
+        :keyword notes: Source to read notes from (for NLP)
         """
         manifest = study_manifest.StudyManifest(target, options=options)
         # In case someone is using the --builder command with a study that hasn't been run,
@@ -175,6 +181,7 @@ class StudyRunner:
             builder=table_builder_name,
             prepare=prepare,
             data_path=data_path,
+            notes=notes,
         )
 
     ### Data exporters
@@ -341,6 +348,7 @@ def run_cli(args: dict):
                     options=args["options"],
                 )
             elif args["action"] == "build":
+                notes = note_utils.NoteSource(args["note_dir"], s3_region={args["region"]})
                 for target in args["target"]:
                     if args["builder"]:
                         runner.build_matching_files(
@@ -349,6 +357,7 @@ def run_cli(args: dict):
                             options=args["options"],
                             prepare=args["prepare"],
                             data_path=args["data_path"],
+                            notes=notes,
                         )
                     else:
                         runner.clean_and_build_study(
@@ -357,6 +366,7 @@ def run_cli(args: dict):
                             options=args["options"],
                             prepare=args["prepare"],
                             data_path=args["data_path"],
+                            notes=notes,
                         )
 
             elif args["action"] == "export":
@@ -424,6 +434,7 @@ def main(cli_args=None):
         ("schema_name", "CUMULUS_LIBRARY_SCHEMA_NAME"),
         ("database", "CUMULUS_LIBRARY_DATABASE"),
         ("max_concurrent", "CUMULUS_LIBRARY_MAX_CONCURRENT"),
+        ("note_dir", "CUMULUS_LIBRARY_NOTE_DIR"),
         ("study_dir", "CUMULUS_LIBRARY_STUDY_DIR"),
         ("umls_key", "UMLS_API_KEY"),
         ("loinc_user", "LOINC_USER"),
@@ -439,7 +450,7 @@ def main(cli_args=None):
     for pair in arg_env_pairs:
         if args.get(pair[0]) is None:
             if env_val := os.environ.get(pair[1]):
-                if pair[0] == "study_dir":
+                if pair[0] in {"note_dir", "study_dir"}:
                     args[pair[0]] = [env_val]
                 else:
                     args[pair[0]] = env_val

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -114,6 +114,19 @@ def add_study_dir_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_note_dir_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--note-dir",
+        metavar="DIR",
+        action="append",
+        help=(
+            "One or more directories in which to look for FHIR resources holding clinical "
+            "notes (like DiagnosticReport and DocumentReference). Searched recursively. "
+            "Can be an s3:// URL or local path. Only relevant for NLP workflows."
+        ),
+    )
+
+
 def add_stage_argument(parser: argparse.ArgumentParser) -> None:
     """Adds --stage arg to a subparser"""
     parser.add_argument(
@@ -207,6 +220,7 @@ AWS Athena, the following order of preference is used to select credentials:
     add_data_path_argument(build)
     add_db_config(build, input_mode=True)
     add_study_dir_argument(build)
+    add_note_dir_argument(build)
     add_table_builder_argument(build)
     add_target_argument(build)
     add_verbose_argument(build)

--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -1,0 +1,312 @@
+import base64
+import dataclasses
+import email
+import os
+import re
+import urllib.parse
+from collections.abc import Callable, Generator
+
+import cumulus_fhir_support as cfs
+import fsspec
+import inscriptis
+
+from cumulus_library import base_utils
+
+#########################
+# Reading notes from disk
+#########################
+
+
+class RemoteAttachment(ValueError):
+    """A note was requested, but it was only available remotely"""
+
+
+@dataclasses.dataclass(kw_only=True)
+class _FileInfo:
+    fs: fsspec.AbstractFileSystem
+    path: str
+    size: int
+
+
+class NoteSource:
+    def __init__(self, note_dirs: list[str] | None = None, *, s3_region: str | None = None):
+        self._files: list[_FileInfo] | None = None
+        self._total_size = 0
+
+        self._note_dirs = note_dirs
+        self._s3_region = s3_region
+
+    def __bool__(self) -> bool:
+        return bool(self._note_dirs)
+
+    def progress_iter(self, label: str) -> Generator[dict]:
+        with base_utils.get_progress_bar() as progress:
+            task = progress.add_task(label, total=None)
+            self._scan()
+            progress.update(task, total=self._total_size)
+            for file in self._files:
+                offset = 0
+                for row in cfs.read_multiline_json_with_details(file.path, fsspec_fs=file.fs):
+                    offset = row["byte_offset"]
+                    progress.advance(task, offset)
+                    yield row["json"]
+                progress.advance(task, file.size - offset)
+
+    def _scan(self) -> None:
+        """Lazily ensure that we've scanned files"""
+        if self._files is not None:
+            return  # already scanned
+
+        self._files = self._flatten_note_dirs()
+        self._total_size = sum(f.size for f in self._files)
+
+    def _flatten_note_dirs(self) -> list[_FileInfo]:
+        """Converts a list of folders into a list of found filenames.
+
+        Flattening like this is useful for performance reasons, to only scan the dirs once.
+        For similar performance reason, when using the list of files, please have care with the
+        number of times we actually read through them.
+        """
+        note_types = {"DiagnosticReport", "DocumentReference"}
+
+        infos = []
+        for one_dir in self._note_dirs or []:
+            one_dir = str(one_dir)  # allow pathlib.Path objects but stringify them here
+            parsed = urllib.parse.urlparse(one_dir)
+            protocol = parsed.scheme or "file"
+            one_dir = one_dir if parsed.scheme else os.path.abspath(one_dir)
+
+            # Initialize a fsspec filesystem
+            options = {}
+            if protocol == "s3" and self._s3_region:
+                options["client_kwargs"] = {"region_name": self._s3_region}
+            fs = fsspec.filesystem(protocol, **options)
+
+            # Actually scan for matching files
+            paths = list(
+                cfs.list_multiline_json_in_dir(one_dir, note_types, fsspec_fs=fs, recursive=True)
+            )
+            sizes = fs.sizes(paths)
+            for idx, path in enumerate(paths):
+                infos.append(_FileInfo(fs=fs, path=path, size=sizes[idx]))
+
+        return infos
+
+
+######################
+# Note text extraction
+######################
+
+
+def get_text_from_note_res(note_res: dict) -> str:
+    """
+    Returns the clinical text contained in the given note resource.
+
+    It will try to find the simplest version (plain text) or convert html to plain text if needed.
+
+    Will raise an exception if text cannot be found.
+    """
+    attachment = _get_clinical_note_attachment(note_res)
+    text = _get_note_from_attachment(attachment)
+
+    mimetype, _ = _parse_content_type(attachment["contentType"])
+    if mimetype in {"text/html", "application/xhtml+xml"}:
+        # An HTML note can confuse/stall NLP.
+        # It may include mountains of spans/styling or inline base64 images that aren't relevant
+        # to our interests.
+        #
+        # Inscriptis makes a very readable version of the note, with a focus on maintaining the
+        # HTML layout.
+        text = inscriptis.get_text(text)
+
+    return text.strip()
+
+
+def _parse_content_type(content_type: str) -> (str, str):
+    """Returns (mimetype, encoding)"""
+    msg = email.message.EmailMessage()
+    msg["content-type"] = content_type
+    return msg.get_content_type(), msg.get_content_charset("utf8")
+
+
+def _mimetype_priority(mimetype: str) -> int:
+    """
+    Returns priority of mimetypes for docref notes.
+
+    0 means "ignore"
+    Higher numbers are higher priority
+    """
+    if mimetype == "text/plain":
+        return 3
+    elif mimetype == "text/html":
+        return 2
+    elif mimetype == "application/xhtml+xml":
+        return 1
+    return 0
+
+
+def _get_note_from_attachment(attachment: dict) -> str:
+    """
+    Decodes or downloads a note from an attachment.
+
+    Note that it is assumed a contentType is provided.
+
+    :returns: the attachment's note text
+    """
+    _mimetype, charset = _parse_content_type(attachment["contentType"])
+
+    if attachment.get("data") is not None:
+        return base64.standard_b64decode(attachment["data"]).decode(charset)
+
+    if attachment.get("url") is not None:
+        raise RemoteAttachment(
+            "Some clinical note texts are only available via URL. "
+            "You may want to inline your notes with SMART Fetch."
+        )
+
+    # Shouldn't ever get here, because get_clinical_note_attachment already checks this,
+    # but just in case...
+    raise ValueError("No data or url field present")  # pragma: no cover
+
+
+def _get_clinical_note_attachment(resource: dict) -> dict:
+    match resource["resourceType"]:
+        case "DiagnosticReport":
+            attachments = resource.get("presentedForm", [])
+        case "DocumentReference":
+            attachments = [
+                content["attachment"]
+                for content in resource.get("content", [])
+                if "attachment" in content
+            ]
+        case _:
+            raise ValueError(f"{resource['resourceType']} is not a supported clinical note type.")
+
+    # Find the best attachment to use, based on mimetype.
+    # We prefer basic text documents, to avoid confusing NLP with extra formatting (like <body>).
+    best_attachment_index = -1
+    best_attachment_priority = 0
+    for index, attachment in enumerate(attachments):
+        if "contentType" in attachment:
+            mimetype, _ = _parse_content_type(attachment["contentType"])
+            priority = _mimetype_priority(mimetype)
+            if priority > best_attachment_priority:
+                best_attachment_priority = priority
+                best_attachment_index = index
+
+    if best_attachment_index < 0:
+        # We didn't find _any_ of our target text content types.
+        raise ValueError("No textual mimetype found")
+
+    attachment = attachments[best_attachment_index]
+
+    if attachment.get("data") is None and not attachment.get("url"):
+        raise ValueError("No data or url field present")
+
+    return attachments[best_attachment_index]
+
+
+################
+# Note filtering
+################
+
+
+_ESCAPED_WHITESPACE = re.compile(r"(\\\s)+")
+
+
+def make_note_filter(
+    reject_by_regex: list[str] | None = None,
+    reject_by_word: list[str] | None = None,
+    select_by_regex: list[str] | None = None,
+    select_by_word: list[str] | None = None,
+) -> Callable[[dict, str], bool]:
+    pattern = _compile_filter_regex(
+        reject_by_regex=reject_by_regex,
+        reject_by_word=reject_by_word,
+        select_by_regex=select_by_regex,
+        select_by_word=select_by_word,
+    )
+
+    def note_filter(note_res: dict, text: str) -> bool:
+        if not _filter_status(note_res):
+            return False
+
+        if pattern.search(text) is None:
+            return False
+
+        return True
+
+    return note_filter
+
+
+def _filter_status(note_res: dict) -> bool:
+    """If the resource status is WIP, obsolete, or entered-in-error, reject it"""
+    match note_res.get("resourceType"):
+        case "DiagnosticReport":
+            valid_status_types = {"final", "amended", "corrected", "appended", "unknown", None}
+            return note_res.get("status") in valid_status_types
+
+        case "DocumentReference":
+            good_status = note_res.get("status") in {"current", None}  # status of DocRef itself
+            # docStatus is status of clinical note attachments
+            good_doc_status = note_res.get("docStatus") in {"final", "amended", None}
+            return good_status and good_doc_status
+
+        case _:  # pragma: no cover
+            return False  # pragma: no cover
+
+
+def _user_regex_to_pattern(term: str) -> str:
+    """Takes a user search regex and adds some boundaries to it"""
+    # Make a custom version of \b that allows non-word characters to be on edge of the term too.
+    # For example:
+    #   This misses: re.match(r"\ba\+\b", "a+")
+    #   But this hits: re.match(r"\ba\+", "a+")
+    # So to work around that, we look for the word boundary ourselves.
+    edge = r"(\W|$|^)"
+    return f"{edge}({term}){edge}"
+
+
+def _user_word_to_pattern(term: str) -> str:
+    """Takes a user search term and turns it into a clinical-note-appropriate regex"""
+    term = re.escape(term)
+    # Allow multi-word "words" (like "severe cough") have any kind of whitespace in between them,
+    # as they may cross line endings in the note (which can happen for normal paragraph wrapping).
+    term = _ESCAPED_WHITESPACE.sub(r"\\s+", term)
+    return _user_regex_to_pattern(term)
+
+
+def _combine_regexes(*, by_regex: list[str] | None, by_word: list[str] | None) -> str:
+    patterns = []
+    if by_regex:
+        patterns.extend(_user_regex_to_pattern(regex) for regex in by_regex)
+    if by_word:
+        patterns.extend(_user_word_to_pattern(word) for word in by_word)
+    return "|".join(patterns)
+
+
+def _compile_filter_regex(
+    *,
+    reject_by_regex: list[str] | None,
+    reject_by_word: list[str] | None,
+    select_by_regex: list[str] | None,
+    select_by_word: list[str] | None,
+) -> re.Pattern:
+    select = _combine_regexes(by_word=select_by_word, by_regex=select_by_regex)
+
+    reject = _combine_regexes(by_word=reject_by_word, by_regex=reject_by_regex)
+    if reject:
+        # Use negative lookahead
+        reject = rf"^(?!.*{reject})"
+
+    if reject and select:
+        # Add positive lookahead
+        final = f"{reject}(?=.*{select})"
+    elif reject:
+        final = reject
+    elif select:
+        final = select
+    else:
+        final = ""  # an empty pattern will match anything
+
+    return re.compile(final, re.IGNORECASE)

--- a/cumulus_library/studies/example_nlp/manifest.toml
+++ b/cumulus_library/studies/example_nlp/manifest.toml
@@ -3,14 +3,14 @@
 
 study_prefix = "example_nlp"
 
-[[stages.example_build]]
+[[stages.nlp]]
 description = "NLP"
 files = [
     "nlp.workflow",
 ]
 type = "build:serial"
 
-[[stages.example_build]]
+[[stages.ranges]]
 description = "Range calculation"
 files = [
     "calculate_ranges.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ dependencies = [
     "awswrangler >= 3.11, < 4",
     "cumulus-fhir-support >= 1.6",
     "duckdb >= 1.4.1, <1.5.0",
+    "fsspec[s3]",
+    "inscriptis",
     "Jinja2 > 3",
     "openpyxl",
     "msgspec",

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -1,19 +1,104 @@
+import base64
+import contextlib
+import io
+import json
+
 import pytest
 
+from cumulus_library import note_utils
 from cumulus_library.builders import nlp_builder
 
 
-def test_ignored_with_no_args():
-    builder = nlp_builder.NlpBuilder()
-    builder.prepare_queries()  # just confirm it doesn't blow up or do something bad
+def add_dxr(text: str | None, file) -> None:
+    dxr = {"resourceType": "DiagnosticReport"}
+    if text is not None:
+        dxr["presentedForm"] = [
+            {
+                "contentType": "text/plain",
+                "data": base64.standard_b64encode(text.encode()).decode(),
+            }
+        ]
+    json.dump(dxr, file)
+    file.write("\n")
 
 
-def test_unexpected_config_field(tmp_path):
+@pytest.fixture
+def note_source(tmp_path) -> note_utils.NoteSource:
+    """Just make a sample note source with a row - contents not important"""
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr(None, f)
+    yield note_utils.NoteSource([tmp_path])
+
+
+def test_unexpected_config_field(tmp_path, note_source):
     workflow_path = f"{tmp_path}/nlp.workflow"
     with open(workflow_path, "w", encoding="utf8") as f:
         f.write("""
 config_type="nlp"
 extra_field="yup"
 """)
-    with pytest.raises(SystemExit, match="contains an unexpected param:"):
-        nlp_builder.NlpBuilder(toml_config_path=workflow_path)
+    with pytest.raises(SystemExit, match="contains unknown field `extra_field`"):
+        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+
+
+def test_empty_note_dir(tmp_path):
+    workflow_path = f"{tmp_path}/nlp.workflow"
+    with open(workflow_path, "w", encoding="utf8") as f:
+        f.write('config_type="nlp"\n[[task]]')
+    with pytest.raises(SystemExit, match="there are no notes to work with"):
+        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_utils.NoteSource())
+
+
+def test_flattened_config(tmp_path, note_source):
+    workflow_path = f"{tmp_path}/nlp.workflow"
+    with open(workflow_path, "w", encoding="utf8") as f:
+        f.write("""
+config_type="nlp"
+[shared]
+system_prompt="hello"
+[[task]]
+name="override"
+system_prompt="bye"
+[[task]]
+name="fallthrough"
+""")
+    builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+    assert builder._workflow_config.task[0].system_prompt == "bye"
+    assert builder._workflow_config.task[1].system_prompt == "hello"
+
+
+def test_filter(tmp_path):
+    workflow_path = f"{tmp_path}/nlp.workflow"
+    with open(workflow_path, "w", encoding="utf8") as f:
+        f.write("""
+config_type="nlp"
+[[task]]
+name="filtered"
+select_by_word=["fever"]
+reject_by_word=["cold"]
+[[task]]
+name="all"
+""")
+
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr(None, f)  # no text, will be skipped
+        add_dxr("hello world", f)  # ignored by filters
+        add_dxr("has fever", f)  # selected by filters
+        add_dxr("has fever and cold", f)  # rejected by filters
+
+    source = note_utils.NoteSource([tmp_path])
+
+    builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=source)
+
+    expected_stats = """ Notes processed:
+  Available:                4 
+  Had text:                 3 
+  Considered (filtered):    1 
+  Got response (filtered):  0 
+  Considered (all):         3 
+  Got response (all):       0 """
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries()
+    assert expected_stats in console_output.getvalue()

--- a/tests/studies/test_example_nlp.py
+++ b/tests/studies/test_example_nlp.py
@@ -5,12 +5,14 @@ import json
 import duckdb
 import pandas
 
+from cumulus_library import cli
 from tests import testbed_utils
+from tests.conftest import duckdb_args
 
 
 def test_empty_build(tmp_path):
     testbed = testbed_utils.LocalTestbed(tmp_path)
-    db = testbed.build("example_nlp")
+    db = testbed.build("example_nlp", stage="ranges")
     df = db.connection.sql("SELECT * FROM example_nlp__range_labels").df()
     assert df.empty  # should exist, but be empty
 
@@ -54,7 +56,7 @@ def test_merging_two_sources(tmp_path):
     )
     con.sql("CREATE TABLE example_nlp__nlp_llama4_scout AS SELECT * FROM llama4_df")
 
-    db = testbed.build("example_nlp")
+    db = testbed.build("example_nlp", stage="ranges")
     df = db.connection.sql(
         "SELECT * FROM example_nlp__range_labels ORDER BY note_ref, origin, span"
     ).df()
@@ -96,3 +98,25 @@ def test_merging_two_sources(tmp_path):
             "origin": "example_nlp__nlp_llama4_scout",
         },
     ]
+
+
+def test_full_build(tmp_path):
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        json.dump({"resourceType": "DiagnosticReport"}, f)
+
+    build_args = duckdb_args(
+        [
+            "build",
+            "-t",
+            "example_nlp",
+            str(tmp_path),
+            "--stage",
+            "all",
+            "--note-dir",
+            str(tmp_path),
+        ],
+        tmp_path,
+    )
+
+    # For now, just test that it doesn't blow up
+    cli.main(cli_args=build_args)

--- a/tests/test_note_utils.py
+++ b/tests/test_note_utils.py
@@ -1,0 +1,384 @@
+import base64
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from cumulus_library import (
+    note_utils,
+)
+
+
+@mock.patch("rich.progress.Progress.advance")
+def test_note_source_iter(mock_advance, tmp_path):
+    dxr1 = json.dumps({"resourceType": "DiagnosticReport", "id": "dxr1"})
+    dxr2 = json.dumps({"resourceType": "DiagnosticReport", "id": "dxr2"})
+    docref1 = json.dumps({"resourceType": "DocumentReference", "id": "docref1"})
+    docref2 = json.dumps({"resourceType": "DocumentReference", "id": "docref2"})
+
+    os.makedirs(f"{tmp_path}/1")
+    with open(f"{tmp_path}/1/dxr.ndjson", "w", encoding="utf8") as f:
+        f.write(f"{dxr1}\n{dxr2}")
+    # Write patient file, which should be ignored
+    with open(f"{tmp_path}/1/pat.ndjson", "w", encoding="utf8") as f:
+        json.dump({"resourceType": "Patient", "id": "pat1"}, f)
+
+    os.makedirs(f"{tmp_path}/2/subdir")  # confirm we are checking recursively w/ a subdir
+    with open(f"{tmp_path}/2/subdir/docref.ndjson", "w", encoding="utf8") as f:
+        f.write(f"{docref1}\n{docref2}")
+
+    source = note_utils.NoteSource([f"{tmp_path}/1", f"{tmp_path}/2"])
+
+    ids = [x["id"] for x in source.progress_iter("testing")]
+    assert ids == ["dxr1", "dxr2", "docref1", "docref2"]
+
+    skips = [call[0][1] for call in mock_advance.call_args_list]
+    assert skips == [0, len(dxr1) + 1, len(dxr2), 0, len(docref1) + 1, len(docref2)]
+
+    # Confirm we can iterate twice
+    ids = [x["id"] for x in source.progress_iter("testing")]
+    assert ids == ["dxr1", "dxr2", "docref1", "docref2"]
+
+
+@mock.patch("cumulus_fhir_support.list_multiline_json_in_dir", return_value=["a"])
+@mock.patch("cumulus_fhir_support.read_multiline_json_with_details", return_value=[])
+@mock.patch("fsspec.filesystem")
+def test_note_source_s3(mock_filesystem, mock_read, mock_list):
+    """Confirm that we correctly create and pass the fsspec object around - no actual I/O here"""
+    fs = mock_filesystem.return_value
+    fs.sizes.return_value = [10]
+
+    source = note_utils.NoteSource(["s3://mockbucket/"], s3_region="cloud9")
+
+    assert list(source.progress_iter("testing")) == []
+    assert mock_filesystem.call_args == mock.call("s3", client_kwargs={"region_name": "cloud9"})
+    assert mock_list.call_args[1]["fsspec_fs"] == fs
+    assert mock_read.call_args[1]["fsspec_fs"] == fs
+
+
+@pytest.mark.parametrize(
+    "res_type,attachments,result",
+    [
+        (  # simple DxReport text
+            "DiagnosticReport",
+            [("text/plain", "hello", "url")],
+            "hello",
+        ),
+        (  # simple DocRef text
+            "DocumentReference",
+            [("text/plain", "hello", "url")],
+            "hello",
+        ),
+        (  # prefer text over any html variant
+            "DocumentReference",
+            [
+                ("text/html", "html", None),
+                ("text/plain", "text", None),
+                ("application/xhtml+xml", "xhtml", None),
+            ],
+            "text",
+        ),
+        (  # prefer html over xhtml
+            "DocumentReference",
+            [("text/html", "html", None), ("application/xhtml+xml", "xhtml", None)],
+            "html",
+        ),
+        (  # but accept xhtml
+            "DocumentReference",
+            [("application/xhtml+xml", "xhtml", None)],
+            "xhtml",
+        ),
+        (  # strips html
+            "DocumentReference",
+            [("text/html", "<html><body>He<b>llooooo</b></html>", None)],
+            "Hellooooo",
+        ),
+        (  # strips xhtml
+            "DocumentReference",
+            [("application/xhtml+xml", "<html><body>He<b>llooooo</b></html>", None)],
+            "Hellooooo",
+        ),
+        (  # does not strips text
+            "DocumentReference",
+            [("text/plain", "<html><body>He<b>llooooo</b></html>", None)],
+            "<html><body>He<b>llooooo</b></html>",
+        ),
+        (  # strips surrounding whitespace
+            "DocumentReference",
+            [("text/plain", "\n\n hello   world \n\n", None)],
+            "hello   world",
+        ),
+        (  # respects charset
+            "DiagnosticReport",
+            [("text/plain; charset=utf16", b"\xff\xfeh\x00e\x00l\x00l\x00o\x00", None)],
+            "hello",
+        ),
+        (  # bad charset
+            "DiagnosticReport",
+            [("text/plain", b"\xff\xfeh\x00e\x00l\x00l\x00o\x00", None)],
+            pytest.raises(UnicodeDecodeError, match="invalid start byte"),
+        ),
+        (  # unsupported mime type
+            "DiagnosticReport",
+            [("application/pdf", "pdf", None)],
+            pytest.raises(ValueError, match="No textual mimetype found"),
+        ),
+        (  # no attachments
+            "DiagnosticReport",
+            [],
+            pytest.raises(ValueError, match="No textual mimetype found"),
+        ),
+        (  # url only
+            "DiagnosticReport",
+            [("text/plain", None, "url")],
+            pytest.raises(note_utils.RemoteAttachment, match="only available via URL"),
+        ),
+        (  # bad resource type
+            "Patient",
+            [],
+            pytest.raises(ValueError, match="Patient is not a supported clinical note type"),
+        ),
+        (  # no data or url
+            "DocumentReference",
+            [("text/plain", None, None)],
+            pytest.raises(ValueError, match="No data or url field present"),
+        ),
+    ],
+)
+def test_get_text_from_note_res(res_type, attachments, result):
+    note_res = {"resourceType": res_type}
+
+    # Build attachment list
+    attachments = [
+        {
+            "contentType": attachment[0],
+            "data": attachment[1],
+            "url": attachment[2],
+        }
+        for attachment in attachments
+    ]
+    for attachment in attachments:
+        if data := attachment["data"]:
+            if isinstance(data, str):
+                data = data.encode()
+            attachment["data"] = base64.standard_b64encode(data).decode()
+    if res_type == "DiagnosticReport":
+        note_res["presentedForm"] = attachments
+    elif res_type == "DocumentReference":
+        note_res["content"] = [{"attachment": a} for a in attachments]
+
+    # Grab text and compare
+    if isinstance(result, str):
+        assert note_utils.get_text_from_note_res(note_res) == result
+    else:
+        with result:
+            note_utils.get_text_from_note_res(note_res)
+
+
+@pytest.mark.parametrize(
+    "res,text,kwargs,selected",
+    [
+        (  # default, no regexes, no status - should pass
+            {"resourceType": "DiagnosticReport"},
+            "",
+            {},
+            True,
+        ),
+        (  # unsupported type
+            {"resourceType": "Patient"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "status": "registered"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "status": "partial"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "status": "preliminary"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "status": "cancelled"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DiagnosticReport", "status": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DocumentReference", "status": "superseded"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad status
+            {"resourceType": "DocumentReference", "status": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad docStatus
+            {"resourceType": "DocumentReference", "docStatus": "preliminary"},
+            "",
+            {},
+            False,
+        ),
+        (  # bad docStatus
+            {"resourceType": "DocumentReference", "docStatus": "entered-in-error"},
+            "",
+            {},
+            False,
+        ),
+        (  # select word (negative case)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_word": ["bye"]},
+            False,
+        ),
+        (  # select word (positive case)
+            {"resourceType": "DiagnosticReport"},
+            "hello, world",
+            {"select_by_word": ["hello"]},
+            True,
+        ),
+        (  # select word (multiple selections, or'd together)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_word": ["bye", "hello"]},
+            True,
+        ),
+        (  # select word (weird characters)
+            {"resourceType": "DiagnosticReport"},
+            "hel*lo.1+ world",
+            {"select_by_word": ["hel*lo.1+"]},
+            True,
+        ),
+        (  # select word (substring isn't matched)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_word": ["hell"]},
+            False,
+        ),
+        (  # select word (multi word)
+            {"resourceType": "DiagnosticReport"},
+            "hello world, mr smith",
+            {"select_by_word": ["mr smith"]},
+            True,
+        ),
+        (  # select regex (matches)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_regex": ["hell."]},
+            True,
+        ),
+        (  # select regex (can cross word boundaries)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_regex": ["hell.*d"]},
+            True,
+        ),
+        (  # select regex (can cross word boundaries, but still respects word ends)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_regex": ["hell.*r"]},
+            False,
+        ),
+        (  # select word and regex (matches either)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"select_by_word": ["world"], "select_by_regex": ["h."]},
+            True,
+        ),
+        (  # reject word (by itself, without matching, we should select note)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_word": ["bye"]},
+            True,
+        ),
+        (  # reject word (by itself, with matching, we should reject note)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_word": ["hello"]},
+            False,
+        ),
+        (  # reject word (multiple options, will reject either)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_word": ["hello", "bye"]},
+            False,
+        ),
+        (  # reject word (and select it, reject should win)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_word": ["hello"], "select_by_word": ["hello"]},
+            False,
+        ),
+        (  # reject word (miss) and select word (hit)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_word": ["bye"], "select_by_word": ["hello"]},
+            True,
+        ),
+        (  # reject regex (simple match)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_regex": ["he..o"]},
+            False,
+        ),
+        (  # reject regex (across words)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_regex": ["he.*rld"]},
+            False,
+        ),
+        (  # reject word and regex (either should reject)
+            {"resourceType": "DiagnosticReport"},
+            "hello world",
+            {"reject_by_regex": ["he..o"], "reject_by_word": ["bye"]},
+            False,
+        ),
+        (  # select on non-first lines
+            {"resourceType": "DiagnosticReport"},
+            "hello\nworld",
+            {"select_by_word": ["world"]},
+            True,
+        ),
+        (  # reject on non-first lines
+            {"resourceType": "DiagnosticReport"},
+            "hello\nworld",
+            {"reject_by_word": ["world"]},
+            False,
+        ),
+        (  # select across lines and whitespace, if multiple words provided
+            {"resourceType": "DiagnosticReport"},
+            "hello  \n  world",
+            {"select_by_word": ["hello world"]},
+            True,
+        ),
+        (  # (don't) select across lines with other stuff in there, confirming a lack of match
+            {"resourceType": "DiagnosticReport"},
+            "hello\n.world",
+            {"select_by_word": ["hello world"]},
+            False,
+        ),
+    ],
+)
+def test_note_filter(res, text, kwargs, selected):
+    note_filter = note_utils.make_note_filter(**kwargs)
+    assert selected == note_filter(res, text), kwargs

--- a/tests/testbed_utils.py
+++ b/tests/testbed_utils.py
@@ -255,7 +255,7 @@ class LocalTestbed:
     def get_db_file(self, study: str = "core") -> str:
         return f"{self.path}/{study}.db"
 
-    def build(self, study: str = "core") -> duckdb.DuckDatabaseBackend:
+    def build(self, study: str = "core", stage: str = "default") -> duckdb.DuckDatabaseBackend:
         db_file = self.get_db_file(study)
         db, _ = create_db_backend(
             {
@@ -271,6 +271,7 @@ class LocalTestbed:
         config = base_utils.StudyConfig(
             db=db,
             schema="main",
+            stage=stage,
             # verbose=True,
         )
         study_runner = cli.StudyRunner(config, data_path=str(self.path))


### PR DESCRIPTION
This adds some code to read through notes on disk during NLP workflows and also enables the NLP select/reject filters to sift through them.

This ports over the note filter and text-extraction code from the ETL, but with three change:
- We always filter note resources by status now, which was only previously done on the ETL side if no filters were defined. But it's probably always a good idea to skip preliminary and error notes.
- If searching for a multi-word term like "severe fever", we now match across lines, to account for paragraph wrapping which can happen at any point.
- We use negative lookahead to stuff the reject regexes into the same regex as the selection regexes, as a tiny optimization.

Next steps are:
- Add filtering-by-athena-table
- Move the text-extraction and filtering to cfs because it should be shared between Library and the ETL (which will continue to need this for other features like upload-notes and sample), but I want to wait on that until I now the fuller shape of this once athena tables are added.


### Checklist
- [ ] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [ ] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [ ] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml`
- [ ] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json