### PR TITLE
Update manifest output during export

### DIFF
--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -374,9 +374,10 @@ class StudyManifest:
         path.parent.mkdir(exist_ok=True, parents=True)
         with open(path, "wb") as f:
             config = copy.deepcopy(self._study_config)
-            config["stages"].pop("all", None)
             # we'll remove the all key we auto created before writing out a copy
-            f.write(msgspec.toml.encode(ManifestConfig(config)))
+            config["stages"].pop("all", None)
+            output = msgspec.toml.encode(config)
+            f.write(output)
 
     ### Dynamic Python code support
 

--- a/tests/actions/test_exporter.py
+++ b/tests/actions/test_exporter.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import tomllib
 import zipfile
 from unittest import mock
 
@@ -58,3 +59,7 @@ def test_export_study(tmp_path, mock_db):
                 )
         else:
             raise Exception("Unexpected file type in export dir")
+    archive.extract("manifest.toml", tmp_path)
+    with open(tmp_path / "manifest.toml", "rb") as file:
+        manifest = tomllib.load(file)
+    assert manifest["study_prefix"] == "core"


### PR DESCRIPTION
During export, we were passing the manifest to the msgspec validator, which ended up storing the entire dict under the first key. Now instead we'll just write it out, and check for an expected key in tests instead.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json