### PR TITLE
Add initial model support (no batching, no writing yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ MRCONSO.RRF
 *.zip
 coverage.xml
 valueset_data/
-/cumulus_library/studies/example_nlp/age.json
 
 # parquet and csv files show up during an export, which devs might do a fair bit in odd places.
 # So for safety, ignore them both here, except in the tests dir where we use them for test data.

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -47,6 +47,7 @@ def build_study(
     prepare: bool = False,
     data_path: pathlib.Path | None = None,
     notes: note_utils.NoteSource | None = None,
+    nlp_config: note_utils.NlpConfig | None = None,
 ) -> None:
     """Creates tables in the schema by iterating through the stages in the specified build type
 
@@ -58,6 +59,7 @@ def build_study(
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
     :keyword notes: Source to read notes from (for NLP)
+    :keyword nlp_config: NLP config options from command line
     """
     if prepare:
         _check_if_preparable(manifest.get_study_prefix())
@@ -115,6 +117,7 @@ def build_study(
                     filename=file,
                     data_path=data_path,
                     notes=notes,
+                    nlp_config=nlp_config,
                     prepare=prepare,
                     parallel=parallel,
                     query_count=query_count,
@@ -169,6 +172,7 @@ def build_matching_files(
     prepare: bool,
     data_path: pathlib.Path,
     notes: note_utils.NoteSource | None = None,
+    nlp_config: note_utils.NlpConfig | None = None,
 ):
     """targets all table builders matching a target string for running
 
@@ -179,6 +183,7 @@ def build_matching_files(
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
     :keyword notes: Source to read notes from (for NLP)
+    :keyword nlp_config: NLP config options from command line
     """
     if prepare:
         _check_if_preparable(manifest.get_study_prefix())  # pragma: no cover
@@ -201,6 +206,7 @@ def build_matching_files(
         prepare=prepare,
         data_path=data_path,
         notes=notes,
+        nlp_config=nlp_config,
     )
 
 
@@ -538,6 +544,7 @@ def _run_workflow(
     data_path: pathlib.Path,
     query_count: int,
     notes: note_utils.NoteSource | None = None,
+    nlp_config: note_utils.NlpConfig | None = None,
     parallel: bool = False,
 ) -> tuple[list[str], bool]:
     """Loads workflow config from toml definitions and executes workflow
@@ -548,6 +555,7 @@ def _run_workflow(
     :keyword prepare: If true, will render query instead of executing
     :keyword data_path: If prepare is true, the path to write rendered data to
     :keyword notes: Source to read notes from (for NLP)
+    :keyword nlp_config: NLP config options from command line
     :keyword query_count: if prepare is true, the number of queries already rendered
     :keyword stage_name: the stage in the build currently being processed
     :keyword parallel; If true, execute queries in parallel if workflow allows
@@ -592,6 +600,7 @@ def _run_workflow(
                 manifest=manifest,
                 toml_config_path=toml_path,
                 notes=notes or note_utils.NoteSource(),
+                nlp_config=nlp_config or note_utils.NlpConfig(),
             )
         case "psm":
             existing_stats = []

--- a/cumulus_library/builders/nlp/caching.py
+++ b/cumulus_library/builders/nlp/caching.py
@@ -1,0 +1,66 @@
+"""Local caching of NLP results, to avoid future calls"""
+
+import hashlib
+from collections.abc import Callable
+from typing import TypeVar
+
+import cumulus_fhir_support as cfs
+
+Obj = TypeVar("Obj")
+
+# TODO MIKE: add back when implementing batching
+
+# def _cache_metadata_path(cache_dir: cfs.FsPath, namespace: str, filename: str) -> cfs.FsPath:
+#     return cache_dir.joinpath(f"nlp-cache/{namespace}/{filename}")
+
+
+# def cache_metadata_write(cache_dir: cfs.FsPath, namespace: str, content: dict) -> None:
+#     path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
+#     path.parent.makedirs()
+#     path.write_json(content, indent=2)
+
+
+# def cache_metadata_read(cache_dir: cfs.FsPath, namespace: str) -> dict:
+#     path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
+#     return path.read_json(default={})
+
+
+def _cache_path(cache_dir: cfs.FsPath, namespace: str, checksum: str) -> cfs.FsPath:
+    return cache_dir.joinpath(f"nlp-cache/{namespace}/{checksum[0:4]}/sha256-{checksum}.cache")
+
+
+def cache_checksum(note_text: str) -> str:
+    return hashlib.sha256(note_text.encode("utf8"), usedforsecurity=False).hexdigest()
+
+
+def cache_write(cache_dir: cfs.FsPath, namespace: str, checksum: str, content: str) -> None:
+    path = _cache_path(cache_dir, namespace, checksum)
+    path.parent.makedirs()
+    path.write_text(content)
+
+
+def cache_read(cache_dir: cfs.FsPath, namespace: str, checksum: str) -> str | None:
+    path = _cache_path(cache_dir, namespace, checksum)
+    return path.read_text(default=None)
+
+
+def cache_wrapper(
+    cache_dir: cfs.FsPath,
+    namespace: str,
+    checksum: str,
+    from_file: Callable[[str], Obj],
+    to_file: Callable[[Obj], str],
+    method: Callable,
+    *args,
+    **kwargs,
+) -> Obj:
+    """Looks up an NLP result in the cache first, falling back to calling the NLP method."""
+    result = cache_read(cache_dir, namespace, checksum)
+
+    if result is None:
+        result = method(*args, **kwargs)
+        cache_write(cache_dir, namespace, checksum, to_file(result))
+    else:
+        result = from_file(result)
+
+    return result

--- a/cumulus_library/builders/nlp/driver.py
+++ b/cumulus_library/builders/nlp/driver.py
@@ -1,0 +1,230 @@
+import datetime
+import json
+import re
+import string
+
+import cumulus_fhir_support as cfs
+import rich
+
+from cumulus_library import errors, note_utils
+
+from . import caching, models, workflow
+
+ESCAPED_WHITESPACE = re.compile(r"(\\\s)+")
+
+
+class NlpStats:
+    def __init__(self, size: int):
+        self.available = 0
+        self.had_text = 0
+        self.considered = [0] * size
+        self.got_response = [0] * size
+
+
+def run_nlp(
+    notes: note_utils.NoteSource,
+    *,
+    nlp_config: note_utils.NlpConfig,
+    tasks: list[workflow.NlpTask],
+    filters: list[cfs.NoteFilter],
+) -> NlpStats:
+    """Iterates through the notes, filtering as it goes, and passes notes to NLP"""
+    stats = NlpStats(len(tasks))
+    pool = NlpNotePool(nlp_config)
+
+    for note_res in notes.progress_iter("Running NLP..."):
+        stats.available += 1
+
+        try:
+            text = cfs.get_text_from_note_res(note_res)
+        except Exception:  # noqa: S112
+            continue
+        stats.had_text += 1
+
+        for idx, task in enumerate(tasks):
+            if not filters[idx](note_res, text=text):
+                continue
+            stats.considered[idx] += 1
+
+            try:
+                stats.got_response[idx] += pool.add_note(task, note_res, text)
+            except Exception as exc:
+                rich.print("Failed to process note:", exc)
+
+    # Finalize each task (in case a batch is waiting to be sent)
+    for idx, task in enumerate(tasks):
+        try:
+            stats.got_response[idx] += pool.finalize(task)
+        except Exception as exc:
+            rich.print("Failed to process note:", exc)
+
+    return stats
+
+
+### Internal driver API to help manage the process
+
+
+class NlpNotePool:
+    """
+    NLP has a couple different batch limits going on. This class pools the notes until one is hit.
+
+    First, you have the general memory batch limit - we don't want to hold too many notes at once
+    or we'll hit out-of-memory errors.
+
+    Second (if we're doing batch-processing of NLP), there's the provider's batch limits, either
+    in byte size and/or number-of-notes.
+
+    But consumers of this class don't have to care about all that. It will just accept notes and
+    either send them out to NLP or not depending on where the limits are.
+    """
+
+    def __init__(self, nlp_config: note_utils.NlpConfig):
+        self._config = nlp_config
+        self._model = models.create_model(nlp_config)
+        self._provider = self._model.provider
+
+        self._notes = {}  # task_name -> list[output row]
+
+        if self._config.use_batching and not self._provider.supports_batches:
+            raise errors.CumulusLibraryError(
+                f"Model {self._provider.model_name} does not support batching."
+            )
+        if not self._config.phi_dir:
+            raise errors.CumulusLibraryError(
+                "NLP requires the --etl-phi-dir argument. Please provide a PHI dir and try again."
+            )
+
+    def add_note(self, task: workflow.NlpTask, note_res: dict, text: str) -> int:
+        """Returns number of successfully processed notes. Might raise an exception."""
+        if self._config.use_batching:
+            # TODO MIKE: finish batching support
+            return 0  # pragma: no cover
+
+        prompt = self._make_prompt(task, text)
+        response = self._model.prompt(prompt)
+        self._add_response(task, note_res, text, response)
+        return 1
+
+    def finalize(self, task: workflow.NlpTask) -> int:
+        """Returns number of successfully processed notes. Might raise an exception."""
+        if self._config.use_batching:
+            # TODO MIKE: finish batching support
+            return 0  # pragma: no cover
+
+        self._write_notes_to_output()
+        return 0
+
+    def _make_prompt(self, task: workflow.NlpTask, text: str) -> models.Prompt:
+        schema = task.response_schema.model_json_schema()
+        system = task.system_prompt or ""
+        system = system.replace("%JSON-SCHEMA%", json.dumps(schema))
+
+        user = task.user_prompt or "%CLINICAL-NOTE%"
+        user = user.replace("%CLINICAL-NOTE%", text)
+
+        return models.Prompt(
+            system=system,
+            user=user,
+            schema=task.response_schema,
+            cache_dir=cfs.FsPath(self._config.phi_dir),
+            cache_namespace=f"{self._table_name(task)}_v{task.version}",
+            cache_checksum=caching.cache_checksum(text),
+        )
+
+    def _table_name(self, task: workflow.NlpTask) -> str:
+        return table_name_for_task(task, self._config)
+
+    def _add_response(
+        self, task: workflow.NlpTask, note_res: dict, text: str, response: models.PromptResponse
+    ) -> None:
+        # Track some basic note metadata (ref, subject, encounter)
+        note_ref = f"{note_res.get('resourceType')}/{note_res.get('id')}"
+        subject_ref = note_res.get("subject", {}).get("reference")
+
+        encounters = note_res.get("context", {}).get("encounter", [])
+        if encounters:
+            encounter_ref = encounters[0].get("reference")
+        else:  # check for dxreport encounter field
+            encounter_ref = note_res.get("encounter", {}).get("reference")
+
+        # Convert pydantic model to JSON and fix up spans to be ints instead of strings.
+        # Pass serialize_as_any=True so we don't get warnings about finding strings when it
+        # expected an Enum (all our enums are strings and default values are often strings)
+        parsed = response.answer.model_dump(mode="json", serialize_as_any=True)
+        self._fix_spans(note_ref, text, parsed)
+
+        # If you change these, change the schema definition in nlp_builder.py too
+        new_row = {
+            "note_ref": note_ref,
+            "encounter_ref": encounter_ref,
+            "subject_ref": subject_ref,
+            # Since this date is stored as a string, use UTC time for easy comparisons
+            "generated_on": datetime.datetime.now(datetime.UTC).isoformat(),
+            "task_version": task.version,
+            "model": self._model.MODEL_ID,
+            "system_fingerprint": response.fingerprint,
+            "result": parsed,
+        }
+
+        # Add new row to pending notes
+        table = self._table_name(task)
+        self._notes.setdefault(table, []).append(new_row)
+
+        # Do we have enough to write out?
+        pending_notes = sum(len(x) for x in self._notes.values())
+        if pending_notes >= self._config.note_limit:
+            self._write_notes_to_output()
+
+    def _fix_spans(self, note_ref: str, text: str, parsed: dict) -> bool:
+        """Converts string spans into integer spans."""
+        all_found = True
+
+        for key, value in parsed.items():
+            if key != "spans":
+                # descend as needed
+                if isinstance(value, dict):
+                    all_found &= self._fix_spans(note_ref, text, value)
+                if isinstance(value, list) and value and isinstance(value[0], dict):
+                    all_found &= all([self._fix_spans(note_ref, text, v) for v in value])
+                continue
+
+            old_spans = value or []
+            new_spans = []
+            for span in old_spans:
+                # Now we need to find this span in the original text.
+                # However, LLMs like to mess with us, and the span is not always accurate to the
+                # original text (e.g. whitespace, case, punctuation differences).
+                # So be a little fuzzy.
+                orig_span = span
+                span = span.strip(string.punctuation + string.whitespace)
+                span = re.escape(span)
+                # Replace sequences of whitespace with a whitespace regex, to allow the span
+                # returned by the LLM to match regardless of what the LLM does with whitespace and
+                # to ignore how we trim trailing whitespace from the original note.
+                span = ESCAPED_WHITESPACE.sub(r"\\s+", span)
+
+                found = False
+                for match in re.finditer(span, text, re.IGNORECASE):
+                    found = True
+                    new_spans.append(match.span())
+                if not found:
+                    all_found = False
+                    rich.print(
+                        f"Could not match span received from NLP server for {note_ref}: {orig_span}"
+                    )
+
+            parsed[key] = new_spans
+
+        return all_found
+
+    def _write_notes_to_output(self) -> None:
+        print("TODO MIKE: write this to parquet", self._notes)  # noqa: T201
+        self._notes = {}
+        self._write_to_disk()  # just for tests to override
+
+    def _write_to_disk(self) -> None:
+        pass
+
+
+def table_name_for_task(task: workflow.NlpTask, nlp_config: note_utils.NlpConfig) -> str:
+    return f"{nlp_config.target}__nlp2_{task.name}"  # TODO MIKE: nlp prefix?

--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -1,0 +1,785 @@
+"""Abstraction layer for inference APIs"""
+
+import abc
+import dataclasses
+import datetime
+import json
+import os
+from collections.abc import Iterable
+from typing import NoReturn, Self
+
+import boto3
+import cumulus_fhir_support as cfs
+import openai
+from openai.types.chat import ParsedChatCompletion
+from pydantic import BaseModel
+
+from cumulus_library import errors, note_utils
+
+from . import caching
+
+
+class UnreachableModel(errors.CumulusLibraryError):
+    """Raised when a server can't be contacted"""
+
+
+@dataclasses.dataclass(kw_only=True)
+class Prompt:
+    system: str
+    user: str
+    schema: type[BaseModel]
+    cache_dir: cfs.FsPath
+    cache_namespace: str
+    cache_checksum: str
+
+
+@dataclasses.dataclass
+class PromptResponse:
+    """
+    The response from an NLP model.
+
+    Be cautious if removing or renaming fields, as it will likely break serialization.
+    """
+
+    answer: BaseModel
+    fingerprint: str | None = None
+
+    def to_dict(self) -> dict:
+        serialized = dataclasses.asdict(self)
+        serialized["answer"] = self.answer.model_dump(
+            round_trip=True, exclude_unset=True, by_alias=True, mode="json"
+        )
+        return serialized
+
+    @classmethod
+    def from_dict(cls, serialized: dict, schema: type[BaseModel]) -> Self:
+        answer = schema.model_validate(serialized.pop("answer"))
+        return PromptResponse(answer, **serialized)
+
+
+@dataclasses.dataclass(kw_only=True)
+class TokenStats:
+    new_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_written_input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclasses.dataclass(kw_only=True)
+class TokenPrices:
+    date: datetime.date  # when these prices were last updated
+    # These values are in dollars per 1,000-tokens (e.g. $0.0165/1000-tokens)
+    new_input_tokens: float
+    cache_read_input_tokens: float = 0
+    cache_written_input_tokens: float = 0
+    output_tokens: float
+    multiplier: float = 1
+
+
+class Provider(abc.ABC):
+    def __init__(self):
+        self.stats = TokenStats()
+        self.supports_batches = False
+
+    def post_init_check(self) -> None:
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    def prompt(self, system: str, user: str, schema: type[BaseModel]) -> PromptResponse:
+        pass  # pragma: no cover
+
+    # Called when all reads are done - provider can finish up any in-progress batches, etc
+    def finish(self) -> None:
+        pass  # pragma: no cover
+
+
+class BedrockProvider(Provider):
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        supports_cache: bool = True,
+        supports_schema: bool = True,
+    ):
+        super().__init__()
+        self.model_name = model_name
+        self.supports_cache = supports_cache
+        self.supports_schema = supports_schema
+        self.client = boto3.client("bedrock-runtime")
+
+    def prompt(self, system: str, user: str, schema: type[BaseModel]) -> PromptResponse:
+        # Bedrock does not make it easy to define a JSON schema.
+        # See https://builder.aws.com/content/2hWA16FSt2bIzKs0Z1fgJBwu589/ for how to do it.
+        # Basically, you have to define a JSON-conversion tool and ask for it to be used.
+        #
+        # But even then, it's only sometimes used, based on the model (e.g. gpt-oss-120b is like
+        # a 50/50 shot).
+        # So we handle both response types below during parsing, regardless of schema support.
+        #
+        # Also, some models *don't* support this approach at all, and will error out if you provide
+        # the toolChoice field. So let's skip those here.
+        extra_args = {}
+        if self.supports_schema:
+            extra_args = {
+                "toolConfig": {
+                    "tools": [
+                        {
+                            "toolSpec": {
+                                "name": "to_json",
+                                "description": "convert to JSON",
+                                "inputSchema": {"json": schema.model_json_schema()},
+                            },
+                        },
+                    ],
+                    "toolChoice": {"tool": {"name": "to_json"}},
+                },
+            }
+            if self.supports_cache:
+                extra_args["toolConfig"]["tools"].append({"cachePoint": {"type": "default"}})
+
+        system_prompts = [{"text": system}]
+        if self.supports_cache:
+            system_prompts.append({"cachePoint": {"type": "default"}})
+
+        response = self.client.converse(
+            modelId=self.model_name,
+            system=system_prompts,
+            messages=[{"role": "user", "content": [{"text": user}]}],
+            inferenceConfig={"temperature": 0},
+            **extra_args,
+        )
+
+        usage = response.get("usage", {})
+        self.stats.cache_read_input_tokens += usage.get("cacheReadInputTokens", 0)
+        self.stats.cache_written_input_tokens += usage.get("cacheWriteInputTokens", 0)
+        self.stats.new_input_tokens += usage.get("inputTokens", 0)
+        self.stats.output_tokens += usage.get("outputTokens", 0)
+
+        stop_reason = response.get("stopReason")
+        if stop_reason not in {"end_turn", "tool_use"}:
+            raise ValueError(f"did not complete, with stop reason: {stop_reason}")
+
+        # There could be multiple content blocks returned (e.g. gpt-oss gives a reasoning block)
+        for content in response["output"]["message"]["content"]:
+            if "toolUse" in content:
+                raw_json = content["toolUse"]["input"]
+                # Sometimes (e.g. with claude sonnet 4.5) we get a wrapper field of "parameter"
+                # or "$PARAMETER_NAME" :shrug: - for now, just look for those names in particular.
+                # If we see a wider variety, we can try to skip any single wrapper field, but I
+                # want to keep the option of studies that have only one top level field for now.
+                top_keys = set(raw_json)
+                if len(top_keys) == 1 and {"parameter", "$PARAMETER_NAME"} & top_keys:
+                    raw_json = raw_json.popitem()[1]
+                answer = schema.model_validate(raw_json)
+                break
+            if "text" in content:
+                # Do a little work to find the JSON in the middle of a text response.
+                # Usually, it is formatted with some markdown (at least in llama4 and gpt-oss).
+                text = content["text"]
+                pieces = text.split("```")
+                if len(pieces) == 3:
+                    text = pieces[1].removeprefix("json")
+                # This might raise a validation error, but that's caught in upper layers.
+                answer = schema.model_validate_json(text)
+                break
+        else:
+            raise ValueError("no response content found")
+
+        return PromptResponse(answer)
+
+
+class OpenAIProvider(Provider):
+    # From https://platform.openai.com/docs/api-reference/batch/create
+    AZURE_MAX_BATCH_COUNT = 50_000
+    AZURE_MAX_BATCH_BYTES = 200_000_000  # 200 MB
+
+    def __init__(
+        self,
+        model_name: str,
+        client: openai.OpenAI,
+        *,
+        max_batch_count: int | None,
+        supports_schema: bool,
+        deployment: str | None = None,
+    ):
+        super().__init__()
+        self.model_name = model_name
+        self.client = client
+        self.supports_batches = max_batch_count is not None
+        self.max_batch_count = self.AZURE_MAX_BATCH_COUNT
+        if self.supports_batches:
+            # TODO MIKE: add coverage
+            self.max_batch_count = min(self.max_batch_count, max_batch_count)  # pragma: no cover
+        self.supports_schema = supports_schema
+        self.deployment = deployment or model_name
+        self.batch_filename = None
+        self.batch_rows = 0
+
+    def post_init_check(self) -> None:
+        try:
+            models = self.client.models.list()
+            names = {model.id for model in models}
+        except openai.APIError as exc:
+            raise UnreachableModel(f"NLP server is unreachable: {exc}") from exc
+
+        if self.model_name not in names:
+            raise errors.CumulusLibraryError(
+                f"NLP server does not have model ID '{self.model_name}'."
+            )
+
+    @staticmethod
+    def pydantic_to_response_format(schema: type[BaseModel]):
+        # Same thing that the openai library does, but done manually here, because the batching
+        # code uses this too, and needs to do it manually like this.
+
+        # OpenAI has some extra formatting requirements on schemas, that would be difficult
+        # to reproduce, but they don't expose those very cleanly. (We want its internal helper
+        # method `to_strict_json_schema()`, but best I see exposed is `pydantic_function_tool`,
+        # which has what we want inside it.)
+        formatted_schema = openai.pydantic_function_tool(schema)["function"]["parameters"]
+
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "schema": formatted_schema,
+                "name": schema.__name__,
+                "strict": True,
+            },
+        }
+
+    def _prompt_args(self, system: str, user: str, schema: type[BaseModel]) -> dict:
+        if self.supports_schema:
+            response_format = self.pydantic_to_response_format(schema)
+        else:
+            # MIKE TODO: add coverage
+            response_format = {"type": "json_object"}  # pragma: no cover
+
+        return {
+            "model": self.deployment,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "seed": 12345,  # arbitrary, just specifying it for reproducibility
+            "temperature": 0,  # minimize temp, also for reproducibility
+            "timeout": 120,  # in seconds
+            "response_format": response_format,
+        }
+
+    def _process_completion_result(
+        self, response: ParsedChatCompletion, schema: type[BaseModel], batched: bool = False
+    ) -> PromptResponse:
+        if response.usage:
+            cached_tokens = 0
+            if response.usage.prompt_tokens_details:
+                cached_tokens = response.usage.prompt_tokens_details.cached_tokens or 0
+            self.stats.cache_read_input_tokens += cached_tokens
+            self.stats.new_input_tokens += response.usage.prompt_tokens - cached_tokens
+            self.stats.output_tokens += response.usage.completion_tokens
+
+        choice = response.choices[0]
+        if self.supports_schema and choice.message.parsed:
+            # TODO MIKE: add coverage
+            parsed = choice.message.parsed  # pragma: no cover
+        else:
+            parsed = schema.model_validate_json(choice.message.content)
+
+        if choice.finish_reason != "stop":
+            raise ValueError(f"did not complete, with finish reason: {choice.finish_reason}")
+
+        return PromptResponse(
+            answer=parsed,
+            fingerprint=response.system_fingerprint,
+        )
+
+    def prompt(self, system: str, user: str, schema: type[BaseModel]) -> PromptResponse:
+        prompt_args = self._prompt_args(system, user, schema)
+        response = self.client.chat.completions.parse(**prompt_args)
+        return self._process_completion_result(response, schema)
+
+    # TODO MIKE: add back when implementing batching
+
+    # async def add_to_batch(self, prompt: Prompt, tmp_dir: str) -> str | None:
+    #     batch_id = None
+
+    #     # Check if we can early exit, because it's in cache already
+    #     cached = caching.cache_read(prompt.cache_dir, prompt.cache_namespace,
+    #                                 prompt.cache_checksum)
+    #     if cached is not None:
+    #         return None
+
+    #     # Format new row
+    #     row = {
+    #         "custom_id": prompt.cache_checksum,
+    #         "method": "POST",
+    #         "url": "/v1/chat/completions",
+    #         "body": self._prompt_args(prompt.system, prompt.user, prompt.schema),
+    #     }
+    #     row = json.dumps(row) + "\n"
+
+    #     # Confirm we won't go past the size limit if we add this new row; send current batch if so
+    #     if self.batch_filename:
+    #         new_size = os.path.getsize(self.batch_filename) + len(row)
+    #         new_lines = self.batch_rows + 1
+    #         if new_size > self.AZURE_MAX_BATCH_BYTES or new_lines > self.AZURE_MAX_BATCH_COUNT:
+    #             # New row wouldn't fit, send old one first
+    #             batch_id = await self._send_batch(prompt.cache_dir, prompt.cache_namespace)
+
+    #     # Are we continuing a WIP file, or do we need to create a new one?
+    #     if self.batch_filename:
+    #         tmp_file = open(self.batch_filename, "a", encoding="utf8")
+    #     else:
+    #         tmp_file = tempfile.NamedTemporaryFile(
+    #             "wt", dir=tmp_dir, delete=False, suffix=".jsonl")
+    #         self.batch_filename = tmp_file.name
+
+    #     # Add our new row
+    #     with tmp_file:
+    #         tmp_file.write(row)
+    #         self.batch_rows += 1
+
+    #     return batch_id
+
+    # async def _send_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str:
+    #     prompt_file = await self.client.files.create(
+    #         file=pathlib.Path(self.batch_filename),
+    #         purpose="batch",
+    #     )
+
+    #     batch = await self.client.batches.create(
+    #         completion_window="24h",
+    #         endpoint="/v1/chat/completions",
+    #         input_file_id=prompt_file.id,
+    #     )
+
+    #     os.unlink(self.batch_filename)
+    #     self.batch_filename = None
+    #     self.batch_rows = 0
+
+    #     # Save this batch ID for resuming later
+    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
+    #     batch_key = f"batches-{_provider_name}"
+    #     metadata[batch_key] = [*metadata.get(batch_key, []), batch.id]
+    #     caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
+
+    #     return batch.id
+
+    # async def finish_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str | None:
+    #     if self.batch_filename:
+    #         return await self._send_batch(cache_dir, cache_namespace)
+    #     return None
+
+    # async def wait_for_batch(
+    #     self,
+    #     batch_id: str, *, schema: type[BaseModel], cache_dir: cfs.FsPath, cache_namespace: str
+    # ) -> None:
+    #     # Poll the batches until completion
+    #     batch = await self.client.batches.retrieve(batch_id=batch_id)
+    #     # You can see the list of valid statuses here:
+    #     # https://platform.openai.com/docs/guides/batch/2-uploading-your-batch-input-file
+    #     while batch.status in {"validating", "in_progress", "finalizing"}:
+    #         await asyncio.sleep(60 * 5)  # check every five minutes
+    #         batch = await self.client.batches.retrieve(batch_id=batch_id)
+
+    #     if batch.status != "completed":
+    #         logging.warning(f"Batch did not complete, got status: '{batch.status}'")
+    #         # Don't exit function - process the errors and output that we do have, and remove the
+    #         # batch from our metadata cache like normal
+
+    #     # Check for errors
+    #     if batch.error_file_id:
+    #         error_file = await self.client.files.content(file_id=batch.error_file_id)
+    #         async for line in await error_file.aiter_lines():
+    #             try:
+    #                 line = json.loads(line)
+    #                 # Yes, error.message.error.message is really where this is kept.
+    #                 msg = line.get("error", {}).get("message", {}).get("error", {}).get("message")
+    #                 if msg:
+    #                     logging.warning(f"Error from NLP: {msg}")
+    #             except json.JSONDecodeError:
+    #                 logging.warning(f"Could not process error message: '{line}'")
+
+    #     # Get the results!
+    #     if batch.output_file_id:
+    #         contents = await self.client.files.content(file_id=batch.output_file_id)
+
+    #         async for line in await contents.aiter_lines():
+    #             line = json.loads(line)
+    #             # If an error happens, it seems to come in via the error_file_id above.
+    #             # But just for safety, we'll also check here.
+    #             if line.get("error") and (error := line["error"].get("message")):
+    #                 logging.warning(f"Error from NLP: {error}")
+    #                 continue
+    #             status = line.get("response", {}).get("status_code", 200)
+    #             if status >= 300:
+    #                 logging.warning(f"Unexpected status code from NLP: {status}")
+    #                 continue
+    #             checksum = line.get("custom_id")
+    #             body = line.get("response", {}).get("body")
+    #             if not body or not checksum:
+    #                 logging.warning("Unexpected response from NLP: missing data")
+    #                 continue
+
+    #             # Write each valid response to cache
+    #             result = ParsedChatCompletion.model_validate(body)
+    #             response = self._process_completion_result(result, schema)
+    #             caching.cache_write(
+    #                 cache_dir, cache_namespace, checksum, json.dumps(response.to_dict())
+    #             )
+
+    #     # We could clean up files here, but the batch, input file, and output file are cleaned
+    #     # automatically after 30 days, so let's not bother deleting them ourselves, in case we
+    #     # need to do some manual recovery.
+
+    #     # Drop this batch ID from resume list
+    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
+    #     batch_key = f"batches-{_provider_name}"
+    #     batch_ids = metadata.get(batch_key, [])
+    #     if batch.id in batch_ids:
+    #         batch_ids.remove(batch.id)
+    #     metadata[batch_key] = batch_ids
+    #     caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
+
+
+class AzureProvider(OpenAIProvider):
+    def __init__(self, model_name: str, **kwargs):
+        super().__init__(
+            model_name,
+            openai.AzureOpenAI(api_version="2024-10-21"),
+            **kwargs,
+        )
+
+
+class VllmProvider(OpenAIProvider):
+    def __init__(self, compose_id, model_name: str, env_stem: str, port: int):
+        url = os.environ.get(f"CUMULUS_{env_stem}_URL")  # set by compose.yaml
+        url = url or f"http://localhost:{port}/v1"  # offer non-docker fallback
+        super().__init__(
+            model_name,
+            openai.OpenAI(base_url=url, api_key=""),
+            supports_schema=True,
+            max_batch_count=None,
+        )
+        self.compose_id = compose_id
+
+    def post_init_check(self) -> None:
+        try:
+            super().post_init_check()
+        except UnreachableModel as exc:
+            raise UnreachableModel(  # add a little suggestion
+                f"Try running 'docker compose up {self.compose_id} --wait'.\n"
+                "Or pass --provider to specify a cloud NLP provider."
+            ) from exc
+
+
+class Model:
+    ##################################
+    # Fields for subclasses to fill in
+    ##################################
+
+    MODEL_ID = None  # official model name in NLP config files
+
+    AZURE_ID = None  # model name in MS Azure
+    AZURE_PRICES: TokenPrices | None = None
+    AZURE_BATCHES = True  # turns on batch support
+    AZURE_SCHEMA = True  # turns on JSON schema support
+
+    BEDROCK_ID = None  # model name in AWS Bedrock
+    BEDROCK_PRICES: TokenPrices | None = None
+    BEDROCK_CACHE = True  # turns on caching
+    BEDROCK_SCHEMA = True  # turns on JSON schema support
+
+    COMPOSE_ID = None  # docker service name in compose.yaml
+    VLLM_INFO = None  # tuple of vLLM model name, env var stem use for URL, plus default port
+
+    #########################################
+    # End of fields for subclasses to fill in
+    #########################################
+
+    AZURE_ENV = ("AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT")
+
+    @staticmethod
+    def _env_defined(env_keys: Iterable[str]) -> bool:
+        return all(os.environ.get(key) for key in env_keys)
+
+    def raise_unsupported_error(self, provider: str) -> NoReturn:
+        raise errors.CumulusLibraryError(
+            f"{self.__class__.__name__} does not support the '{provider}' provider."
+        )
+
+    def __init__(self, config: note_utils.NlpConfig):
+        self.prices = None
+        self.max_batch_count = config.note_limit
+
+        if config.provider == "azure":
+            if not self.AZURE_ID:
+                self.raise_unsupported_error(config.provider)
+            if not self._env_defined(self.AZURE_ENV):
+                raise errors.CumulusLibraryError(
+                    "Missing Azure environment variables. "
+                    "Set both AZURE_OPENAI_API_KEY & AZURE_OPENAI_ENDPOINT."
+                )
+            self.provider = AzureProvider(
+                self.AZURE_ID,
+                max_batch_count=self.max_batch_count if self.AZURE_BATCHES else None,
+                supports_schema=self.AZURE_SCHEMA,
+                deployment=config.azure_deployment,
+            )
+            self.prices = self.AZURE_PRICES
+
+        elif config.provider == "bedrock":
+            if not self.BEDROCK_ID:
+                self.raise_unsupported_error(config.provider)
+            self.provider = BedrockProvider(
+                self.BEDROCK_ID,
+                supports_cache=self.BEDROCK_CACHE,
+                supports_schema=self.BEDROCK_SCHEMA,
+            )
+            self.prices = self.BEDROCK_PRICES
+
+        else:
+            if not self.COMPOSE_ID:
+                self.raise_unsupported_error(config.provider)
+            self.provider = VllmProvider(
+                self.COMPOSE_ID,
+                self.VLLM_INFO[0],
+                self.VLLM_INFO[1],
+                self.VLLM_INFO[2],
+            )
+
+        if self.provider.supports_batches and config.use_batching:
+            # Currently, both Azure and Bedrock charge 50% for batch mode.
+            # TODO MIKE: remove no cover
+            self.prices.multiplier = 0.5  # pragma: no cover
+
+    @property
+    def stats(self) -> TokenStats:
+        # MIKE TODO: drop no cover once used
+        return self.provider.stats  # pragma: no cover
+
+    # override to add your own checks
+    def post_init_check(self) -> None:
+        self.provider.post_init_check()
+
+    def prompt(self, prompt: Prompt) -> PromptResponse:
+        return caching.cache_wrapper(
+            prompt.cache_dir,
+            prompt.cache_namespace,
+            prompt.cache_checksum,
+            lambda x: PromptResponse.from_dict(json.loads(x), prompt.schema),  # from file
+            lambda x: json.dumps(x.to_dict()),  # to file
+            self.provider.prompt,
+            prompt.system,
+            prompt.user,
+            prompt.schema,
+        )
+
+    # TODO MIKE: add back when implementing batching (and move to driver.py?)
+
+    # async def prompt_via_batches_if_possible(
+    #     self,
+    #     *,
+    #     schema: type[BaseModel],
+    #     cache_dir: cfs.FsPath,
+    #     cache_namespace: str,
+    #     prompt_iter: AsyncIterator[Prompt],
+    # ) -> None:
+    #     """Will resume any previous batches, run new notes via batches, and save all in cache"""
+    #     if not _use_batch_mode:
+    #         return
+    #     if not self.provider.supports_batches:
+    #         raise errors.CumulusLibraryError(
+    #             f"Model {self.provider.model_name} does not support batching."
+    #         )
+
+    #     # First, resume any previously started batches
+    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
+    #     batch_ids = metadata.get(f"batches-{_provider_name}")
+    #     if batch_ids:
+    #         rich.print(" Resuming previously created batches.")
+    #         await self._wait_for_batches(
+    #             batch_ids, schema=schema, cache_dir=cache_dir, cache_namespace=cache_namespace
+    #         )
+
+    #     # Then, regardless of whether there were existing ones, make new batches for any new
+    #     # notes we now see.
+    #     batch_ids = set()
+    #     with tempfile.TemporaryDirectory() as tmp_dir:
+    #         async for prompt in prompt_iter:
+    #             batch_ids.add(await self.provider.add_to_batch(prompt, tmp_dir))
+    #         batch_ids.add(await self.provider.finish_batch(cache_dir, cache_namespace))
+    #     batch_ids.discard(None)  # drop any None's from calls that didn't create a batch
+    #     if batch_ids:
+    #         rich.print(" Waiting for batches to finish (can be resumed if interrupted).")
+    #         await self._wait_for_batches(
+    #             batch_ids,
+    #             cache_dir=cache_dir,
+    #             cache_namespace=cache_namespace,
+    #             schema=schema,
+    #         )
+
+    # async def _wait_for_batches(
+    #     self,
+    #     batch_ids: set[str],
+    #     *,
+    #     schema: type[BaseModel],
+    #     cache_dir: cfs.FsPath,
+    #     cache_namespace: str,
+    # ) -> None:
+    #     status_box = rich.text.Text()
+
+    #     count = len(batch_ids)
+
+    #     def update_text() -> None:
+    #         plural = "" if count == 1 else "es"
+    #         status_box.plain = (
+    #             f"Waiting for {count} batch{plural} to finish… (may take up to a day)"
+    #         )
+
+    #     async def run_batch(batch_id: str) -> None:
+    #         nonlocal count
+
+    #         await self.provider.wait_for_batch(
+    #             batch_id,
+    #             schema=schema,
+    #             cache_dir=cache_dir,
+    #             cache_namespace=cache_namespace,
+    #         )
+
+    #         count -= 1
+    #         update_text()
+
+    #     with rich.get_console().status(status_box):
+    #         update_text()
+    #         coroutines = [run_batch(batch_id) for batch_id in batch_ids]
+    #         await asyncio.gather(*coroutines)
+
+    #     count = len(batch_ids)
+    #     batch_plural = "" if count == 1 else "es"
+    #     rich.print(f" Waited for {count} batch{batch_plural}.")
+
+
+class Gpt35Model(Model):
+    MODEL_ID = "gpt35"
+    AZURE_ID = "gpt-35-turbo-0125"
+    AZURE_PRICES = TokenPrices(
+        # https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+        # "gpt-35-turbo-0125"
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.00055,
+        output_tokens=0.00165,
+    )
+    AZURE_BATCHES = False
+    AZURE_SCHEMA = False
+
+
+class Gpt4Model(Model):
+    MODEL_ID = "gpt4"
+    AZURE_ID = "gpt-4"
+    AZURE_PRICES = TokenPrices(
+        # https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+        # "GPT-4" with 32K context
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.06,
+        output_tokens=0.12,
+    )
+    AZURE_BATCHES = False
+
+
+class Gpt4oModel(Model):
+    MODEL_ID = "gpt4o"
+    AZURE_ID = "gpt-4o"
+    AZURE_PRICES = TokenPrices(
+        # https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+        # "GPT-4o-2024-1120 Global"
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.0025,
+        cache_read_input_tokens=0.00125,
+        output_tokens=0.01,
+    )
+
+
+class Gpt5Model(Model):
+    MODEL_ID = "gpt5"
+    AZURE_ID = "gpt-5"
+    AZURE_PRICES = TokenPrices(
+        # https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+        # "GPT-5 2025-08-07 Global"
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.00125,
+        cache_read_input_tokens=0.00013,
+        output_tokens=0.01,
+    )
+    AZURE_BATCHES = False
+
+
+class GptOss120bModel(Model):
+    MODEL_ID = "gpt-oss-120b"
+    AZURE_ID = "gpt-oss-120b"
+    AZURE_BATCHES = False
+    # AZURE_PRICES = TokenPrices(...)  # TODO: find online
+    BEDROCK_ID = "openai.gpt-oss-120b-1:0"
+    BEDROCK_CACHE = False
+    BEDROCK_PRICES = TokenPrices(
+        # https://aws.amazon.com/bedrock/pricing/ for us-east-1
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.00015,
+        output_tokens=0.0006,
+    )
+    COMPOSE_ID = "gpt-oss-120b"
+    VLLM_INFO = ("openai/gpt-oss-120b", "GPT_OSS_120B", 8086)
+
+
+class Llama4ScoutModel(Model):
+    MODEL_ID = "llama4-scout"
+    AZURE_ID = "Llama-4-Scout-17B-16E-Instruct"
+    AZURE_BATCHES = False
+    # AZURE_PRICES = TokenPrices(...)  # TODO: find online
+    BEDROCK_ID = "us.meta.llama4-scout-17b-instruct-v1:0"
+    BEDROCK_CACHE = False
+    BEDROCK_SCHEMA = False
+    BEDROCK_PRICES = TokenPrices(
+        # https://aws.amazon.com/bedrock/pricing/ for us-east-1
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.00017,
+        output_tokens=0.00066,
+    )
+    COMPOSE_ID = "llama4-scout"  # TODO MIKE: add compose file to repo & docs
+    VLLM_INFO = ("nvidia/Llama-4-Scout-17B-16E-Instruct-FP4", "LLAMA4_SCOUT", 8087)
+
+
+class ClaudeSonnet45Model(Model):
+    MODEL_ID = "claude-sonnet45"
+    BEDROCK_ID = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    BEDROCK_PRICES = TokenPrices(
+        # https://aws.amazon.com/bedrock/pricing/ for us-east-1
+        date=datetime.date(2025, 10, 15),
+        new_input_tokens=0.0033,
+        cache_read_input_tokens=0.00033,
+        cache_written_input_tokens=0.004125,
+        output_tokens=0.0165,
+    )
+
+
+_MODELS = [
+    ClaudeSonnet45Model,
+    Gpt35Model,
+    Gpt4Model,
+    Gpt4oModel,
+    Gpt5Model,
+    GptOss120bModel,
+    Llama4ScoutModel,
+]
+
+
+def create_model(config: note_utils.NlpConfig) -> Model:
+    if not config.model:
+        raise errors.CumulusLibraryError("An NLP model ID must be provided (using --nlp-model).")
+
+    for model in _MODELS:
+        if config.model == model.MODEL_ID:
+            instance = model(config)
+            instance.post_init_check()
+            return instance
+
+    raise errors.CumulusLibraryError(f"Unknown NLP model ID '{config.model}'")

