### PR TITLE
Add support for select_by_table by querying the database

### DIFF
--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -7,7 +7,8 @@ from collections.abc import Callable
 import msgspec
 import rich
 
-from cumulus_library import BaseTableBuilder, note_utils
+import cumulus_library
+from cumulus_library import note_utils
 
 # NLP is driven by a workflow config. See docs/workflows/nlp.md for more details
 # on syntax and expectations.
@@ -35,7 +36,7 @@ class NlpWorkflow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True
     shared: NlpShared = msgspec.field(default_factory=NlpShared)
 
 
-class NlpBuilder(BaseTableBuilder):
+class NlpBuilder(cumulus_library.BaseTableBuilder):
     def __init__(
         self,
         *args,
@@ -72,12 +73,19 @@ class NlpBuilder(BaseTableBuilder):
                     shared_val = getattr(self._workflow_config.shared, field)
                     setattr(task, field, shared_val)
 
-    def _make_note_filter(self, task: NlpTask) -> Callable[[dict, str], bool]:
+    def _make_note_filter(
+        self, table_refs: dict[str, note_utils.TableRefs], task: NlpTask
+    ) -> Callable[[dict, str], bool]:
+        extra = {}
+        if refs := table_refs.get(task.select_by_table):
+            extra["select_by_note_ref"] = refs.notes
+            extra["select_by_patient_ref"] = refs.patients
         return note_utils.make_note_filter(
             reject_by_regex=task.reject_by_regex,
             reject_by_word=task.reject_by_word,
             select_by_regex=task.select_by_regex,
             select_by_word=task.select_by_word,
+            **extra,
         )
 
     def _print_note_stats(
@@ -102,6 +110,7 @@ class NlpBuilder(BaseTableBuilder):
     def prepare_queries(
         self,
         *args,
+        config: cumulus_library.StudyConfig,
         **kwargs,
     ):
         # Set up some stat counters
@@ -110,7 +119,22 @@ class NlpBuilder(BaseTableBuilder):
         considered = [0] * len(self._workflow_config.task)
         got_response = [0] * len(self._workflow_config.task)
 
-        note_filters = [self._make_note_filter(task) for task in self._workflow_config.task]
+        # Gather note filters together
+        cursor = config.db.cursor()
+        select_by_tables = {task.select_by_table for task in self._workflow_config.task}
+
+        if list(filter(None, select_by_tables)) and not self._notes.salt:
+            raise RuntimeError(
+                "Cannot calculate anonymized resource IDs without a PHI dir defined. "
+                "Pass --etl-phi-dir and try again."
+            )
+
+        table_refs = {
+            table: note_utils.get_table_refs(cursor, table) for table in select_by_tables if table
+        }
+        note_filters = [
+            self._make_note_filter(table_refs, task) for task in self._workflow_config.task
+        ]
 
         # Go through notes one by one and run NLP on them
         for note_res in self._notes.progress_iter("Running NLP..."):
@@ -123,7 +147,7 @@ class NlpBuilder(BaseTableBuilder):
             had_text += 1
 
             for idx, task in enumerate(self._workflow_config.task):
-                if not note_filters[idx](note_res, text):
+                if not note_filters[idx](note_res, text=text, salt=self._notes.salt):
                     continue
                 considered[idx] += 1
 

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -344,7 +344,9 @@ def run_cli(args: dict):
                     options=args["options"],
                 )
             elif args["action"] == "build":
-                notes = note_utils.NoteSource(args["note_dir"], s3_region={args["region"]})
+                notes = note_utils.NoteSource(
+                    args["note_dir"], phi_dir=args["etl_phi_dir"], s3_region={args["region"]}
+                )
                 if args["builder"]:
                     runner.build_matching_files(
                         study_dict[args["target"]],

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -127,6 +127,17 @@ def add_note_dir_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_etl_phi_dir_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--etl-phi-dir",
+        metavar="DIR",
+        help=(
+            "The directory in which Cumulus ETL drops PHI mapping information. "
+            "Can be an s3:// URL or local path. Only relevant for NLP workflows."
+        ),
+    )
+
+
 def add_stage_argument(parser: argparse.ArgumentParser) -> None:
     """Adds --stage arg to a subparser"""
     parser.add_argument(
@@ -220,6 +231,7 @@ AWS Athena, the following order of preference is used to select credentials:
     add_db_config(build, input_mode=True)
     add_study_dir_argument(build)
     add_note_dir_argument(build)
+    add_etl_phi_dir_argument(build)
     add_table_builder_argument(build)
     add_target_argument(build)
     add_verbose_argument(build)

--- a/cumulus_library/databases/__init__.py
+++ b/cumulus_library/databases/__init__.py
@@ -1,4 +1,4 @@
 from .athena import AthenaDatabaseBackend, AthenaParser
 from .base import DatabaseBackend, DatabaseCursor, DatabaseParser
 from .duckdb import DuckDatabaseBackend, DuckDbParser
-from .utils import create_db_backend, get_ndjson_files, read_ndjson_dir
+from .utils import SQL_NAME_CHARS, create_db_backend, get_ndjson_files, read_ndjson_dir

--- a/cumulus_library/databases/utils.py
+++ b/cumulus_library/databases/utils.py
@@ -1,4 +1,5 @@
 import pathlib
+import string
 import sys
 from collections.abc import Iterable
 from concurrent import futures
@@ -11,6 +12,8 @@ import rich
 
 from cumulus_library import base_utils, db_config, errors
 from cumulus_library.databases import athena, base, duckdb
+
+SQL_NAME_CHARS = set(string.ascii_letters + string.digits + "_")
 
 
 def _list_files_for_resource(path: pathlib.Path, resource: str) -> list[str]:

--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -1,16 +1,20 @@
 import base64
+import binascii
 import dataclasses
 import email
+import hmac
+import json
 import os
+import pathlib
 import re
 import urllib.parse
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Container, Generator, Iterable, Sequence
 
 import cumulus_fhir_support as cfs
 import fsspec
 import inscriptis
 
-from cumulus_library import base_utils
+from cumulus_library import base_utils, databases
 
 #########################
 # Reading notes from disk
@@ -29,15 +33,33 @@ class _FileInfo:
 
 
 class NoteSource:
-    def __init__(self, note_dirs: list[str] | None = None, *, s3_region: str | None = None):
+    def __init__(
+        self,
+        note_dirs: list[str | pathlib.Path] | None = None,
+        *,
+        phi_dir: str | pathlib.Path | None = None,
+        s3_region: str | None = None,
+    ):
         self._files: list[_FileInfo] | None = None
         self._total_size = 0
 
         self._note_dirs = note_dirs
         self._s3_region = s3_region
 
+        self._salt = None
+        if phi_dir:
+            fs, phi_dir = self._get_fsspec_path(phi_dir)
+            with fs.open(os.path.join(phi_dir, "codebook.json")) as f:
+                codebook = json.load(f)
+            if id_salt := codebook.get("id_salt"):
+                self._salt = binascii.unhexlify(id_salt)
+
     def __bool__(self) -> bool:
         return bool(self._note_dirs)
+
+    @property
+    def salt(self) -> bytes | None:
+        return self._salt
 
     def progress_iter(self, label: str) -> Generator[dict]:
         with base_utils.get_progress_bar() as progress:
@@ -60,6 +82,20 @@ class NoteSource:
         self._files = self._flatten_note_dirs()
         self._total_size = sum(f.size for f in self._files)
 
+    def _get_fsspec_path(self, path: str | pathlib.Path) -> tuple[fsspec.AbstractFileSystem, str]:
+        path = str(path)  # allow pathlib.Path objects but stringify them here
+        parsed = urllib.parse.urlparse(path)
+        protocol = parsed.scheme or "file"
+        path = path if protocol == "file" else os.path.abspath(path)
+
+        # Initialize a fsspec filesystem
+        options = {}
+        if protocol == "s3" and self._s3_region:
+            options["client_kwargs"] = {"region_name": self._s3_region}
+        fs = fsspec.filesystem(protocol, **options)
+
+        return fs, path
+
     def _flatten_note_dirs(self) -> list[_FileInfo]:
         """Converts a list of folders into a list of found filenames.
 
@@ -71,16 +107,7 @@ class NoteSource:
 
         infos = []
         for one_dir in self._note_dirs or []:
-            one_dir = str(one_dir)  # allow pathlib.Path objects but stringify them here
-            parsed = urllib.parse.urlparse(one_dir)
-            protocol = parsed.scheme or "file"
-            one_dir = one_dir if parsed.scheme else os.path.abspath(one_dir)
-
-            # Initialize a fsspec filesystem
-            options = {}
-            if protocol == "s3" and self._s3_region:
-                options["client_kwargs"] = {"region_name": self._s3_region}
-            fs = fsspec.filesystem(protocol, **options)
+            fs, one_dir = self._get_fsspec_path(one_dir)
 
             # Actually scan for matching files
             paths = list(
@@ -91,6 +118,27 @@ class NoteSource:
                 infos.append(_FileInfo(fs=fs, path=path, size=sizes[idx]))
 
         return infos
+
+
+################
+# Anonymized IDs
+################
+
+
+def anon_id(id_val: str | None, salt: bytes) -> str | None:
+    if not id_val:
+        return None
+    return hmac.new(salt, digestmod="sha256", msg=id_val.encode()).hexdigest()
+
+
+def anon_ref(ref_val: str | None, salt: bytes) -> str | None:
+    if not ref_val:
+        return None
+    try:
+        res_type, id_val = ref_val.split("/", 1)
+    except ValueError:
+        return None
+    return f"{res_type}/{anon_id(id_val, salt)}"
 
 
 ######################
@@ -206,6 +254,106 @@ def _get_clinical_note_attachment(resource: dict) -> dict:
     return attachments[best_attachment_index]
 
 
+#####################
+# Table ref discovery
+#####################
+
+
+@dataclasses.dataclass
+class TableRefs:
+    notes: set[str] | None = None
+    patients: set[str] | None = None
+
+
+# Get table refs (will make immediate query, if a table is defined)
+def get_table_refs(cursor, table: str | None) -> TableRefs:
+    if not table:
+        return TableRefs()
+
+    if set(table) - databases.SQL_NAME_CHARS:
+        raise ValueError(f"Invalid SQL table name '{table}'")
+    rows = cursor.execute(f"SELECT * FROM {table}")  # noqa: S608
+
+    columns = [field[0].casefold() for field in rows.description]
+    ref_getter = _make_ref_getter(table, columns, is_anon=True)
+
+    refs = TableRefs()
+    for row in rows.fetchall():
+        note_ref, pat_ref = ref_getter(row)
+        if note_ref:
+            if refs.notes is None:
+                refs.notes = set()
+            refs.notes.add(note_ref)
+        if pat_ref:
+            if refs.patients is None:
+                refs.patients = set()
+            refs.patients.add(pat_ref)
+
+    return refs
+
+
+def _make_ref_getter(
+    table: str, fieldnames: Sequence[str], *, is_anon: bool = False
+) -> Callable[[Sequence[str]], tuple[str | None, str | None]]:
+    """Returns a callable that returns (note ref, patient ref)"""
+    get_dxr = _find_header(fieldnames, "DiagnosticReport", is_anon=is_anon)
+    get_doc = _find_header(fieldnames, "DocumentReference", is_anon=is_anon)
+    get_pat = _find_header(fieldnames, "Patient", is_anon=is_anon)
+
+    if not get_dxr and not get_doc and not get_pat:
+        raise ValueError(f"No patient or note IDs found in table '{table}'.")
+
+    # A method that takes a row of a table and returns a patient/note ref from it
+    def getter(row: Sequence[str]) -> str | None:
+        if get_dxr:
+            if val := get_dxr(row):
+                return val, None
+        if get_doc:
+            if val := get_doc(row):
+                return val, None
+        # If and only if we don't have any resource ID matchers, we'll check by patient
+        if not get_dxr and not get_doc and get_pat:
+            if val := get_pat(row):
+                return None, val
+        return None, None
+
+    return getter
+
+
+def _find_header(
+    fieldnames: Sequence[str], res_type: str, *, is_anon: bool = False
+) -> Callable[[Sequence[str]], str | None] | None:
+    folded = res_type.casefold()
+    id_names = [f"{folded}_id"]
+    ref_names = [f"{folded}_ref"]
+
+    if res_type in {"DiagnosticReport", "DocumentReference"}:
+        ref_names.append("document_ref")
+        ref_names.append("note_ref")
+    if res_type == "DocumentReference":
+        id_names.append("docref_id")
+    if res_type == "Patient":
+        id_names.append("subject_id")
+        ref_names.append("subject_ref")
+
+    if is_anon:
+        # Look for both anon_ and normal versions, but prefer an explicit column in case both exist
+        id_names = [f"anon_{x}" for x in id_names] + id_names
+        ref_names = [f"anon_{x}" for x in ref_names] + ref_names
+
+    for field in id_names:
+        if field in fieldnames:
+            idx = fieldnames.index(field)
+            return lambda x: f"{res_type}/{x[idx]}"
+    for field in ref_names:
+        if field in fieldnames:
+            idx = fieldnames.index(field)
+            prefix = f"{res_type}/"
+            return lambda x: x[idx] if x[idx].startswith(prefix) else None
+
+    return None
+
+
 ################
 # Note filtering
 ################
@@ -215,10 +363,13 @@ _ESCAPED_WHITESPACE = re.compile(r"(\\\s)+")
 
 
 def make_note_filter(
-    reject_by_regex: list[str] | None = None,
-    reject_by_word: list[str] | None = None,
-    select_by_regex: list[str] | None = None,
-    select_by_word: list[str] | None = None,
+    *,
+    reject_by_regex: Iterable[str] | None = None,
+    reject_by_word: Iterable[str] | None = None,
+    select_by_note_ref: Container[str] | None = None,
+    select_by_patient_ref: Container[str] | None = None,
+    select_by_regex: Iterable[str] | None = None,
+    select_by_word: Iterable[str] | None = None,
 ) -> Callable[[dict, str], bool]:
     pattern = _compile_filter_regex(
         reject_by_regex=reject_by_regex,
@@ -227,8 +378,16 @@ def make_note_filter(
         select_by_word=select_by_word,
     )
 
-    def note_filter(note_res: dict, text: str) -> bool:
+    def note_filter(note_res: dict, *, text: str, salt: bytes | None = None) -> bool:
         if not _filter_status(note_res):
+            return False
+
+        if salt and not _filter_refs(
+            note_res,
+            salt=salt,
+            select_by_patient_ref=select_by_patient_ref,
+            select_by_note_ref=select_by_note_ref,
+        ):
             return False
 
         if pattern.search(text) is None:
@@ -241,7 +400,14 @@ def make_note_filter(
 
 def _filter_status(note_res: dict) -> bool:
     """If the resource status is WIP, obsolete, or entered-in-error, reject it"""
-    match note_res.get("resourceType"):
+    note_type = note_res.get("resourceType")
+    note_id = note_res.get("id")
+
+    # Require basic note fields, so that other filters can use these without guards
+    if not note_type or not note_id:
+        return False
+
+    match note_type:
         case "DiagnosticReport":
             valid_status_types = {"final", "amended", "corrected", "appended", "unknown", None}
             return note_res.get("status") in valid_status_types
@@ -254,6 +420,28 @@ def _filter_status(note_res: dict) -> bool:
 
         case _:  # pragma: no cover
             return False  # pragma: no cover
+
+
+def _filter_refs(
+    note_res: dict,
+    *,
+    salt: bytes,
+    select_by_patient_ref: Container[str] | None,
+    select_by_note_ref: Container[str] | None,
+) -> bool:
+    """Returns False if refs are provided and this note doesn't match any of them"""
+    if select_by_patient_ref is not None:
+        # Both DxReports and DocRefs use subject
+        subject_ref = anon_ref(note_res.get("subject", {}).get("reference"), salt)
+        if subject_ref not in select_by_patient_ref:
+            return False
+
+    if select_by_note_ref is not None:
+        note_ref = f"{note_res['resourceType']}/{anon_id(note_res['id'], salt)}"
+        if note_ref not in select_by_note_ref:
+            return False
+
+    return True
 
 
 def _user_regex_to_pattern(term: str) -> str:
@@ -276,21 +464,21 @@ def _user_word_to_pattern(term: str) -> str:
     return _user_regex_to_pattern(term)
 
 
-def _combine_regexes(*, by_regex: list[str] | None, by_word: list[str] | None) -> str:
+def _combine_regexes(*, by_regex: Iterable[str] | None, by_word: Iterable[str] | None) -> str:
     patterns = []
     if by_regex:
-        patterns.extend(_user_regex_to_pattern(regex) for regex in by_regex)
+        patterns.extend(_user_regex_to_pattern(regex) for regex in set(by_regex))
     if by_word:
-        patterns.extend(_user_word_to_pattern(word) for word in by_word)
+        patterns.extend(_user_word_to_pattern(word) for word in set(by_word))
     return "|".join(patterns)
 
 
 def _compile_filter_regex(
     *,
-    reject_by_regex: list[str] | None,
-    reject_by_word: list[str] | None,
-    select_by_regex: list[str] | None,
-    select_by_word: list[str] | None,
+    reject_by_regex: Iterable[str] | None,
+    reject_by_word: Iterable[str] | None,
+    select_by_regex: Iterable[str] | None,
+    select_by_word: Iterable[str] | None,
 ) -> re.Pattern:
     select = _combine_regexes(by_word=select_by_word, by_regex=select_by_regex)
 

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -1,16 +1,23 @@
 import base64
+import binascii
 import contextlib
 import io
 import json
+import os
+from unittest import mock
 
 import pytest
 
-from cumulus_library import note_utils
+from cumulus_library import cli, note_utils
 from cumulus_library.builders import nlp_builder
+from tests.conftest import duckdb_args
+
+SALT_STR = "e359191164cd209708d93551f481edd048946a9d844c51dea1b64d3f83dfd1fa"
+SALT_BYTES = binascii.unhexlify(SALT_STR)
 
 
-def add_dxr(text: str | None, file) -> None:
-    dxr = {"resourceType": "DiagnosticReport"}
+def add_dxr(id_val: str, text: str | None, file) -> None:
+    dxr = {"resourceType": "DiagnosticReport", "id": id_val}
     if text is not None:
         dxr["presentedForm"] = [
             {
@@ -26,7 +33,7 @@ def add_dxr(text: str | None, file) -> None:
 def note_source(tmp_path) -> note_utils.NoteSource:
     """Just make a sample note source with a row - contents not important"""
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
-        add_dxr(None, f)
+        add_dxr("empty", None, f)
     yield note_utils.NoteSource([tmp_path])
 
 
@@ -49,6 +56,20 @@ def test_empty_note_dir(tmp_path):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_utils.NoteSource())
 
 
+def test_table_filter_but_no_salt(tmp_path, note_source, mock_db_config):
+    workflow_path = f"{tmp_path}/nlp.workflow"
+    with open(workflow_path, "w", encoding="utf8") as f:
+        f.write("""
+config_type="nlp"
+[[task]]
+select_by_table="table"
+""")
+    builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+    err_msg = "Cannot calculate anonymized resource IDs without a PHI dir defined"
+    with pytest.raises(RuntimeError, match=err_msg):
+        builder.prepare_queries(config=mock_db_config)
+
+
 def test_flattened_config(tmp_path, note_source):
     workflow_path = f"{tmp_path}/nlp.workflow"
     with open(workflow_path, "w", encoding="utf8") as f:
@@ -67,7 +88,11 @@ name="fallthrough"
     assert builder._workflow_config.task[1].system_prompt == "hello"
 
 
-def test_filter(tmp_path):
+def test_filter(tmp_path, mock_db_config):
+    codebook_path = f"{tmp_path}/codebook.json"
+    with open(codebook_path, "w", encoding="utf8") as f:
+        json.dump({"id_salt": SALT_STR}, f)
+
     workflow_path = f"{tmp_path}/nlp.workflow"
     with open(workflow_path, "w", encoding="utf8") as f:
         f.write("""
@@ -76,29 +101,76 @@ config_type="nlp"
 name="filtered"
 select_by_word=["fever"]
 reject_by_word=["cold"]
+select_by_table="prev_table"
 [[task]]
 name="all"
 """)
 
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
-        add_dxr(None, f)  # no text, will be skipped
-        add_dxr("hello world", f)  # ignored by filters
-        add_dxr("has fever", f)  # selected by filters
-        add_dxr("has fever and cold", f)  # rejected by filters
+        add_dxr("1", None, f)  # no text, will be skipped
+        add_dxr("2", "hello world", f)  # ignored by filters
+        add_dxr("3", "has fever", f)  # selected by filters
+        add_dxr("4", "has fever and cold", f)  # rejected by filters
+        add_dxr("5", "has fever", f)  # would be selected but is excluded by table
 
-    source = note_utils.NoteSource([tmp_path])
+    expected_stats = """ Notes processed:
+  Available:                5 
+  Had text:                 4 
+  Considered (filtered):    1 
+  Got response (filtered):  0 
+  Considered (all):         4 
+  Got response (all):       0 """
+
+    mock_db_config.db.cursor().execute(f"""
+        CREATE TABLE prev_table AS SELECT * FROM (
+            VALUES
+            ('{note_utils.anon_id("1", SALT_BYTES)}'),
+            ('{note_utils.anon_id("2", SALT_BYTES)}'),
+            ('{note_utils.anon_id("3", SALT_BYTES)}'),
+            ('{note_utils.anon_id("4", SALT_BYTES)}')
+        )
+        AS t (diagnosticreport_id)
+    """)
+
+    source = note_utils.NoteSource([tmp_path], phi_dir=tmp_path)
 
     builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=source)
 
-    expected_stats = """ Notes processed:
-  Available:                4 
-  Had text:                 3 
-  Considered (filtered):    1 
-  Got response (filtered):  0 
-  Considered (all):         3 
-  Got response (all):       0 """
-
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries()
+        builder.prepare_queries(config=mock_db_config)
     assert expected_stats in console_output.getvalue()
+
+
+@mock.patch.dict(os.environ, clear=True)
+@mock.patch("cumulus_library.builders.nlp_builder.NlpBuilder")
+def test_args_passed_down(mock_builder, tmp_path):
+    os.makedirs(f"{tmp_path}/notes")
+    with open(f"{tmp_path}/notes/dxr.ndjson", "w", encoding="utf8") as f:
+        dxr = {"resourceType": "DiagnosticReport", "id": "1"}
+        json.dump(dxr, f)
+
+    os.makedirs(f"{tmp_path}/phi")
+    with open(f"{tmp_path}/phi/codebook.json", "w", encoding="utf8") as f:
+        json.dump({"id_salt": SALT_STR}, f)
+
+    mock_builder.side_effect = RuntimeError("nope")
+
+    build_args = duckdb_args(
+        [
+            "build",
+            str(tmp_path),
+            "--target=example_nlp",
+            "--stage=nlp",
+            f"--note-dir={tmp_path}",
+            f"--etl-phi-dir={tmp_path}/phi",
+        ],
+        tmp_path,
+    )
+
+    with pytest.raises(RuntimeError, match="nope"):
+        cli.main(cli_args=build_args)
+
+    source = mock_builder.call_args[1]["notes"]
+    assert source.salt == SALT_BYTES
+    assert list(source.progress_iter("label")) == [dxr]

--- a/tests/studies/test_example_nlp.py
+++ b/tests/studies/test_example_nlp.py
@@ -102,7 +102,7 @@ def test_merging_two_sources(tmp_path):
 
 def test_full_build(tmp_path):
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
-        json.dump({"resourceType": "DiagnosticReport"}, f)
+        json.dump({"resourceType": "DiagnosticReport", "id": "1"}, f)
 
     build_args = duckdb_args(
         [

--- a/tests/test_note_utils.py
+++ b/tests/test_note_utils.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import json
 import os
 from unittest import mock
@@ -8,6 +9,10 @@ import pytest
 from cumulus_library import (
     note_utils,
 )
+
+# Some convenience salt values to use
+SALT_STR = "e359191164cd209708d93551f481edd048946a9d844c51dea1b64d3f83dfd1fa"
+SALT_BYTES = binascii.unhexlify(SALT_STR)
 
 
 @mock.patch("rich.progress.Progress.advance")
@@ -55,6 +60,40 @@ def test_note_source_s3(mock_filesystem, mock_read, mock_list):
     assert mock_filesystem.call_args == mock.call("s3", client_kwargs={"region_name": "cloud9"})
     assert mock_list.call_args[1]["fsspec_fs"] == fs
     assert mock_read.call_args[1]["fsspec_fs"] == fs
+
+
+def test_note_source_phi_dir(tmp_path):
+    """Just confirm we parse the salt from a codebook file"""
+    with open(f"{tmp_path}/codebook.json", "w") as f:
+        json.dump({"id_salt": SALT_STR}, f)
+
+    source = note_utils.NoteSource(phi_dir=tmp_path)
+    assert source.salt == SALT_BYTES
+
+
+@pytest.mark.parametrize(
+    "id_val,expected",
+    [
+        (None, None),
+        ("", None),
+        ("abc", "75b245a08d21040487dde2efe7038f93ea7ecb06dfc1dc7275e4ad3a22f57a22"),
+    ],
+)
+def test_anon_id(id_val, expected):
+    assert note_utils.anon_id(id_val, SALT_BYTES) == expected
+
+
+@pytest.mark.parametrize(
+    "ref_val,expected",
+    [
+        (None, None),
+        ("", None),
+        ("abc", None),
+        ("Device/abc", "Device/75b245a08d21040487dde2efe7038f93ea7ecb06dfc1dc7275e4ad3a22f57a22"),
+    ],
+)
+def test_anon_ref(ref_val, expected):
+    assert note_utils.anon_ref(ref_val, SALT_BYTES) == expected
 
 
 @pytest.mark.parametrize(
@@ -177,208 +216,347 @@ def test_get_text_from_note_res(res_type, attachments, result):
 
 
 @pytest.mark.parametrize(
+    "cols,row,result",
+    [
+        (  # basic id match
+            "patient_id,DocumentREFERENCE_ID",
+            "xxx,yyy",
+            ("DocumentReference/yyy", None),
+        ),
+        (  # basic ref match
+            "patient_id,diagnosticreport_ref",
+            "xxx,DiagnosticReport/yyy",
+            ("DiagnosticReport/yyy", None),
+        ),
+        (  # custom document_ref alias
+            "patient_id,document_ref",
+            "xxx,DiagnosticReport/ref",
+            ("DiagnosticReport/ref", None),
+        ),
+        (  # custom note_ref alias
+            "patient_id,note_ref",
+            "xxx,DocumentReference/ref",
+            ("DocumentReference/ref", None),
+        ),
+        (  # custom docref_id alias
+            "patient_id,docref_id",
+            "xxx,ref",
+            ("DocumentReference/ref", None),
+        ),
+        (  # patient id match (can't be note ref in there)
+            "patient_id,other_col",
+            "xxx,blarg",
+            (None, "Patient/xxx"),
+        ),
+        (  # patient ref match (can't be note ref in there)
+            "patient_ref,other_col",
+            "Patient/abc,blarg",
+            (None, "Patient/abc"),
+        ),
+        (  # custom subject_id alias
+            "subject_id,other_col",
+            "abc,blarg",
+            (None, "Patient/abc"),
+        ),
+        (  # custom subject_ref alias
+            "subject_ref,other_col",
+            "Patient/abc,blarg",
+            (None, "Patient/abc"),
+        ),
+        (  # prefer anon version of id columns
+            "anon_patient_id,patient_id",
+            "anon,orig",
+            (None, "Patient/anon"),
+        ),
+        (  # prefer anon version of ref columns
+            "note_ref,anon_note_ref",
+            "DocumentReference/orig,DocumentReference/anon",
+            ("DocumentReference/anon", None),
+        ),
+        (  # unsupported ref type
+            "note_ref",
+            "Patient/abc",
+            (None, None),
+        ),
+        (  # no valid cols found
+            "other,nope",
+            "xxx,yyy",
+            ValueError,
+        ),
+    ],
+)
+def test_get_table_refs(cols, row, result):
+    cursor = mock.MagicMock()
+    cursor.execute.return_value.fetchall.return_value = [row.split(",")]
+    cursor.execute.return_value.description = [[x] for x in cols.split(",")]
+
+    if isinstance(result, type):
+        with pytest.raises(result):
+            note_utils.get_table_refs(cursor, "my_table")
+    else:
+        note, pat = result
+        refs = note_utils.get_table_refs(cursor, "my_table")
+        assert ({note} if note else None) == refs.notes, cols
+        assert ({pat} if pat else None) == refs.patients, cols
+
+
+def test_get_table_refs_bad_table():
+    with pytest.raises(ValueError, match="Invalid SQL table name"):
+        note_utils.get_table_refs(None, "table; drop USERS")
+
+
+def test_get_table_refs_no_args():
+    assert note_utils.get_table_refs(None, None) == note_utils.TableRefs()
+
+
+@pytest.mark.parametrize(
     "res,text,kwargs,selected",
     [
         (  # default, no regexes, no status - should pass
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "",
             {},
             True,
         ),
         (  # unsupported type
-            {"resourceType": "Patient"},
+            {"resourceType": "Patient", "id": "1"},
+            "",
+            {},
+            False,
+        ),
+        (  # No ID
+            {"resourceType": "DiagnosticReport"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DiagnosticReport", "status": "registered"},
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "registered"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DiagnosticReport", "status": "partial"},
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "partial"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DiagnosticReport", "status": "preliminary"},
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "preliminary"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DiagnosticReport", "status": "cancelled"},
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "cancelled"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DiagnosticReport", "status": "entered-in-error"},
+            {"resourceType": "DiagnosticReport", "id": "1", "status": "entered-in-error"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DocumentReference", "status": "superseded"},
+            {"resourceType": "DocumentReference", "id": "1", "status": "superseded"},
             "",
             {},
             False,
         ),
         (  # bad status
-            {"resourceType": "DocumentReference", "status": "entered-in-error"},
+            {"resourceType": "DocumentReference", "id": "1", "status": "entered-in-error"},
             "",
             {},
             False,
         ),
         (  # bad docStatus
-            {"resourceType": "DocumentReference", "docStatus": "preliminary"},
+            {"resourceType": "DocumentReference", "id": "1", "docStatus": "preliminary"},
             "",
             {},
             False,
         ),
         (  # bad docStatus
-            {"resourceType": "DocumentReference", "docStatus": "entered-in-error"},
+            {"resourceType": "DocumentReference", "id": "1", "docStatus": "entered-in-error"},
             "",
             {},
             False,
         ),
         (  # select word (negative case)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_word": ["bye"]},
+            {"select_by_word": {"bye"}},
             False,
         ),
         (  # select word (positive case)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello, world",
-            {"select_by_word": ["hello"]},
+            {"select_by_word": {"hello"}},
             True,
         ),
         (  # select word (multiple selections, or'd together)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_word": ["bye", "hello"]},
+            {"select_by_word": {"bye", "hello"}},
             True,
         ),
         (  # select word (weird characters)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hel*lo.1+ world",
-            {"select_by_word": ["hel*lo.1+"]},
+            {"select_by_word": {"hel*lo.1+"}},
             True,
         ),
         (  # select word (substring isn't matched)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_word": ["hell"]},
+            {"select_by_word": {"hell"}},
             False,
         ),
         (  # select word (multi word)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world, mr smith",
-            {"select_by_word": ["mr smith"]},
+            {"select_by_word": {"mr smith"}},
             True,
         ),
         (  # select regex (matches)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_regex": ["hell."]},
+            {"select_by_regex": {"hell."}},
             True,
         ),
         (  # select regex (can cross word boundaries)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_regex": ["hell.*d"]},
+            {"select_by_regex": {"hell.*d"}},
             True,
         ),
         (  # select regex (can cross word boundaries, but still respects word ends)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_regex": ["hell.*r"]},
+            {"select_by_regex": {"hell.*r"}},
             False,
         ),
         (  # select word and regex (matches either)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"select_by_word": ["world"], "select_by_regex": ["h."]},
+            {"select_by_word": {"world"}, "select_by_regex": {"h."}},
             True,
         ),
         (  # reject word (by itself, without matching, we should select note)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_word": ["bye"]},
+            {"reject_by_word": {"bye"}},
             True,
         ),
         (  # reject word (by itself, with matching, we should reject note)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_word": ["hello"]},
+            {"reject_by_word": {"hello"}},
             False,
         ),
         (  # reject word (multiple options, will reject either)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_word": ["hello", "bye"]},
+            {"reject_by_word": {"hello", "bye"}},
             False,
         ),
         (  # reject word (and select it, reject should win)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_word": ["hello"], "select_by_word": ["hello"]},
+            {"reject_by_word": {"hello"}, "select_by_word": {"hello"}},
             False,
         ),
         (  # reject word (miss) and select word (hit)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_word": ["bye"], "select_by_word": ["hello"]},
+            {"reject_by_word": {"bye"}, "select_by_word": {"hello"}},
             True,
         ),
         (  # reject regex (simple match)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_regex": ["he..o"]},
+            {"reject_by_regex": {"he..o"}},
             False,
         ),
         (  # reject regex (across words)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_regex": ["he.*rld"]},
+            {"reject_by_regex": {"he.*rld"}},
             False,
         ),
         (  # reject word and regex (either should reject)
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello world",
-            {"reject_by_regex": ["he..o"], "reject_by_word": ["bye"]},
+            {"reject_by_regex": {"he..o"}, "reject_by_word": {"bye"}},
             False,
         ),
         (  # select on non-first lines
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello\nworld",
-            {"select_by_word": ["world"]},
+            {"select_by_word": {"world"}},
             True,
         ),
         (  # reject on non-first lines
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello\nworld",
-            {"reject_by_word": ["world"]},
+            {"reject_by_word": {"world"}},
             False,
         ),
         (  # select across lines and whitespace, if multiple words provided
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello  \n  world",
-            {"select_by_word": ["hello world"]},
+            {"select_by_word": {"hello world"}},
             True,
         ),
         (  # (don't) select across lines with other stuff in there, confirming a lack of match
-            {"resourceType": "DiagnosticReport"},
+            {"resourceType": "DiagnosticReport", "id": "1"},
             "hello\n.world",
-            {"select_by_word": ["hello world"]},
+            {"select_by_word": {"hello world"}},
+            False,
+        ),
+        (  # select note ref
+            {"resourceType": "DocumentReference", "id": "1"},
+            "",
+            {
+                "select_by_note_ref": {
+                    "DocumentReference/69123f5b2305aba4bc734b41c66cedab639b3e81d4ae8eeb9569d6dc1476a1e7"
+                }
+            },
+            True,
+        ),
+        (  # select note ref and word (miss on ref, so we never consider the word)
+            {"resourceType": "DocumentReference", "id": "1"},
+            "hello world",
+            {"select_by_note_ref": {"DocumentReference/xxx"}, "select_by_word": {"world"}},
+            False,
+        ),
+        (  # select patient ref
+            {"resourceType": "DiagnosticReport", "id": "1", "subject": {"reference": "Patient/1"}},
+            "",
+            {
+                "select_by_patient_ref": {
+                    "Patient/69123f5b2305aba4bc734b41c66cedab639b3e81d4ae8eeb9569d6dc1476a1e7"
+                }
+            },
+            True,
+        ),
+        (  # select patient ref (miss)
+            {"resourceType": "DiagnosticReport", "id": "1", "subject": {"reference": "Patient/1"}},
+            "",
+            {"select_by_patient_ref": {"Patient/xxx"}},
             False,
         ),
     ],
 )
 def test_note_filter(res, text, kwargs, selected):
     note_filter = note_utils.make_note_filter(**kwargs)
-    assert selected == note_filter(res, text), kwargs
+    assert note_filter(res, text=text, salt=SALT_BYTES) is selected, kwargs
+
+
+def test_note_filter_no_salt():
+    note_filter = note_utils.make_note_filter(select_by_note_ref={"xxx"})
+    # Normally, this would be rejected because the given note filter doesn't match.
+    # But since we're not passing in a salt, we never check the note refs and pass it.
+    assert note_filter({"resourceType": "DiagnosticReport", "id": "1"}, text="") is True


### PR DESCRIPTION
This also adds a new CLI arg: --etl-phi-dir to tell Library where the PHI folder is, which holds the codebook with the salt we need to match original note IDs to Athena table values.

FYI, there are now two new CLI args in the NLP feature work: `--etl-phi-dir` and `--note-dir`

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json