### PR TITLE
Better type casting in file_upload action

### DIFF
--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -12,7 +12,7 @@ import rich
 import sqlglot
 from rich import progress
 
-from cumulus_library import databases, study_manifest
+from cumulus_library import databases, errors, study_manifest
 
 
 @dataclasses.dataclass
@@ -202,3 +202,26 @@ def get_viewtable_names_from_create_queries(
             table_name = table_name.split(".", 1)[1].replace('"', "").replace("`", "")
         artifacts.append((table_name, parser.kind))
     return artifacts
+
+
+def numpy_types_from_hive_types(field_types: list[str]):
+    new_types = []
+    for field in field_types:
+        match field.lower():
+            case "tinyint" | "smallint" | "int" | "integer" | "bigint":
+                new_types.append("int")
+            case "float" | "double" | "double precision" | "decimal":
+                new_types.append("float")
+            case "date" | "timestamp":
+                new_types.append("datetime64[ns]")
+            case "interval":
+                new_types.append("timedelta64[ns]")
+            case "string" | "varchar" | "char":
+                new_types.append("string")
+            case "boolean" | "binary":
+                new_types.append("bool")
+            case _:
+                raise errors.CumulusLibraryError(
+                    f"Field type {field} is not a supported hive data type"
+                )
+    return new_types

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -8,6 +8,7 @@ import zipfile
 from contextlib import contextmanager
 
 import platformdirs
+import pyarrow
 import rich
 import sqlglot
 from rich import progress
@@ -204,22 +205,24 @@ def get_viewtable_names_from_create_queries(
     return artifacts
 
 
-def numpy_types_from_hive_types(field_types: list[str]):
+def pyarrow_types_from_hive_types(field_types: list[str]):
     new_types = []
     for field in field_types:
         match field.lower():
             case "tinyint" | "smallint" | "int" | "integer" | "bigint":
-                new_types.append("int")
+                new_types.append(pyarrow.int64())
             case "float" | "double" | "double precision" | "decimal":
-                new_types.append("float")
-            case "date" | "timestamp":
-                new_types.append("datetime64[ns]")
+                new_types.append(pyarrow.float64())
+            case "timestamp":
+                new_types.append(pyarrow.timestamp("ns"))
+            case "date":
+                new_types.append(pyarrow.date64())
             case "interval":
-                new_types.append("timedelta64[ns]")
+                new_types.append(pyarrow.duration("ns"))
             case "string" | "varchar" | "char":
-                new_types.append("string")
+                new_types.append(pyarrow.string())
             case "boolean" | "binary":
-                new_types.append("bool")
+                new_types.append(pyarrow.bool_())
             case _:
                 raise errors.CumulusLibraryError(
                     f"Field type {field} is not a supported hive data type"

--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -7,6 +7,7 @@ import sys
 import msgspec
 import pandas
 import platformdirs
+import pyarrow
 
 from cumulus_library import BaseTableBuilder, base_utils, errors, study_manifest
 from cumulus_library.template_sql import base_templates
@@ -182,12 +183,14 @@ class FileUploadBuilder(BaseTableBuilder):
                             f"col_types has {len(table['col_types'])} entries."
                         )
                     type_dict = {}
-                    numpy_types = base_utils.numpy_types_from_hive_types(table["col_types"])
-                    for pos in range(0, len(numpy_types)):
-                        type_dict[df.columns[pos]] = numpy_types[pos]
-                    df = df.astype(type_dict)
+                    pyarrow_types = base_utils.pyarrow_types_from_hive_types(table["col_types"])
+                    arrow_table = pyarrow.Table.from_pandas(df, preserve_index=False)
+                    for pos in range(0, len(pyarrow_types)):
+                        type_dict[df.columns[pos]] = pyarrow_types[pos]
+                    schema = pyarrow.schema([pyarrow.field(x[0], x[1]) for x in type_dict.items()])
+                    arrow_table = arrow_table.cast(schema)
                     parquet_path.parent.mkdir(parents=True, exist_ok=True)
-                    df.to_parquet(parquet_path)
+                    pyarrow.parquet.write_table(arrow_table, parquet_path)
                     remote_path = config.db.upload_file(
                         file=parquet_path,
                         study=manifest.get_study_prefix(),

--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -182,8 +182,9 @@ class FileUploadBuilder(BaseTableBuilder):
                             f"col_types has {len(table['col_types'])} entries."
                         )
                     type_dict = {}
-                    for pos in range(0, len(table["col_types"])):
-                        type_dict[df.columns[pos]] = table["col_types"][pos].lower()
+                    numpy_types = base_utils.numpy_types_from_hive_types(table["col_types"])
+                    for pos in range(0, len(numpy_types)):
+                        type_dict[df.columns[pos]] = numpy_types[pos]
                     df = df.astype(type_dict)
                     parquet_path.parent.mkdir(parents=True, exist_ok=True)
                     df.to_parquet(parquet_path)

--- a/tests/builders/test_upload_builder.py
+++ b/tests/builders/test_upload_builder.py
@@ -102,6 +102,52 @@ def test_wrong_cols_filetype(mock_cache, mock_db_config, tmp_path):
 
 
 @mock.patch("platformdirs.user_cache_dir")
+def test_date_handling(mock_cache, mock_db_config, tmp_path):
+    mock_cache.return_value = tmp_path / "cache"
+    manifest = study_manifest.StudyManifest()
+    manifest._study_config = {
+        "study_prefix": "upload_date",
+        "stages": {
+            "test": [
+                {"type": "build:serial", "files": ["workflow.toml"]},
+            ],
+        },
+    }
+    manifest._study_prefix = "upload_date"
+    manifest.write_manifest(tmp_path)
+    conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "file_upload",
+            "tables": {"dates": {"files": ["dates.csv"], "col_types": ["DATE", "DATE", "boolean"]}},
+        },
+        filename="workflow.toml",
+    )
+
+    with open(tmp_path / "dates.csv", "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(["period_start", "period_end", "include_history"])
+        writer.writerow(["2016-01-01", "2026-01-01", "true"])
+    builder = file_upload_builder.FileUploadBuilder(
+        toml_config_path=tmp_path / "workflow.toml",
+    )
+    builder.execute_queries(config=mock_db_config, manifest=manifest)
+    col_types = (
+        mock_db_config.db.cursor()
+        .execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name='upload_date__dates'"
+        )
+        .fetchall()
+    )
+    assert col_types == [
+        ("period_start", "TIMESTAMP_NS"),
+        ("period_end", "TIMESTAMP_NS"),
+        ("include_history", "BOOLEAN"),
+    ]
+
+
+@mock.patch("platformdirs.user_cache_dir")
 def test_multifile_mismatch(mock_cache, mock_db_config, tmp_path):
     mock_cache.return_value = tmp_path / "cache"
     shutil.copytree(TEST_DATA_PATH, tmp_path / "file_upload", dirs_exist_ok=True)