--- a/cumulus_library/builders/nlp/workflow.py
+++ b/cumulus_library/builders/nlp/workflow.py
@@ -1,0 +1,23 @@
+import msgspec
+
+
+class NlpShared(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    system_prompt: str | None = None
+    user_prompt: str | None = None
+    select_by_word: list[str] | None = None
+    select_by_regex: list[str] | None = None
+    select_by_table: str | None = None  # TODO
+    reject_by_word: list[str] | None = None
+    reject_by_regex: list[str] | None = None
+
+
+class NlpTask(NlpShared):
+    version: int = 0
+    response_schema: str = ""
+    name: str = ""
+
+
+class NlpWorkflow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    config_type: str
+    task: list[NlpTask]
+    shared: NlpShared = msgspec.field(default_factory=NlpShared)

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -1,39 +1,21 @@
 """Class for generating NLP results"""
 
+import json
 import pathlib
 import sys
 
 import cumulus_fhir_support as cfs
+import jambo
 import msgspec
 import rich
 
 import cumulus_library
 from cumulus_library import note_utils
+from cumulus_library.builders.nlp import driver, workflow
+from cumulus_library.template_sql import base_templates
 
 # NLP is driven by a workflow config. See docs/workflows/nlp.md for more details
 # on syntax and expectations.
-
-
-class NlpShared(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
-    system_prompt: str | None = None
-    user_prompt: str | None = None
-    select_by_word: list[str] | None = None
-    select_by_regex: list[str] | None = None
-    select_by_table: str | None = None  # TODO
-    reject_by_word: list[str] | None = None
-    reject_by_regex: list[str] | None = None
-
-
-class NlpTask(NlpShared):
-    version: int = 0
-    response_schema: str = ""
-    name: str = ""
-
-
-class NlpWorkflow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
-    config_type: str
-    task: list[NlpTask]
-    shared: NlpShared = msgspec.field(default_factory=NlpShared)
 
 
 class NlpBuilder(cumulus_library.BaseTableBuilder):
@@ -42,19 +24,23 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         *args,
         toml_config_path: pathlib.Path,
         notes: note_utils.NoteSource,
+        nlp_config: note_utils.NlpConfig | None = None,
         **kwargs,
     ):
         super().__init__()
+        self.stats = None
+        toml_config_path = pathlib.Path(toml_config_path)
+        self._nlp_config = nlp_config or note_utils.NlpConfig()
 
         try:
             with open(toml_config_path, "rb") as file:
                 file_bytes = file.read()
-                self._workflow_config = msgspec.toml.decode(file_bytes, type=NlpWorkflow)
+                self._workflow_config = msgspec.toml.decode(file_bytes, type=workflow.NlpWorkflow)
 
         except Exception as e:
             sys.exit(f"The NLP workflow at {toml_config_path!s} is invalid: \n{e}")
 
-        self._flatten_config()
+        self._flatten_config(toml_config_path.parent)
 
         self._notes = notes
         if not self._notes:
@@ -64,66 +50,77 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
                 "or DocumentReference with inlined clinical notes."
             )
 
