### PR TITLE
Handle malformed file uploads

### DIFF
--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -102,6 +102,64 @@ class FileUploadBuilder(BaseTableBuilder):
             df[col] = pandas.to_datetime(df[col])
         return df
 
+    def _read_file(self, file, table, cache_dir, task_name):
+        table_filename = pathlib.Path(file).name
+
+        # First, we're going to read data into a pandas dataframe.
+        # For non-parquet cases, we have to jump through some hoops to support
+        # date casting. So, we'll first check if column types were supplied.
+        # Then we're going to naievely load the file, so we can inspect it to get the
+        # names of columns and create a list of expected data types if needed (subbing
+        # out dates for objects, so we can do that postprocessing later) and the actual
+        # column names, which we don't ask the user to provide. We'll then load it a
+        # second time with the required types (getting around some type casting issues
+        # after the dataframe has been created), and then manually cast the date columns
+        # from objects to dates. Yeesh!
+        if table["col_types"] is None:
+            pandas_types = None
+        else:
+            pandas_types = base_utils.pandas_types_from_hive_types(table["col_types"])
+        if file.endswith(".md"):
+            return None, None
+        elif file.endswith(".xlsx"):
+            parquet_path = cache_dir / table_filename.replace(".xlsx", ".parquet")
+            df = pandas.read_excel(self._toml_config_dir / file)
+            dtype_dict, date_cols = self.get_pandas_read_params(df, pandas_types, task_name)
+            df = pandas.read_excel(self._toml_config_dir / file, dtype=pandas_types)
+        elif file.endswith(".csv") or file.endswith(".tsv") or file.endswith(".bsv"):
+            parquet_path = cache_dir / f"{table_filename[:-4]}.parquet"
+            if table["delimiter"] is None:
+                match file.split(".")[-1]:
+                    case "bsv":
+                        table["delimiter"] = "|"
+                    case "csv":
+                        table["delimiter"] = ","
+                    case "tsv":
+                        table["delimiter"] = "\t"
+            df = pandas.read_csv(
+                self._toml_config_dir / file,
+                delimiter=table["delimiter"],
+            )
+            dtype_dict, date_cols = self.get_pandas_read_params(df, pandas_types, task_name)
+            df = pandas.read_csv(
+                self._toml_config_dir / file,
+                delimiter=table["delimiter"],
+                dtype=dtype_dict,
+            )
+
+        elif file.endswith(".parquet"):
+            parquet_path = cache_dir / table_filename
+            df = pandas.read_parquet(self._toml_config_dir / file)
+            dtype_dict, date_cols = self.get_pandas_read_params(df, pandas_types, task_name)
+
+        else:
+            raise errors.FileUploadError(
+                f"{table['file']} is not a supported upload file type.\n"
+                "Supported file types: csv, bsv, tsv, xlsx, parquet"
+            )
+        df = self.reformat_dates(df, date_cols)
+        return df, parquet_path
+
     def prepare_queries(
         self,
         config: base_utils.StudyConfig,
@@ -144,73 +202,14 @@ class FileUploadBuilder(BaseTableBuilder):
                 table["files"] = new_files
 
                 for file in table["files"]:
-                    table_filename = pathlib.Path(file).name
-
-                    # First, we're going to read data into a pandas dataframe.
-                    # For non-parquet cases, we have to jump through some hoops to support
-                    # date casting. So, we'll first check if column types were supplied.
-                    # Then we're going to naievely load the file, so we can inspect it to get the
-                    # names of columns and create a list of expected data types if needed (subbing
-                    # out dates for objects, so we can do that postprocessing later) and the actual
-                    # column names, which we don't ask the user to provide. We'll then load it a
-                    # second time with the required types (getting around some type casting issues
-                    # after the dataframe has been created), and then manually cast the date columns
-                    # from objects to dates. Yeesh!
-                    if table["col_types"] is None:
-                        pandas_types = None
-                    else:
-                        pandas_types = base_utils.pandas_types_from_hive_types(table["col_types"])
                     try:
-                        if file.endswith(".md"):
-                            continue
-                        elif file.endswith(".xlsx"):
-                            parquet_path = cache_dir / table_filename.replace(".xlsx", ".parquet")
-                            df = pandas.read_excel(self._toml_config_dir / file)
-                            dtype_dict, date_cols = self.get_pandas_read_params(
-                                df, pandas_types, task_name
-                            )
-                            df = pandas.read_excel(self._toml_config_dir / file, dtype=pandas_types)
-                        elif (
-                            file.endswith(".csv") or file.endswith(".tsv") or file.endswith(".bsv")
-                        ):
-                            parquet_path = cache_dir / f"{table_filename[:-4]}.parquet"
-                            if table["delimiter"] is None:
-                                match file.split(".")[-1]:
-                                    case "bsv":
-                                        table["delimiter"] = "|"
-                                    case "csv":
-                                        table["delimiter"] = ","
-                                    case "tsv":
-                                        table["delimiter"] = "\t"
-                            df = pandas.read_csv(
-                                self._toml_config_dir / file,
-                                delimiter=table["delimiter"],
-                            )
-                            dtype_dict, date_cols = self.get_pandas_read_params(
-                                df, pandas_types, task_name
-                            )
-                            df = pandas.read_csv(
-                                self._toml_config_dir / file,
-                                delimiter=table["delimiter"],
-                                dtype=dtype_dict,
-                            )
+                        df, parquet_path = self._read_file(file, table, cache_dir, task_name)
 
-                        elif file.endswith(".parquet"):
-                            parquet_path = cache_dir / table_filename
-                            df = pandas.read_parquet(self._toml_config_dir / file)
-                            dtype_dict, date_cols = self.get_pandas_read_params(
-                                df, pandas_types, task_name
-                            )
-
-                        else:
-                            raise errors.FileUploadError(
-                                f"{table['file']} is not a supported upload file type.\n"
-                                "Supported file types: csv, bsv, tsv, xlsx, parquet"
-                            )
                     except pandas.errors.ParserError as e:
                         rich.print(f"Error reading {file}: {e}")
                         sys.exit()
-                    df = self.reformat_dates(df, date_cols)
+                    if df is None:
+                        continue
                     if table["create_mode"] == "single":
                         # for single table mode, we can use the name of the task from the workflow
                         table_name = task_name

--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -9,6 +9,7 @@ import numpy
 import pandas
 import platformdirs
 import pyarrow
+import rich
 
 from cumulus_library import BaseTableBuilder, base_utils, errors, study_manifest
 from cumulus_library.template_sql import base_templates
@@ -159,51 +160,55 @@ class FileUploadBuilder(BaseTableBuilder):
                         pandas_types = None
                     else:
                         pandas_types = base_utils.pandas_types_from_hive_types(table["col_types"])
-                    if file.endswith(".md"):
-                        continue
-                    elif file.endswith(".xlsx"):
-                        parquet_path = cache_dir / table_filename.replace(".xlsx", ".parquet")
-                        df = pandas.read_excel(self._toml_config_dir / file)
-                        dtype_dict, date_cols = self.get_pandas_read_params(
-                            df, pandas_types, task_name
-                        )
-                        df = pandas.read_excel(self._toml_config_dir / file, dtype=pandas_types)
-                    elif file.endswith(".csv") or file.endswith(".tsv") or file.endswith(".bsv"):
-                        parquet_path = cache_dir / f"{table_filename[:-4]}.parquet"
-                        if table["delimiter"] is None:
-                            match file.split(".")[-1]:
-                                case "bsv":
-                                    table["delimiter"] = "|"
-                                case "csv":
-                                    table["delimiter"] = ","
-                                case "tsv":
-                                    table["delimiter"] = "\t"
-                        df = pandas.read_csv(
-                            self._toml_config_dir / file,
-                            delimiter=table["delimiter"],
-                        )
-                        dtype_dict, date_cols = self.get_pandas_read_params(
-                            df, pandas_types, task_name
-                        )
-                        df = pandas.read_csv(
-                            self._toml_config_dir / file,
-                            delimiter=table["delimiter"],
-                            dtype=dtype_dict,
-                        )
+                    try:
+                        if file.endswith(".md"):
+                            continue
+                        elif file.endswith(".xlsx"):
+                            parquet_path = cache_dir / table_filename.replace(".xlsx", ".parquet")
+                            df = pandas.read_excel(self._toml_config_dir / file)
+                            dtype_dict, date_cols = self.get_pandas_read_params(
+                                df, pandas_types, task_name
+                            )
+                            df = pandas.read_excel(self._toml_config_dir / file, dtype=pandas_types)
+                        elif (
+                            file.endswith(".csv") or file.endswith(".tsv") or file.endswith(".bsv")
+                        ):
+                            parquet_path = cache_dir / f"{table_filename[:-4]}.parquet"
+                            if table["delimiter"] is None:
+                                match file.split(".")[-1]:
+                                    case "bsv":
+                                        table["delimiter"] = "|"
+                                    case "csv":
+                                        table["delimiter"] = ","
+                                    case "tsv":
+                                        table["delimiter"] = "\t"
+                                df = pandas.read_csv(
+                                    self._toml_config_dir / file,
+                                    delimiter=table["delimiter"],
+                                )
+                                dtype_dict, date_cols = self.get_pandas_read_params(
+                                    df, pandas_types, task_name
+                                )
+                                df = pandas.read_csv(
+                                    self._toml_config_dir / file,
+                                    delimiter=table["delimiter"],
+                                    dtype=dtype_dict,
+                                )
+                        elif file.endswith(".parquet"):
+                            parquet_path = cache_dir / table_filename
+                            df = pandas.read_parquet(self._toml_config_dir / file)
+                            dtype_dict, date_cols = self.get_pandas_read_params(
+                                df, pandas_types, task_name
+                            )
 
-                    elif file.endswith(".parquet"):
-                        parquet_path = cache_dir / table_filename
-                        df = pandas.read_parquet(self._toml_config_dir / file)
-                        dtype_dict, date_cols = self.get_pandas_read_params(
-                            df, pandas_types, task_name
-                        )
-
-                    else:
-                        raise errors.FileUploadError(
-                            f"{table['file']} is not a supported upload file type.\n"
-                            "Supported file types: csv, bsv, tsv, xlsx, parquet"
-                        )
-
+                        else:
+                            raise errors.FileUploadError(
+                                f"{table['file']} is not a supported upload file type.\n"
+                                "Supported file types: csv, bsv, tsv, xlsx, parquet"
+                            )
+                    except pandas.errors.ParserError as e:
+                        rich.print(f"Error reading {file}: {e}")
+                        sys.exit()
                     df = self.reformat_dates(df, date_cols)
                     if table["create_mode"] == "single":
                         # for single table mode, we can use the name of the task from the workflow

--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -182,18 +182,19 @@ class FileUploadBuilder(BaseTableBuilder):
                                         table["delimiter"] = ","
                                     case "tsv":
                                         table["delimiter"] = "\t"
-                                df = pandas.read_csv(
-                                    self._toml_config_dir / file,
-                                    delimiter=table["delimiter"],
-                                )
-                                dtype_dict, date_cols = self.get_pandas_read_params(
-                                    df, pandas_types, task_name
-                                )
-                                df = pandas.read_csv(
-                                    self._toml_config_dir / file,
-                                    delimiter=table["delimiter"],
-                                    dtype=dtype_dict,
-                                )
+                            df = pandas.read_csv(
+                                self._toml_config_dir / file,
+                                delimiter=table["delimiter"],
+                            )
+                            dtype_dict, date_cols = self.get_pandas_read_params(
+                                df, pandas_types, task_name
+                            )
+                            df = pandas.read_csv(
+                                self._toml_config_dir / file,
+                                delimiter=table["delimiter"],
+                                dtype=dtype_dict,
+                            )
+
                         elif file.endswith(".parquet"):
                             parquet_path = cache_dir / table_filename
                             df = pandas.read_parquet(self._toml_config_dir / file)

--- a/tests/builders/test_upload_builder.py
+++ b/tests/builders/test_upload_builder.py
@@ -60,6 +60,43 @@ def test_snake_case():
 
 
 @mock.patch("platformdirs.user_cache_dir")
+def test_bad_datasource(mock_cache, mock_db_config, tmp_path):
+    mock_cache.return_value = tmp_path / "cache"
+    conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "file_upload",
+            "tables": {"bad_csv": {"file": "a.csv"}},
+        },
+        filename="workflow.toml",
+    )
+    conftest.write_toml(
+        tmp_path,
+        {
+            "study_prefix": "study",
+            "stages": {"default": [{"files": ["a.csv"]}]},
+        },
+        filename="manifest.toml",
+    )
+    manifest = study_manifest.StudyManifest(tmp_path)
+    with open(tmp_path / "a.csv", "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(["x", "y"])
+        writer.writerow(
+            [
+                "1",
+                "2",
+            ]
+        )
+        writer.writerow(["3", "4", "5"])
+    with pytest.raises(SystemExit):
+        builder = file_upload_builder.FileUploadBuilder(
+            toml_config_path=tmp_path / "workflow.toml",
+        )
+        builder.prepare_queries(config=mock_db_config, manifest=manifest)
+
+
+@mock.patch("platformdirs.user_cache_dir")
 def test_unsupported_filetype(mock_cache, mock_db_config, tmp_path):
     mock_cache.return_value = tmp_path / "cache"
     shutil.copytree(TEST_DATA_PATH, tmp_path / "file_upload", dirs_exist_ok=True)


### PR DESCRIPTION
This addresses #524 by catching errors related to pandas parsing when reading data in during a file upload.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json