### PR TITLE
More control over zipping behavior

### DIFF
--- a/cumulus_library/actions/exporter.py
+++ b/cumulus_library/actions/exporter.py
@@ -82,4 +82,6 @@ def export_study(
         for table in skipped_tables:
             rich.print(f"  - {table}")
     manifest.write_manifest(data_path / manifest.get_study_prefix())
-    base_utils.zip_dir(path, data_path, manifest.get_study_prefix(), archive_csvs=archive)
+    base_utils.zip_dir(
+        path, data_path, manifest.get_study_prefix(), archive_csvs=archive, zip_subdirs=False
+    )

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -121,9 +121,13 @@ def get_tablename_safe_iso_timestamp() -> str:
     return safe_timestamp
 
 
-def zip_dir(read_path, write_path, archive_name, archive_csvs=False):
+def zip_dir(read_path, write_path, archive_name, archive_csvs=False, zip_subdirs=True):
     """Moves a directory to an archive"""
-    file_list = [file for file in read_path.glob("**/*") if file.is_file()]
+    if zip_subdirs:
+        glob_pattern = "**/*"
+    else:
+        glob_pattern = "*"
+    file_list = [file for file in read_path.glob(glob_pattern) if file.is_file()]
     timestamp = get_utc_datetime().isoformat().replace("+00:00", "Z")
     if archive_csvs:
         # archives including csvs are meant to be permanent and are kept outside the study data dirs

--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -123,7 +123,7 @@ def get_tablename_safe_iso_timestamp() -> str:
 
 def zip_dir(read_path, write_path, archive_name, archive_csvs=False, zip_subdirs=True):
     """Moves a directory to an archive"""
-    if zip_subdirs:
+    if zip_subdirs or archive_csvs:
         glob_pattern = "**/*"
     else:
         glob_pattern = "*"

--- a/tests/test_base_utils.py
+++ b/tests/test_base_utils.py
@@ -1,7 +1,10 @@
+import zipfile
+
 import numpy
 import pandas
 import pyarrow
 import pytest
+import time_machine
 
 from cumulus_library import base_utils, errors
 
@@ -80,3 +83,25 @@ def test_pandas_from_hive():
 def test_pandas_from_hive_error():
     with pytest.raises(errors.CumulusLibraryError):
         base_utils.pandas_types_from_hive_types(["EnterpriseBeanFactoryFactory"])
+
+
+@pytest.mark.parametrize(
+    "subdirs,csv,archive_path,expected",
+    [
+        (True, False, "data/data.zip", ["a.parquet", "subdir/b.parquet"]),
+        (False, False, "data/data.zip", ["a.parquet"]),
+        (False, True, "data__2024-01-01T00:00:00Z.zip", ["a.csv"]),
+    ],
+)
+@time_machine.travel("2024-01-01T00:00:00Z", tick=False)
+def test_zip_dir(tmp_path, subdirs, csv, archive_path, expected):
+    data_path = tmp_path / "data"
+    data_path.mkdir()
+    (data_path / "a.parquet").write_text("")
+    (data_path / "a.csv").write_text("")
+    (data_path / "subdir").mkdir()
+    (data_path / "subdir/b.parquet").write_text("")
+
+    base_utils.zip_dir(data_path, tmp_path, "data")
+    with zipfile.ZipFile(tmp_path / "data/data.zip") as z:
+        assert z.namelist() == ["a.parquet", "subdir/b.parquet"]


### PR DESCRIPTION
While doing aggregator integration testing, I ended up creating a lot of issues for myself by expanding a previously uploaded zip in place to examine it's contents, which ended up causing strange behavior.

So - Now the zip method can take a flag which sets it to will only look at the specified dir, and not recurse into subdirs.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json