-    def _flatten_config(self) -> None:
+    def _flatten_config(self, config_dir: pathlib.Path) -> None:
         """Takes any non-specified task values from the [shared] table"""
-        fields = [x.name for x in msgspec.inspect.type_info(NlpShared).fields]
+        fields = [x.name for x in msgspec.inspect.type_info(workflow.NlpShared).fields]
         for task in self._workflow_config.task:
+            # Grab values from [shared] if not specified
             for field in fields:
                 if getattr(task, field) is None:
                     shared_val = getattr(self._workflow_config.shared, field)
                     setattr(task, field, shared_val)
 
-    def _make_note_filter(self, table_refs: dict[str, cfs.RefSet], task: NlpTask) -> cfs.NoteFilter:
+            # Validate task a little
+            if not task.name:
+                raise ValueError("A task name must be provided")
+            if not task.response_schema:
+                raise ValueError(f"A response schema must be provided for task '{task.name}'")
+
+            # Convert task schema filenames to the JSON schema itself.
+            # Be strict here, just for safety's sake - we can ease up if needed later.
+            if "/" in task.response_schema:
+                raise ValueError("response_schema must be a simple filename, no path elements")
+
+            # Load and parse the response JSON schema into a pydantic model, but check first to
+            # ensure we don't already have an inline JSON definition (useful in tests).
+            if task.response_schema.lstrip().startswith("{"):
+                task.response_schema = json.loads(task.response_schema)
+            else:
+                schema_path = config_dir.joinpath(task.response_schema)
+                with open(schema_path, "rb") as f:
+                    task.response_schema = json.load(f)
+
+            # We are currently using the Python project `jambo`, but it's a new project, less than
+            # a year old. If it becomes obsolete, we can reimplement the parts we care about by
+            # maybe adapting the StackOverflow answers below and augmenting it with (at least)
+            # $defs/$ref support. It wouldn't be pretty, but...
+            # https://stackoverflow.com/questions/73841072/
+            task.response_schema = jambo.SchemaConverter.build(task.response_schema)
+
+    def _make_note_filter(
+        self, table_refs: dict[str, cfs.RefSet], task: workflow.NlpTask
+    ) -> cfs.NoteFilter:
         extra = {}
         if refs := table_refs.get(task.select_by_table):
             extra["select_by_ref"] = refs
         return cfs.make_note_filter(
             reject_by_regex=task.reject_by_regex,
             reject_by_word=task.reject_by_word,
-            salt=self._notes.salt,
+            salt=self._nlp_config.salt,
             select_by_regex=task.select_by_regex,
             select_by_word=task.select_by_word,
             **extra,
         )
 