--- a/tests/builders/test_upload_builder.py
+++ b/tests/builders/test_upload_builder.py
@@ -119,7 +119,9 @@ def test_date_handling(mock_cache, mock_db_config, tmp_path):
         tmp_path,
         {
             "config_type": "file_upload",
-            "tables": {"dates": {"files": ["dates.csv"], "col_types": ["DATE", "DATE", "boolean"]}},
+            "tables": {
+                "dates": {"files": ["dates.csv"], "col_types": ["DATE", "TIMESTAMP", "boolean"]}
+            },
         },
         filename="workflow.toml",
     )
@@ -141,7 +143,7 @@ def test_date_handling(mock_cache, mock_db_config, tmp_path):
         .fetchall()
     )
     assert col_types == [
-        ("period_start", "TIMESTAMP_NS"),
+        ("period_start", "DATE"),
         ("period_end", "TIMESTAMP_NS"),
         ("include_history", "BOOLEAN"),
     ]

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,0 +1,50 @@
+import pytest
+
+from cumulus_library import base_utils, errors
+
+
+def test_numpy_from_hive():
+    hive_types = [
+        "tinyint",
+        "smallint",
+        "int",
+        "integer",
+        "bigint",
+        "float",
+        "double",
+        "double precision",
+        "decimal",
+        "date",
+        "timestamp",
+        "interval",
+        "string",
+        "varchar",
+        "char",
+        "boolean",
+        "binary",
+    ]
+    res = base_utils.numpy_types_from_hive_types(hive_types)
+    assert res == [
+        "int",
+        "int",
+        "int",
+        "int",
+        "int",
+        "float",
+        "float",
+        "float",
+        "float",
+        "datetime64[ns]",
+        "datetime64[ns]",
+        "timedelta64[ns]",
+        "string",
+        "string",
+        "string",
+        "bool",
+        "bool",
+    ]
+
+
+def test_numpy_from_hive_error():
+    with pytest.raises(errors.CumulusLibraryError):
+        base_utils.numpy_types_from_hive_types(["EnterpriseBeanFactoryFactory"])

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,3 +1,4 @@
+import pyarrow
 import pytest
 
 from cumulus_library import base_utils, errors
@@ -23,28 +24,28 @@ def test_numpy_from_hive():
         "boolean",
         "binary",
     ]
-    res = base_utils.numpy_types_from_hive_types(hive_types)
+    res = base_utils.pyarrow_types_from_hive_types(hive_types)
     assert res == [
-        "int",
-        "int",
-        "int",
-        "int",
-        "int",
-        "float",
-        "float",
-        "float",
-        "float",
-        "datetime64[ns]",
-        "datetime64[ns]",
-        "timedelta64[ns]",
-        "string",
-        "string",
-        "string",
-        "bool",
-        "bool",
+        pyarrow.int64(),
+        pyarrow.int64(),
+        pyarrow.int64(),
+        pyarrow.int64(),
+        pyarrow.int64(),
+        pyarrow.float64(),
+        pyarrow.float64(),
+        pyarrow.float64(),
+        pyarrow.float64(),
+        pyarrow.date64(),
+        pyarrow.timestamp("ns"),
+        pyarrow.duration("ns"),
+        pyarrow.string(),
+        pyarrow.string(),
+        pyarrow.string(),
+        pyarrow.bool_(),
+        pyarrow.bool_(),
     ]
 
 
-def test_numpy_from_hive_error():
+def test_pyarrow_from_hive_error():
     with pytest.raises(errors.CumulusLibraryError):
-        base_utils.numpy_types_from_hive_types(["EnterpriseBeanFactoryFactory"])
+        base_utils.pyarrow_types_from_hive_types(["EnterpriseBeanFactoryFactory"])


### PR DESCRIPTION
This addresses #508 by making an explicit cast from hive types to the corresponding numpy types, which prevents type cast errors in pandas.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json