### PR TITLE
Changed the default stage behavior to match "all"

### DIFF
--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -243,7 +243,7 @@ class StudyManifest:
         stage_contents = self._study_config.get("stages", {}).get(stage, [])
         # if we're looking for a default stage and we don't find it, assume we should run everything
         if stage == "default" and stage_contents == []:
-            stage_contents = self._study_config.get("stages", {})["all"]
+            stage_contents = self._study_config.get("stages", {}).get("all", [])
         return stage_contents
 
     def get_file_list(

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -1,5 +1,6 @@
 """Class for loading study configuration data from manifest.toml files"""
 
+import copy
 import dataclasses
 import pathlib
 import re
@@ -192,10 +193,6 @@ class StudyManifest:
                     all_actions.append(action)
             config["stages"][stage] = actions
 
-        # if there isn't a default stage, we'll assume that we should run the first one
-        if "default" not in defined_stages:
-            config["stages"]["default"] = config["stages"][defined_stages[0]]
-
         config["stages"]["all"] = all_actions
 
         # We'll set these to class vars now so we can reuse the class getters
@@ -243,7 +240,11 @@ class StudyManifest:
 
     def get_stage(self, stage) -> list:
         """Returns the contents of the specified stage"""
-        return self._study_config.get("stages", {}).get(stage, [])
+        stage_contents = self._study_config.get("stages", {}).get(stage, [])
+        # if we're looking for a default stage and we don't find it, assume we should run everything
+        if stage == "default" and stage_contents == []:
+            stage_contents = self._study_config.get("stages", {})["all"]
+        return stage_contents
 
     def get_file_list(
         self,
@@ -366,10 +367,10 @@ class StudyManifest:
             path = path / "manifest.toml"
         path.parent.mkdir(exist_ok=True, parents=True)
         with open(path, "wb") as f:
-            # we'll remove the all key we auto created before writing out a copy
-            config = self._study_config
+            config = copy.deepcopy(self._study_config)
             config["stages"].pop("all", None)
-            f.write(msgspec.toml.encode(ManifestConfig(self._study_config)))
+            # we'll remove the all key we auto created before writing out a copy
+            f.write(msgspec.toml.encode(ManifestConfig(config)))
 
     ### Dynamic Python code support
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -207,13 +207,13 @@ directory, with the following contents:
 ```toml
 study_prefix = "example"
 description = "An example study looking at medication usage by preteens with bronchitis"
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables" # this is shown when the study is being built
 files = [ "queries/study_population.sql" ]
 ```
 
 {:.note } 
-The `[[stages.default]]` syntax indicates that we're adding the data below it to a list.
+The `[[stages.cohort]]` syntax indicates that we're adding the data below it to a list.
 We'll use this pattern repeatedly to add actions to our study.
 
 Let's go ahead and build our study, just to make sure that everything is working correctly.
@@ -344,11 +344,11 @@ action to our manifest.toml to run this workflow:
 ```toml
 study_prefix = "example"
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables" # this is shown when the study is being built
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets"
 files = [ "workflows/upload.workflow" ]
 ```
@@ -403,15 +403,15 @@ And we'll add a new action to our manifest to handle building this table:
 ```toml
 study_prefix = "example"
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables" # this is shown when the study is being built
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets"
 files = [ "workflows/upload.workflow" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "bronchitis cohort definition"
 files = [ "queries/bronchitis_condition.sql" ]
 ```
@@ -467,18 +467,18 @@ So our manifest now looks like this:
 ```toml
 study_prefix = "example"
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables"
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets & define cohort"
 files = [ 
     "workflows/upload.workflow",
     "queries/bronchitis_condition.sql"
 ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "bronchitis cohort additional resources"
 type = "build:parallel"
 files = [ 
@@ -572,7 +572,7 @@ and replacing them with new ones, and if the underlying data changes, the shape 
 also change. 
 
 Since we're in the analysis phase, we're going to make use of the concept of a *stage* - we've been
-doing this already, every time we've used `[[stages.default]]` in the manifest. A study can support
+doing this already, every time we've used `[[stages.cohort]]` in the manifest. A study can support
 more than one stage, and only cleans up the tables associated with the stage you're running. So, let's
 add a new stage, `analysis`, and add a file upload workflow there as well.
 
@@ -592,18 +592,18 @@ And then we'll update the manifest to reference that stage:
 ```toml
 study_prefix = "example"
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables"
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets & define cohort"
 files = [ 
     "workflows/upload.workflow",
     "queries/bronchitis_condition.sql"
 ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "bronchitis cohort additional resources"
 type = "build:parallel"
 files = [ 
@@ -619,8 +619,15 @@ files = [
 ]
 ```
 
-To run this, we're going to add a `--stage` command to the arguments we've been using up until this
-point:
+By default, we'll run all stages in the order they are found in the manifest. If we didn't like
+this behavior, there are two things we could do:
+
+- If we create a stage named `default`, that stage is the only one that will be run unless we specify
+otherwise
+- We can use the `--stage` command to run a single stage of our choice.
+
+Let's use the second one here. We're going to add a `--stage` command to the arguments we've been using
+up until this point:
 
 - For DuckDB:
   ```bash
@@ -716,18 +723,18 @@ And now we'll add this file to our action in the analysis stage:
 ```toml
 study_prefix = "example"
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables"
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets & define cohort"
 files = [ 
     "workflows/upload.workflow",
     "queries/bronchitis_condition.sql"
 ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "bronchitis cohort additional resources"
 type = "build:parallel"
 files = [ 
@@ -858,18 +865,18 @@ This study was designed to run against the 1000 patient sample bulk FHIR dataset
 intended to show how building a study works, while providing a realistic use case for
 anchoring the clinical context."""
 
-[[stages.default]]
+[[stages.cohort]]
 label = "study population tables"
 files = [ "queries/study_population.sql" ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "upload valuesets & define cohort"
 files = [ 
     "workflows/upload.workflow",
     "queries/bronchitis_condition.sql"
 ]
 
-[[stages.default]]
+[[stages.cohort]]
 label = "bronchitis cohort additional resources"
 type = "build:parallel"
 files = [ 

--- a/docs/study-configuration.md
+++ b/docs/study-configuration.md
@@ -86,7 +86,7 @@ study with some descriptive text. \
 
 # There are two special kinds of stage names:
 # - 'default': this stage will be run if the stage is not specified. If not defined,
-#   we'll use the first stage in the list as the default.
+#   we'll assume we should use the 'all' behavior
 # - 'all': this will run all the stages, in the order they are defined in the manifest.
 #    This behavior can't be overriden.
 

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -25,13 +25,6 @@ from tests import conftest
                                 "tables": ["study_valid__table", "study_valid__table2"],
                             },
                         ],
-                        "default": [
-                            {"type": "build:serial", "files": ["test.sql", "test2.sql"]},
-                            {
-                                "type": "export:counts",
-                                "tables": ["study_valid__table", "study_valid__table2"],
-                            },
-                        ],
                         "stage_1": [
                             {"type": "build:serial", "files": ["test.sql", "test2.sql"]},
                             {
@@ -135,10 +128,6 @@ def test_submanifests(tmp_path):
                 {"label": "action 2", "type": "build:serial", "files": ["baz"]},
                 {"label": "subaction 1", "type": "build:serial", "files": ["foobar"]},
             ],
-            "default": [
-                {"label": "action 1", "type": "build:serial", "files": ["foo", "bar"]},
-                {"label": "action 2", "type": "build:serial", "files": ["baz"]},
-            ],
             "stage_1": [
                 {"label": "action 1", "type": "build:serial", "files": ["foo", "bar"]},
                 {"label": "action 2", "type": "build:serial", "files": ["baz"]},
@@ -200,7 +189,7 @@ def test_missing_action(tmp_path):
         study_manifest.StudyManifest(tmp_path)
 
 
-def test_all_protected(mock_db_config, tmp_path):
+def test_all_protected(tmp_path):
     manifest_dict = {
         "study_prefix": "test",
         "stages": {"all": [{"files": ["foo"], "type": "build:serial"}]},
@@ -208,6 +197,36 @@ def test_all_protected(mock_db_config, tmp_path):
     conftest.write_toml(tmp_path, manifest_dict, "manifest.toml")
     with pytest.raises(errors.StudyManifestParsingError):
         study_manifest.StudyManifest(tmp_path)
+
+
+def test_default_handling(tmp_path):
+    manifest_dict = {
+        "study_prefix": "test",
+        "stages": {
+            "one": [{"files": ["foo"], "type": "build:serial"}],
+            "two": [{"files": ["bar"], "type": "build:serial"}],
+        },
+    }
+    conftest.write_toml(tmp_path, manifest_dict, "manifest.toml")
+    manifest = study_manifest.StudyManifest(tmp_path)
+    stage = manifest.get_stage("default")
+    assert stage == [
+        {"type": "build:serial", "files": ["foo"]},
+        {"type": "build:serial", "files": ["bar"]},
+    ]
+    manifest_dict = {
+        "study_prefix": "test",
+        "stages": {
+            "default": [{"files": ["foo"], "type": "build:serial"}],
+            "two": [{"files": ["bar"], "type": "build:serial"}],
+        },
+    }
+    conftest.write_toml(tmp_path, manifest_dict, "manifest.toml")
+    manifest = study_manifest.StudyManifest(tmp_path)
+    stage = manifest.get_stage("default")
+    assert stage == [
+        {"type": "build:serial", "files": ["foo"]},
+    ]
 
 
 def test_empty_stage(mock_db_config, tmp_path):


### PR DESCRIPTION
By request, running the entire study manifest is now the default behavior if a default stage is not specified.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json