-    def _print_note_stats(
-        self,
-        *,
-        names: list[str],
-        available: int,
-        had_text: int,
-        considered: list[int],
-        got_response: list[int],
-    ) -> None:
+    def _print_note_stats(self, *, names: list[str], stats: driver.NlpStats) -> None:
         rich.print(" Notes processed:")
         table = rich.table.Table("", "", box=None, show_header=False)
-        table.add_row(" Available:", f"{available:,}")
-        table.add_row(" Had text:", f"{had_text:,}")
+        table.add_row(" Available:", f"{stats.available:,}")
+        table.add_row(" Had text:", f"{stats.had_text:,}")
         for idx, name in enumerate(names):
             suffix = f" ({name})" if name else ""
-            table.add_row(f" Considered{suffix}:", f"{considered[idx]:,}")
-            table.add_row(f" Got response{suffix}:", f"{got_response[idx]:,}")
+            table.add_row(f" Considered{suffix}:", f"{stats.considered[idx]:,}")
+            table.add_row(f" Got response{suffix}:", f"{stats.got_response[idx]:,}")
         rich.get_console().print(table)
 
-    def prepare_queries(
-        self,
-        *args,
-        config: cumulus_library.StudyConfig,
-        **kwargs,
-    ):
-        # Set up some stat counters
-        available = 0
-        had_text = 0
-        considered = [0] * len(self._workflow_config.task)
-        got_response = [0] * len(self._workflow_config.task)
-
+    def _run_nlp(self, config: cumulus_library.StudyConfig) -> None:
         # Gather note filters together
         cursor = config.db.cursor()
         select_by_tables = {
             task.select_by_table for task in self._workflow_config.task if task.select_by_table
         }
 
-        if select_by_tables and not self._notes.salt:
+        if select_by_tables and not self._nlp_config.salt:
             raise RuntimeError(
                 "Cannot calculate anonymized resource IDs without a PHI dir defined. "
                 "Pass --etl-phi-dir and try again."
@@ -134,28 +131,79 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
             self._make_note_filter(table_refs, task) for task in self._workflow_config.task
         ]
 
-        # Go through notes one by one and run NLP on them
-        for note_res in self._notes.progress_iter("Running NLP..."):
-            available += 1
-
-            try:
-                text = cfs.get_text_from_note_res(note_res)
-            except Exception:  # noqa: S112
-                continue
-            had_text += 1
-
-            for idx, task in enumerate(self._workflow_config.task):
-                if not note_filters[idx](note_res, text=text):
-                    continue
-                considered[idx] += 1
-
-                # TODO: the actual NLP :D
+        # Go through notes one by one and run NLP on them (save it to class, so we can examine them
+        # in tests)
+        self.stats = driver.run_nlp(
+            self._notes,
+            tasks=self._workflow_config.task,
+            filters=note_filters,
+            nlp_config=self._nlp_config,
+        )
 
         # Print stat block, because that's interesting feedback
-        self._print_note_stats(
-            names=[t.name for t in self._workflow_config.task],
-            available=available,
-            had_text=had_text,
-            considered=considered,
-            got_response=got_response,
-        )
+        # TODO MIKE: print token stats too
+        self._print_note_stats(names=[t.name for t in self._workflow_config.task], stats=self.stats)
+
+    def _table_is_view(self, study_config: cumulus_library.StudyConfig) -> bool:
+        # When we create a table from parquet with duckdb, we are injecting the data and it
+        # needs to already exist on disk. So we must run the NLP beforehand.
+        # But in Athena, the table is dynamic and we can create the table first, so that even if
+        # cumulus-library gets interrupted during NLP, the user can still see data in there.
+        # Thus, we indicate here whether the database table we're gonna make will act like a view
+        # or a materialized table.
+        return study_config.db.db_type == "athena"
+
+    def _headers(self) -> list[str]:
+        # If you change these, change the schema definition in nlp_builder.py too
+        return [
+            "note_ref",
+            "encounter_ref",
+            "subject_ref",
+            "generated_on",
+            "task_version",
+            "model",
+            "system_fingerprint",
+            "result",
+        ]
+
+    def _col_types_for_task(self, task: workflow.NlpTask) -> list[str]:
+        # If you change these, change the schema definition in nlp_builder.py too
+        return [
+            "VARCHAR",
+            "VARCHAR",
+            "VARCHAR",
+            "VARCHAR",
+            "INT",
+            "VARCHAR",
+            "VARCHAR",
+            "VARCHAR",  # TODO MIKE: this last one is a lie for now - convert to struct
+        ]
+
+    def prepare_queries(
+        self,
+        *args,
+        config: cumulus_library.StudyConfig,
+        **kwargs,
+    ):
+        if not self._table_is_view(config):
+            self._run_nlp(config)
+
+        self.queries = [
+            base_templates.get_ctas_empty_query(  # TODO MIKE: use _from_parquet
+                schema_name=config.schema,
+                table_name=driver.table_name_for_task(task, self._nlp_config),
+                table_cols=self._headers(),
+                table_cols_types=self._col_types_for_task(task),
+            )
+            for task in self._workflow_config.task
+        ]
+
+    def post_execution(
+        self,
+        config: cumulus_library.StudyConfig,
+        *args,
+        **kwargs,
+    ):
+        if self._table_is_view(config):
+            # TODO MIKE: add athena tests
+            self._run_nlp(config)  # pragma: no cover

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -89,6 +89,7 @@ class StudyRunner:
         prepare: bool = False,
         data_path: pathlib.Path | None = None,
         notes: note_utils.NoteSource | None = None,
+        nlp_config: note_utils.NlpConfig | None = None,
     ) -> None:
         """Recreates study views/tables
 
@@ -98,6 +99,7 @@ class StudyRunner:
         :keyword prepare: If true, will render query instead of executing
         :keyword data_path: If prepare is true, the path to write rendered data to
         :keyword notes: Source to read notes from (for NLP)
+        :keyword nlp_config: NLP config options from command line
         """
         manifest = study_manifest.StudyManifest(target, self.data_path, options=options)
         try:
@@ -128,6 +130,7 @@ class StudyRunner:
                 continue_from=continue_from,
                 data_path=data_path,
                 notes=notes,
+                nlp_config=nlp_config,
                 prepare=prepare,
             )
             if not prepare:
@@ -159,6 +162,7 @@ class StudyRunner:
         prepare: bool = False,
         data_path: pathlib.Path,
         notes: note_utils.NoteSource,
+        nlp_config: note_utils.NlpConfig,
     ) -> None:
         """Runs a single table builder
 
@@ -168,6 +172,7 @@ class StudyRunner:
         :keyword prepare: If true, will render query instead of executing
         :keyword data_path: If prepare is true, the path to write rendered data to
         :keyword notes: Source to read notes from (for NLP)
+        :keyword nlp_config: NLP config options from command line
         """
         manifest = study_manifest.StudyManifest(target, options=options)
         # In case someone is using the --builder command with a study that hasn't been run,
@@ -180,6 +185,7 @@ class StudyRunner:
             prepare=prepare,
             data_path=data_path,
             notes=notes,
+            nlp_config=nlp_config,
         )
 
     ### Data exporters
@@ -345,7 +351,8 @@ def run_cli(args: dict):
                     options=args["options"],
                 )
             elif args["action"] == "build":
-                notes = note_utils.NoteSource(args["note_dir"], phi_dir=args["etl_phi_dir"])
+                notes = note_utils.NoteSource(args["note_dir"])
+                nlp_config = note_utils.NlpConfig(args)
                 if args["builder"]:
                     runner.build_matching_files(
                         study_dict[args["target"]],
@@ -354,6 +361,7 @@ def run_cli(args: dict):
                         prepare=args["prepare"],
                         data_path=args["data_path"],
                         notes=notes,
+                        nlp_config=nlp_config,
                     )
                 else:
                     runner.clean_and_build_study(
@@ -363,6 +371,7 @@ def run_cli(args: dict):
                         prepare=args["prepare"],
                         data_path=args["data_path"],
                         notes=notes,
+                        nlp_config=nlp_config,
                     )
 
             elif args["action"] == "export":

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -138,6 +138,43 @@ def add_etl_phi_dir_argument(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_nlp_config(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("Database config")
+    group.add_argument(
+        "--nlp-model",
+        choices=[
+            "claude-sonnet45",
+            "gpt-oss-120b",
+            "gpt35",
+            "gpt4",
+            "gpt4o",
+            "gpt5",
+            "llama4-scout",
+        ],
+        help="Which model to use for NLP (must be provided when using NLP)",
+    )
+    group.add_argument(
+        "--nlp-provider",
+        choices=["azure", "bedrock", "local"],
+        default="local",
+        help="Which model provider to use for NLP (default is local)",
+    )
+    group.add_argument(
+        "--azure-deployment",
+        help="What Azure deployment name to use for NLP (default is model name)",
+    )
+    group.add_argument(
+        "--batch-nlp",
+        action="store_true",
+        help="Use NLP batching mode (saves money, might take longer, not all models support it)",
+    )
+    group.add_argument(
+        "--clean-nlp",
+        action="store_true",
+        help="Previous NLP task results will be deleted before uploading the new ones",
+    )
+
+
 def add_stage_argument(parser: argparse.ArgumentParser) -> None:
     """Adds --stage arg to a subparser"""
     parser.add_argument(
@@ -232,6 +269,7 @@ AWS Athena, the following order of preference is used to select credentials:
     add_study_dir_argument(build)
     add_note_dir_argument(build)
     add_etl_phi_dir_argument(build)
+    add_nlp_config(build)
     add_table_builder_argument(build)
     add_target_argument(build)
     add_verbose_argument(build)

--- a/cumulus_library/enums.py
+++ b/cumulus_library/enums.py
@@ -22,7 +22,7 @@ class ProtectedTables(enum.Enum):
 
 
 class ProtectedTableKeywords(enum.Enum):
-    """Tables with a pattern like '_{keyword}_' are not manually dropped."""
+    """Tables with a pattern like '_{keyword}_' are not automatically dropped."""
 
     ETL = "etl"
     LIB = "lib"

--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -1,3 +1,4 @@
+import argparse
 import binascii
 import pathlib
 from collections.abc import Generator
@@ -15,27 +16,14 @@ class NoteSource:
     def __init__(
         self,
         note_dirs: list[str | pathlib.Path] | None = None,
-        *,
-        phi_dir: str | pathlib.Path | None = None,
     ):
         self._files: dict[cfs.FsPath, int] | None = None
         self._total_size = 0
 
         self._note_dirs = note_dirs
 
-        self._salt = None
-        if phi_dir:
-            codebook_path = cfs.FsPath(phi_dir, "codebook.json")
-            codebook = codebook_path.read_json(default={})
-            if id_salt := codebook.get("id_salt"):
-                self._salt = binascii.unhexlify(id_salt)
-
     def __bool__(self) -> bool:
         return bool(self._note_dirs)
-
-    @property
-    def salt(self) -> bytes | None:
-        return self._salt
 
     def progress_iter(self, label: str) -> Generator[dict]:
         with base_utils.get_progress_bar() as progress:
@@ -100,3 +88,39 @@ def get_table_refs(cursor, table: str) -> cfs.RefSet:
             refs.add_ref(ref)
 
     return refs
+
+
+###################
+# NLP Configuration
+###################
+
+
+class NlpConfig:
+    def __init__(self, args: argparse.Namespace | None = None):
+        """
+        Creates an NlpConfig instance from CLI args.
+
+        Only pass None as an argument in test contexts, where you don't care about full NLP
+        working as expected.
+        """
+        args = args or {}
+        self.model = args.get("nlp_model")
+        self.provider = args.get("nlp_provider", "local")
+        self.azure_deployment = args.get("azure_deployment")
+        self.use_batching = args.get("batch_nlp", False)
+        self.clean = args.get("clean_nlp", False)
+        self.phi_dir = args.get("etl_phi_dir")
+        self.target = args.get("target")
+
+        if self.phi_dir:
+            codebook_path = cfs.FsPath(self.phi_dir, "codebook.json")
+            codebook = codebook_path.read_json(default={})
+            if id_salt := codebook.get("id_salt"):
+                self.salt = binascii.unhexlify(id_salt)
+        else:
+            self.salt = None
+
+        # Hard code a global memory limit for now. This limit is the number of notes we're willing
+        # to hold in memory at once. Once we hit this limit, we write out the current notes.
+        # This can be configurable in the future, as needed.
+        self.note_limit = 100_000

--- a/cumulus_library/studies/example_nlp/age.json
+++ b/cumulus_library/studies/example_nlp/age.json
@@ -1,0 +1,39 @@
+{
+  "properties": {
+    "has_mention": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Has Mention"
+    },
+    "spans": {
+      "description": "Supporting text spans",
+      "items": {
+        "type": "string"
+      },
+      "title": "Spans",
+      "type": "array"
+    },
+    "age": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The age of the patient",
+      "title": "Age"
+    }
+  },
+  "title": "AgeMention",
+  "type": "object"
+}

--- a/cumulus_library/studies/example_nlp/nlp.workflow
+++ b/cumulus_library/studies/example_nlp/nlp.workflow
@@ -2,6 +2,8 @@ config_type = "nlp"
 
 [[task]]
 
+name = "age"
+
 # Version History:
 # ** 1 (2025-10): New serialized format **
 # ** 0 (2025-08): Initial work **

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,14 @@ name = "cumulus-library"
 requires-python = ">= 3.11"
 dependencies = [
     "awswrangler >= 3.11, < 4",
+    "boto3 >= 1.34.131",
     "cumulus-fhir-support >= 1.12",
     "duckdb >= 1.4.1, <1.5.0",
+    "jambo >= 0.1.7",
     "Jinja2 > 3",
     "openpyxl",
     "msgspec",
+    "openai",
     "pandas <3, >=2.1.3",
     "platformdirs",
     "pyarrow >= 11.0",
@@ -44,6 +47,7 @@ test = [
     "pytest-cov",
     "pytest-xdist",
     "responses",
+    "respx",
 ]
 
 [project.urls]

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -8,17 +8,42 @@ from unittest import mock
 
 import cumulus_fhir_support as cfs
 import pytest
+import respx
 
-from cumulus_library import cli, note_utils
+from cumulus_library import cli, errors, note_utils
 from cumulus_library.builders import nlp_builder
+from tests import conftest, nlp_utils
 from tests.conftest import duckdb_args
 
 SALT_STR = "e359191164cd209708d93551f481edd048946a9d844c51dea1b64d3f83dfd1fa"
 SALT_BYTES = binascii.unhexlify(SALT_STR)
 
 
+def add_doc(id_val: str, text: str | None, file) -> None:
+    doc = {
+        "resourceType": "DocumentReference",
+        "id": id_val,
+        "context": {"encounter": [{"reference": "Encounter/enc1"}]},
+    }
+    if text is not None:
+        doc["content"] = [
+            {
+                "attachment": {
+                    "contentType": "text/plain",
+                    "data": base64.standard_b64encode(text.encode()).decode(),
+                },
+            },
+        ]
+    json.dump(doc, file)
+    file.write("\n")
+
+
 def add_dxr(id_val: str, text: str | None, file) -> None:
-    dxr = {"resourceType": "DiagnosticReport", "id": id_val}
+    dxr = {
+        "resourceType": "DiagnosticReport",
+        "id": id_val,
+        "encounter": {"reference": "Encounter/enc1"},
+    }
     if text is not None:
         dxr["presentedForm"] = [
             {
@@ -34,37 +59,84 @@ def add_dxr(id_val: str, text: str | None, file) -> None:
 def note_source(tmp_path) -> note_utils.NoteSource:
     """Just make a sample note source with a row - contents not important"""
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
-        add_dxr("empty", None, f)
+        add_dxr("hello", "hello world", f)
     yield note_utils.NoteSource([tmp_path])
 
 
 def test_unexpected_config_field(tmp_path, note_source):
-    workflow_path = f"{tmp_path}/nlp.workflow"
-    with open(workflow_path, "w", encoding="utf8") as f:
-        f.write("""
-config_type="nlp"
-extra_field="yup"
-""")
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "extra_field": "yup",
+        },
+        "nlp.workflow",
+    )
+
     with pytest.raises(SystemExit, match="contains unknown field `extra_field`"):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
 
 
+def test_task_without_name(tmp_path, note_source):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [{}],
+        },
+        "nlp.workflow",
+    )
+    with pytest.raises(ValueError, match="A task name must be provided"):
+        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+
+
+def test_task_without_schema(tmp_path, note_source):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [{"name": "test"}],
+        },
+        "nlp.workflow",
+    )
+    with pytest.raises(ValueError, match="response schema must be provided for task 'test'"):
+        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+
+
+def test_sketch_schema_path(tmp_path, note_source):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [{"name": "test", "response_schema": "../../../passwd"}],
+        },
+        "nlp.workflow",
+    )
+    with pytest.raises(ValueError, match="response_schema must be a simple filename"):
+        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+
+
 def test_empty_note_dir(tmp_path):
-    workflow_path = f"{tmp_path}/nlp.workflow"
-    with open(workflow_path, "w", encoding="utf8") as f:
-        f.write('config_type="nlp"\n[[task]]')
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
     with pytest.raises(SystemExit, match="there are no notes to work with"):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_utils.NoteSource())
 
 
 def test_table_filter_but_no_salt(tmp_path, note_source, mock_db_config):
-    workflow_path = f"{tmp_path}/nlp.workflow"
-    with open(workflow_path, "w", encoding="utf8") as f:
-        f.write("""
-config_type="nlp"
-[[task]]
-select_by_table="table"
-""")
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "test",
+                    "select_by_table": "table",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                }
+            ],
+        },
+        "nlp.workflow",
+    )
     builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
     err_msg = "Cannot calculate anonymized resource IDs without a PHI dir defined"
     with pytest.raises(RuntimeError, match=err_msg):
@@ -72,40 +144,54 @@ select_by_table="table"
 
 
 def test_flattened_config(tmp_path, note_source):
-    workflow_path = f"{tmp_path}/nlp.workflow"
-    with open(workflow_path, "w", encoding="utf8") as f:
-        f.write("""
-config_type="nlp"
-[shared]
-system_prompt="hello"
-[[task]]
-name="override"
-system_prompt="bye"
-[[task]]
-name="fallthrough"
-""")
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "shared": {
+                "system_prompt": "hello",
+            },
+            "task": [
+                {
+                    "name": "override",
+                    "system_prompt": "bye",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+                {
+                    "name": "fallthrough",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+            ],
+        },
+        "nlp.workflow",
+    )
     builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
     assert builder._workflow_config.task[0].system_prompt == "bye"
     assert builder._workflow_config.task[1].system_prompt == "hello"
 
 
+@respx.mock
 def test_filter(tmp_path, mock_db_config):
-    codebook_path = f"{tmp_path}/codebook.json"
-    with open(codebook_path, "w", encoding="utf8") as f:
-        json.dump({"id_salt": SALT_STR}, f)
-
-    workflow_path = f"{tmp_path}/nlp.workflow"
-    with open(workflow_path, "w", encoding="utf8") as f:
-        f.write("""
-config_type="nlp"
-[[task]]
-name="filtered"
-select_by_word=["fever"]
-reject_by_word=["cold"]
-select_by_table="prev_table"
-[[task]]
-name="all"
-""")
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "filtered",
+                    "select_by_word": ["fever"],
+                    "reject_by_word": ["cold"],
+                    "select_by_table": "prev_table",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+                {
+                    "name": "all",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+            ],
+        },
+        "nlp.workflow",
+    )
 
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
         add_dxr("1", None, f)  # no text, will be skipped
@@ -118,9 +204,9 @@ name="all"
   Available:                5 
   Had text:                 4 
   Considered (filtered):    1 
-  Got response (filtered):  0 
+  Got response (filtered):  1 
   Considered (all):         4 
-  Got response (all):       0 """
+  Got response (all):       4 """
 
     mock_db_config.db.cursor().execute(f"""
         CREATE TABLE prev_table AS SELECT * FROM (
@@ -133,9 +219,12 @@ name="all"
         AS t (diagnosticreport_id)
     """)
 
-    source = note_utils.NoteSource([tmp_path], phi_dir=tmp_path)
+    source = note_utils.NoteSource([tmp_path])
+    model = nlp_utils.MockModel()
 
-    builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=source)
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=source, nlp_config=model.nlp_config()
+    )
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
@@ -151,11 +240,9 @@ def test_args_passed_down(mock_builder, tmp_path):
         dxr = {"resourceType": "DiagnosticReport", "id": "1"}
         json.dump(dxr, f)
 
-    os.makedirs(f"{tmp_path}/phi")
-    with open(f"{tmp_path}/phi/codebook.json", "w", encoding="utf8") as f:
-        json.dump({"id_salt": SALT_STR}, f)
-
     mock_builder.side_effect = RuntimeError("nope")
+
+    mock_model = nlp_utils.MockModel()
 
     build_args = duckdb_args(
         [
@@ -164,7 +251,7 @@ def test_args_passed_down(mock_builder, tmp_path):
             "--target=example_nlp",
             "--stage=nlp",
             f"--note-dir={tmp_path}",
-            f"--etl-phi-dir={tmp_path}/phi",
+            *mock_model.cli_args(),
         ],
         tmp_path,
     )
@@ -172,6 +259,420 @@ def test_args_passed_down(mock_builder, tmp_path):
     with pytest.raises(RuntimeError, match="nope"):
         cli.main(cli_args=build_args)
 
+    config = mock_builder.call_args[1]["nlp_config"]
+    assert config.salt == SALT_BYTES
+
     source = mock_builder.call_args[1]["notes"]
-    assert source.salt == SALT_BYTES
     assert list(source.progress_iter("label")) == [dxr]
+
+
+def test_unreachable_vllm(tmp_path, note_source, mock_db_config):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    model.mock_openai_model_list(status_code=500)
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+    with pytest.raises(errors.CumulusLibraryError, match="Try running 'docker compose up"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+def test_cached_response(tmp_path, mock_db_config):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "hello_world",
+                    "response_schema": '{"title":"test", "type": "object", '
+                    '"properties": {"hello": {"type": "string"}}}',
+                },
+            ],
+        },
+        "nlp.workflow",
+    )
+
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr("1", "say hello to the world", f)
+
+    source = note_utils.NoteSource([tmp_path])
+
+    model = nlp_utils.MockModel()
+    model.mock_openai_response({"hello": "world"})
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=source, nlp_config=model.nlp_config()
+    )
+    builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 1
+
+    # Confirm that we cache the response and don't hit the endpoint again
+    # (and add a new note to sanity check that we do actually fail on the new one)
+    model.mock_openai_response({}, status_code=500)
+
+    with open(f"{tmp_path}/dxr.ndjson", "a", encoding="utf8") as f:
+        add_dxr("2", "goodbye", f)
+
+    builder.prepare_queries(config=mock_db_config)
+    assert builder.stats.considered[0] == 2
+    assert builder.stats.got_response[0] == 1  # still got our cached result
+
+
+@respx.mock
+def test_span_correction(tmp_path, mock_db_config):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "hello_world",
+                    # Make spans array deeply nested, to prove we can find it anywhere
+                    "response_schema": """{
+                        "title":"test", "type": "object", "properties": {
+                            "parent_list": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "parent_dict": {
+                                            "type": "object",
+                                            "properties": {
+                                                "spans": {
+                                                    "type": "array",
+                                                    "items": {"type": "string"}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }""",
+                },
+            ],
+        },
+        "nlp.workflow",
+    )
+
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr("dxr", "First, second \n\nthird  fourth.", f)
+
+    source = note_utils.NoteSource([tmp_path])
+
+    model = nlp_utils.MockModel()
+    model.mock_openai_response(
+        {"parent_list": [{"parent_dict": {"spans": [" first,   ", "second third", "forth"]}}]}
+    )
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 1
+    assert "'spans': [(0, 5), (7, 21)]" in console_output.getvalue()
+    failure_msg = "Could not match span received from NLP server for DiagnosticReport/dxr: forth"
+    assert failure_msg in console_output.getvalue()
+
+
+@respx.mock
+def test_writes_out_at_note_limit(tmp_path, mock_db_config):
+    with open(f"{tmp_path}/doc.ndjson", "w", encoding="utf8") as f:
+        add_doc("1", "Note one", f)
+        add_doc("2", "Note two", f)
+        add_doc("3", "Note three", f)
+
+    source = note_utils.NoteSource([tmp_path])
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    config = model.nlp_config()
+    config.note_limit = 2
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=source,
+        nlp_config=config,
+    )
+
+    with mock.patch("cumulus_library.builders.nlp.driver.NlpNotePool._write_to_disk") as mock_write:
+        # Fake an error too, to confirm we gracefully handle that and print message
+        mock_write.side_effect = [RuntimeError("test1"), RuntimeError("test2")]
+        console_output = io.StringIO()
+        with contextlib.redirect_stdout(console_output):
+            builder.prepare_queries(config=mock_db_config)
+
+    assert mock_write.call_count == 2
+    assert "Failed to process note: test1" in console_output.getvalue()
+    assert "Failed to process note: test2" in console_output.getvalue()
+
+
+@respx.mock
+def test_no_batching_support(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="does not support batching"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+def test_no_phi_dir(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    config = model.nlp_config()
+    config.phi_dir = None
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=config
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="Please provide a PHI dir"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+def test_bad_nlp_model(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    config = model.nlp_config()
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=config
+    )
+
+    config.model = "nope"
+    with pytest.raises(errors.CumulusLibraryError, match="Unknown NLP model ID"):
+        builder.prepare_queries(config=mock_db_config)
+
+    config.model = None
+    with pytest.raises(errors.CumulusLibraryError, match="An NLP model ID must be provided"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+def test_missing_nlp_model(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    model.mock_openai_model_list(models=[])
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="NLP server does not have model ID"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+def test_bad_stop(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+    model.mock_openai_response({}, finish_reason="bad_reason")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 0
+    assert "did not complete, with finish reason: bad_reason" in console_output.getvalue()
+
+
+@respx.mock
+def test_cloud_model_but_local_provider(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(model_id="gpt5")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="does not support the 'local' provider"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+@respx.mock
+@nlp_utils.mock_env("azure")
+def test_azure_happy_path(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    builder.prepare_queries(config=mock_db_config)
+    assert builder.stats.got_response[0] == 1
+
+
+def test_azure_bad_model(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(model_id="claude-sonnet45", provider="azure")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="does not support the 'azure' provider"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+def test_azure_no_env(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="Missing Azure environment variables"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+def test_bedrock_happy_path(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="bedrock", model_id="claude-sonnet45")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    builder.prepare_queries(config=mock_db_config)
+    assert builder.stats.got_response[0] == 1
+
+
+def test_bedrock_bad_stop(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="bedrock")
+    model.mock_bedrock_response({}, stop_reason="bad_reason")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 0
+    assert "did not complete, with stop reason: bad_reason" in console_output.getvalue()
+
+
+def test_bedrock_bad_model(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="bedrock", model_id="gpt5")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    with pytest.raises(errors.CumulusLibraryError, match="does not support the 'bedrock' provider"):
+        builder.prepare_queries(config=mock_db_config)
+
+
+def test_bedrock_skips_wrapper_in_response(tmp_path, mock_db_config, note_source):
+    """Confirm we drop a "parameter" wrapper object in response"""
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "hello_world",
+                    "response_schema": '{"title":"test", "type": "object", '
+                    '"properties": {"hello": {"type": "string"}}}',
+                }
+            ],
+        },
+        "nlp.workflow",
+    )
+
+    model = nlp_utils.MockModel(provider="bedrock")
+    model.mock_bedrock_response({"parameter": {"hello": "world"}})
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 1
+    assert "'result': {'hello': 'world'}" in console_output.getvalue()
+
+
+def test_bedrock_text_response(tmp_path, mock_db_config, note_source):
+    """Confirm we find json inside a text response"""
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "hello_world",
+                    "response_schema": '{"title":"test", "type": "object", '
+                    '"properties": {"hello": {"type": "string"}}}',
+                }
+            ],
+        },
+        "nlp.workflow",
+    )
+
+    model = nlp_utils.MockModel(provider="bedrock")
+    model.mock_bedrock_response(
+        """
+Preamble...
+
+```json
+{"hello": "goodbye"}
+```
+
+Summary.
+""",
+        mode="text",
+    )
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 1
+    assert "'result': {'hello': 'goodbye'}" in console_output.getvalue()
+
+
+def test_bedrock_no_response(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="bedrock")
+    model.mock_bedrock_response("", mode="none")
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.prepare_queries(config=mock_db_config)
+
+    assert builder.stats.got_response[0] == 0
+    assert "Failed to process note: no response content found" in console_output.getvalue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,10 +111,11 @@ def duckdb_args(args: list, tmp_path, stats=False):
     return [*args, "--db-type", "duckdb", "--database", f"{tmp_path}/duck.db"]
 
 
-def write_toml(path, toml_dict, filename="manifest.toml"):
+def write_toml(path, toml_dict, filename="manifest.toml") -> pathlib.Path:
     manifest_str = msgspec.toml.encode(toml_dict)
     with open(path / filename, "wb") as f:
         f.write(manifest_str)
+    return path / filename
 
 
 def date_to_epoch(year: int, month: int, day: int) -> int:

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -1,0 +1,172 @@
+import functools
+import json
+import os
+import pathlib
+import tempfile
+import weakref
+from unittest import mock
+
+import respx
+
+from cumulus_library import note_utils
+from tests import conftest
+
+EMPTY_SCHEMA = '{"title":"test", "type": "object"}'
+
+
+def mock_env(provider: str = "local"):
+    if provider == "azure":
+        new = {
+            "AZURE_OPENAI_API_KEY": "azure-key",
+            "AZURE_OPENAI_ENDPOINT": "https://example.com/azure",
+        }
+    else:
+        new = {}
+
+    def outer(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            with mock.patch.dict(os.environ, new, clear=True):
+                return func(*args, **kwargs)
+
+        return inner
+
+    return outer
+
+
+class MockModel:
+    def __init__(self, model_id: str = "gpt-oss-120b", provider: str = "local"):
+        self.model_id = model_id
+        self.provider = provider
+
+        # Create a codebook for any NLP we do, to keep consistent anon IDs
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.phi = pathlib.Path(self.tempdir.name, "phi")
+        self.phi.mkdir()
+        with open(self.phi / "codebook.json", "w", encoding="utf8") as f:
+            salt = "e359191164cd209708d93551f481edd048946a9d844c51dea1b64d3f83dfd1fa"
+            json.dump({"id_salt": salt}, f)
+
+        # Determine the server to use for this model
+        if provider == "bedrock":
+            boto_patcher = mock.patch("boto3.client")
+            weakref.finalize(self, boto_patcher.stop)
+            self._boto = mock.MagicMock()
+            client_mock = boto_patcher.start()
+            client_mock.return_value = self._boto
+            self.mock_bedrock_response({})
+        else:
+            if provider == "azure":
+                url = "https://example.com/azure/openai"
+                chat_prefix = f"/deployments/{model_id}"
+                params = {"api-version": "2024-10-21"}
+            else:
+                urls = {
+                    "gpt-oss-120b": "http://localhost:8086/v1",
+                    "llama4-scout": "http://localhost:8087/v1",
+                }
+                url = urls.get(model_id, "nope://invalid")
+                chat_prefix = ""
+                params = {}
+
+            # Do some basic always-on mocking
+            self._list_route = respx.get(f"{url}/models", params=params)
+            self._chat_route = respx.post(f"{url}{chat_prefix}/chat/completions", params=params)
+            self.mock_openai_model_list()
+            self.mock_openai_response({})
+
+    def cli_args(self, *args, **kwargs) -> list[str]:
+        config = self.nlp_config(*args, **kwargs)
+        args = [
+            f"--nlp-model={config.model}",
+            f"--nlp-provider={config.provider}",
+            f"--etl-phi-dir={config.phi_dir}",
+        ]
+        if config.use_batching:
+            args.append("--batch-nlp")
+        return args
+
+    def nlp_config(self, batching: bool = False) -> note_utils.NlpConfig:
+        args = {
+            "nlp_model": self.model_id,
+            "nlp_provider": self.provider,
+            "etl_phi_dir": self.phi,
+            "target": "test",
+            "batch_nlp": batching,
+        }
+        return note_utils.NlpConfig(args)
+
+    def mock_bedrock_response(
+        self, value: dict | str, stop_reason: str = "tool_use", mode: str = "json"
+    ) -> None:
+        response = {
+            "stopReason": stop_reason,
+        }
+        if mode == "text":
+            response["output"] = {"message": {"content": [{"text": value}]}}
+        elif mode == "json":
+            response["output"] = {"message": {"content": [{"toolUse": {"input": value}}]}}
+        else:
+            response["output"] = {"message": {"content": []}}
+        self._boto.converse.return_value = response
+
+    def mock_openai_model_list(
+        self, models: list[str] | None = None, status_code: int = 200
+    ) -> None:
+        if models is None:
+            model_aliases = {
+                "gpt-oss-120b": ["gpt-oss-120b", "openai.gpt-oss-120b-1:0", "openai/gpt-oss-120b"],
+            }
+            models = model_aliases.get(self.model_id, [])
+
+        data = [{"id": alias} for alias in models]
+        self._list_route.respond(status_code=status_code, json={"object": "list", "data": data})
+
+    def mock_openai_response(
+        self, value: dict, finish_reason: str = "stop", status_code: int = 200
+    ) -> None:
+        # https://developers.openai.com/api/reference/chat-completions/overview
+        self._chat_route.respond(
+            status_code=status_code,
+            json={
+                "id": "test-completion",
+                "object": "chat.completion",
+                "created": 1741569952,
+                "model": self.model_id,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(value),
+                        },
+                        "finish_reason": finish_reason,
+                    },
+                ],
+                "usage": {
+                    "prompt_tokens": 19,
+                    "completion_tokens": 10,
+                    "total_tokens": 29,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 5,
+                    },
+                },
+            },
+        )
+
+
+def basic_workflow(tmp_path) -> pathlib.Path:
+    """Returns a dead simple valid config, for when you don't super care what it looks like"""
+    return conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "test",
+                    "response_schema": EMPTY_SCHEMA,
+                },
+            ],
+        },
+        "nlp.workflow",
+    )

--- a/tests/studies/test_example_nlp.py
+++ b/tests/studies/test_example_nlp.py
@@ -4,9 +4,10 @@ import json
 
 import duckdb
 import pandas
+import respx
 
 from cumulus_library import cli
-from tests import testbed_utils
+from tests import nlp_utils, testbed_utils
 from tests.conftest import duckdb_args
 
 
@@ -100,9 +101,12 @@ def test_merging_two_sources(tmp_path):
     ]
 
 
+@respx.mock
 def test_full_build(tmp_path):
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
         json.dump({"resourceType": "DiagnosticReport", "id": "1"}, f)
+
+    model = nlp_utils.MockModel()
 
     build_args = duckdb_args(
         [
@@ -114,6 +118,7 @@ def test_full_build(tmp_path):
             "all",
             "--note-dir",
             str(tmp_path),
+            *model.cli_args(),
         ],
         tmp_path,
     )

--- a/tests/test_note_utils.py
+++ b/tests/test_note_utils.py
@@ -50,8 +50,8 @@ def test_note_source_phi_dir(tmp_path):
     with open(f"{tmp_path}/codebook.json", "w") as f:
         json.dump({"id_salt": SALT_STR}, f)
 
-    source = note_utils.NoteSource(phi_dir=tmp_path)
-    assert source.salt == SALT_BYTES
+    config = note_utils.NlpConfig({"etl_phi_dir": tmp_path})
+    assert config.salt == SALT_BYTES
 
 
 def test_get_table_refs():


### PR DESCRIPTION
This adds some new files to `cumulus_library/builds/nlp/`:
- `caching.py`: this is a copy of caching code from the ETL, nothing new here
- `models.py`: this is a copy of "talking directly to models" from the ETL - only interesting new stuff is that I commented out the batching support and made it sync instead of async.
- `driver.py`: this is new code, to iterate over notes and handle nlp responses.
- `workflow.py`: this is existing code from `nlp_builder.py`, just moved into this file for sharing

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json