### PR TITLE
Actually write out NLP results into parquets and make table

### DIFF
--- a/cumulus_library/builders/file_upload_builder.py
+++ b/cumulus_library/builders/file_upload_builder.py
@@ -6,7 +6,6 @@ import sys
 
 import msgspec
 import pandas
-import platformdirs
 
 from cumulus_library import BaseTableBuilder, base_utils, errors, study_manifest
 from cumulus_library.template_sql import base_templates
@@ -85,10 +84,7 @@ class FileUploadBuilder(BaseTableBuilder):
         *args,
         **kwargs,
     ):
-        cache_dir = (
-            pathlib.Path(platformdirs.user_cache_dir("cumulus-library", "smart-on-fhir"))
-            / f"file_uploads/{manifest.get_study_prefix()}"
-        )
+        cache_dir = base_utils.get_user_cache_dir() / f"file_uploads/{manifest.get_study_prefix()}"
         cache_dir.mkdir(parents=True, exist_ok=True)
 
         with base_utils.get_progress_bar() as progress:

--- a/cumulus_library/builders/nlp/driver.py
+++ b/cumulus_library/builders/nlp/driver.py
@@ -1,16 +1,22 @@
 import datetime
+import enum
 import json
 import re
 import string
+import types
+import typing
 
 import cumulus_fhir_support as cfs
+import pyarrow
+import pydantic
 import rich
 
-from cumulus_library import errors, note_utils
+from cumulus_library import base_utils, databases, errors, note_utils
 
 from . import caching, models, workflow
 
 ESCAPED_WHITESPACE = re.compile(r"(\\\s)+")
+PARQUET_PATTERN = re.compile(r"nlp\.([0-9]+)\.parquet")
 
 
 class NlpStats:
@@ -27,13 +33,33 @@ def run_nlp(
     nlp_config: note_utils.NlpConfig,
     tasks: list[workflow.NlpTask],
     filters: list[cfs.NoteFilter],
+    db: databases.DatabaseBackend,
 ) -> NlpStats:
     """Iterates through the notes, filtering as it goes, and passes notes to NLP"""
     stats = NlpStats(len(tasks))
-    pool = NlpNotePool(nlp_config)
 
+    # If asked to clean, do it
+    if nlp_config.clean:
+        for task in tasks:
+            # We wanna clean out all previous uploads for this table.
+            # Do this before making the pool because that looks at the files in the folder to
+            # get the first batch number to use.
+            root = output_path_for_task(nlp_config.target, task, db).parent
+            slug = table_slug_for_task(task)
+            table_with_version = re.compile(rf"/{slug}_v[0-9]+(\.ids)?$")
+            for folder in root.ls():
+                if table_with_version.search(str(folder)):
+                    folder.rm()
+
+    # Read ID refs for any already-uploaded notes
+    prev_upload_refs = [read_upload_refs_for_task(nlp_config.target, task, db) for task in tasks]
+
+    # Loop through every note and add to the note pool for NLP processing
+    pool = NlpNotePool(nlp_config, db=db, tasks=tasks)
     for note_res in notes.progress_iter("Running NLP..."):
         stats.available += 1
+
+        note_ref = f"{note_res['resourceType']}/{note_res['id']}"
 
         try:
             text = cfs.get_text_from_note_res(note_res)
@@ -42,6 +68,8 @@ def run_nlp(
         stats.had_text += 1
 
         for idx, task in enumerate(tasks):
+            if note_ref in prev_upload_refs[idx]:
+                continue
             if not filters[idx](note_res, text=text):
                 continue
             stats.considered[idx] += 1
@@ -61,6 +89,44 @@ def run_nlp(
     return stats
 
 
+def table_name_for_task(task: workflow.NlpTask, nlp_config: note_utils.NlpConfig) -> str:
+    slug = table_slug_for_task(task)
+    return f"{nlp_config.target}__{slug}"
+
+
+def table_slug_for_task(task: workflow.NlpTask) -> str:
+    return f"nlp2_{task.name}"  # TODO MIKE: nlp prefix?
+
+
+def schema_for_task(task: workflow.NlpTask) -> pyarrow.Schema:
+    result_schema = convert_pydantic_fields_to_pyarrow(task.response_schema.model_fields)
+    return pyarrow.schema(
+        [
+            pyarrow.field("note_ref", pyarrow.string()),
+            pyarrow.field("encounter_ref", pyarrow.string()),
+            pyarrow.field("subject_ref", pyarrow.string()),
+            pyarrow.field("generated_on", pyarrow.string()),
+            pyarrow.field("task_version", pyarrow.int32()),
+            pyarrow.field("model", pyarrow.string()),
+            pyarrow.field("system_fingerprint", pyarrow.string()),
+            pyarrow.field("result", result_schema),
+        ]
+    )
+
+
+def output_path_for_task(
+    prefix: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+) -> cfs.FsPath:
+    upload_slug = table_slug_for_task(task) + f"_v{task.version}"
+    if base_path := db.get_remote_upload_path(prefix, upload_slug):
+        return cfs.FsPath(base_path)
+
+    # OK, database backend doesn't support remote files, let's write it locally to our cache
+    # Note: this is the same location for all duckdb files... file_upload has same issue.
+    cache_root = base_utils.get_user_cache_dir()
+    return cfs.FsPath(cache_root, "nlp", prefix, upload_slug)
+
+
 ### Internal driver API to help manage the process
 
 
@@ -78,10 +144,18 @@ class NlpNotePool:
     either send them out to NLP or not depending on where the limits are.
     """
 
-    def __init__(self, nlp_config: note_utils.NlpConfig):
+    def __init__(
+        self,
+        nlp_config: note_utils.NlpConfig,
+        *,
+        db: databases.DatabaseBackend,
+        tasks: list[workflow.NlpTask],
+    ):
         self._config = nlp_config
         self._model = models.create_model(nlp_config)
         self._provider = self._model.provider
+        self._db = db
+        self._tasks = tasks
 
         self._notes = {}  # task_name -> list[output row]
 
@@ -111,7 +185,15 @@ class NlpNotePool:
             # TODO MIKE: finish batching support
             return 0  # pragma: no cover
 
-        self._write_notes_to_output()
+        try:
+            self._write_notes_to_output()
+        finally:
+            # If any of our tasks wrote no rows, let's write out a zero-row parquet so that we can
+            # still create a table based off it for duckdb (which requires parquets).
+            for task in self._tasks:
+                if self._next_parquet_path(task).name == "nlp.0.parquet":
+                    self._write_single_parquet(task, [])
+
         return 0
 
     def _make_prompt(self, task: workflow.NlpTask, text: str) -> models.Prompt:
@@ -153,7 +235,7 @@ class NlpNotePool:
         parsed = response.answer.model_dump(mode="json", serialize_as_any=True)
         self._fix_spans(note_ref, text, parsed)
 
-        # If you change these, change the schema definition in nlp_builder.py too
+        # If you change these, change the schema definition in schema_for_task() too
         new_row = {
             "note_ref": note_ref,
             "encounter_ref": encounter_ref,
@@ -167,8 +249,7 @@ class NlpNotePool:
         }
 
         # Add new row to pending notes
-        table = self._table_name(task)
-        self._notes.setdefault(table, []).append(new_row)
+        self._notes.setdefault(task.name, []).append(new_row)
 
         # Do we have enough to write out?
         pending_notes = sum(len(x) for x in self._notes.values())
@@ -218,13 +299,103 @@ class NlpNotePool:
         return all_found
 
     def _write_notes_to_output(self) -> None:
-        print("TODO MIKE: write this to parquet", self._notes)  # noqa: T201
+        notes = self._notes
         self._notes = {}
-        self._write_to_disk()  # just for tests to override
 
-    def _write_to_disk(self) -> None:
-        pass
+        for task in self._tasks:
+            if task.name in notes:
+                rows = notes[task.name]
+                self._write_single_parquet(task, rows)
+                add_upload_refs_for_task(self._config.target, task, self._db, rows)
+
+    def _next_parquet_path(self, task: workflow.NlpShared) -> cfs.FsPath:
+        folder = output_path_for_task(self._config.target, task, self._db)
+
+        # First, determine what the next upload number should be
+        basenames = [path.name for path in folder.ls()]
+        matches = [PARQUET_PATTERN.match(basename) for basename in basenames]
+        numbers = [int(match.group(1)) for match in matches if match]
+        next_index = max(numbers, default=-1) + 1
+
+        return folder.joinpath(f"nlp.{next_index}.parquet")
+
+    def _write_single_parquet(self, task: workflow.NlpTask, rows: list[dict]) -> int:
+        path = self._next_parquet_path(task)
+        path.parent.makedirs()
+
+        # Build the pyarrow table (with schema) and write it out
+        table = pyarrow.Table.from_pylist(rows, schema=schema_for_task(task))
+        pyarrow.parquet.write_table(table, str(path), compression="snappy", filesystem=path.fs)
 
 
-def table_name_for_task(task: workflow.NlpTask, nlp_config: note_utils.NlpConfig) -> str:
-    return f"{nlp_config.target}__nlp2_{task.name}"  # TODO MIKE: nlp prefix?
+def upload_refs_path(
+    prefix: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+) -> cfs.FsPath:
+    path = output_path_for_task(prefix, task, db)
+    return cfs.FsPath(str(path) + ".ids")
+
+
+def read_upload_refs_for_task(
+    prefix: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+) -> set[str]:
+    path = upload_refs_path(prefix, task, db)
+    refs = path.read_text(default="")
+    return set(refs.splitlines())
+
+
+def add_upload_refs_for_task(
+    prefix: str, task: workflow.NlpTask, db: databases.DatabaseBackend, rows: list[dict]
+) -> set[str]:
+    refs = sorted(f"{row['note_ref']}" for row in rows)  # sort for tests
+    path = upload_refs_path(prefix, task, db)
+    path.parent.makedirs()
+    mode = "a" if path.exists() else "w"  # work around memory:// fs having bad "a" semantics
+    with path.open(mode) as f:
+        for ref in refs:
+            f.write(ref)
+            f.write("\n")
+
+
+def convert_pydantic_fields_to_pyarrow(
+    fields: dict[str, pydantic.fields.FieldInfo],
+) -> pyarrow.StructType:
+    return pyarrow.struct(
+        [
+            pyarrow.field(name, pyarrow.list_(pyarrow.list_(pyarrow.int32(), 2)), nullable=True)
+            if name == "spans"
+            else pyarrow.field(name, _convert_type_to_pyarrow(info.annotation), nullable=True)
+            for name, info in fields.items()
+        ]
+    )
+
+
+def _convert_type_to_pyarrow(annotation) -> pyarrow.DataType:
+    # Since we only need to handle a small amount of possible types, we just do this ourselves
+    # rather than relying on an external library.
+    if origin := typing.get_origin(annotation):  # e.g. "Annotated", "UnionType", "list"
+        sub_type = typing.get_args(annotation)[0]
+        if origin is typing.Union or origin is types.UnionType:
+            # This is gonna be something like "str | None" so just grab first arg.
+            # We mark all our fields are nullable at the pyarrow layer.
+            return _convert_type_to_pyarrow(sub_type)
+        elif origin is typing.Annotated:
+            annotation = sub_type
+        elif issubclass(origin, list):
+            return pyarrow.list_(_convert_type_to_pyarrow(sub_type))
+        else:
+            raise ValueError(f"Unsupported type {annotation}")  # pragma: no cover
+
+    if issubclass(annotation, str):
+        return pyarrow.string()
+    elif issubclass(annotation, bool):
+        return pyarrow.bool_()
+    elif issubclass(annotation, int):
+        return pyarrow.int32()
+    elif issubclass(annotation, float):
+        return pyarrow.float32()
+    elif issubclass(annotation, enum.Enum):
+        return pyarrow.string()  # for now, assume all enums are strings
+    elif issubclass(annotation, pydantic.BaseModel):
+        return convert_pydantic_fields_to_pyarrow(annotation.model_fields)
+
+    raise ValueError(f"Unsupported type {annotation}")  # pragma: no cover

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -3,14 +3,17 @@
 import json
 import pathlib
 import sys
+import tempfile
 
 import cumulus_fhir_support as cfs
 import jambo
 import msgspec
+import pandas
+import pyarrow
 import rich
 
 import cumulus_library
-from cumulus_library import note_utils
+from cumulus_library import databases, note_utils
 from cumulus_library.builders.nlp import driver, workflow
 from cumulus_library.template_sql import base_templates
 
@@ -138,6 +141,7 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
             tasks=self._workflow_config.task,
             filters=note_filters,
             nlp_config=self._nlp_config,
+            db=config.db,
         )
 
         # Print stat block, because that's interesting feedback
@@ -153,31 +157,26 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         # or a materialized table.
         return study_config.db.db_type == "athena"
 
-    def _headers(self) -> list[str]:
-        # If you change these, change the schema definition in nlp_builder.py too
-        return [
-            "note_ref",
-            "encounter_ref",
-            "subject_ref",
-            "generated_on",
-            "task_version",
-            "model",
-            "system_fingerprint",
-            "result",
-        ]
+    def _pyarrow_schema_to_parquet(
+        self, schema: pyarrow.Schema, db: databases.DatabaseBackend
+    ) -> list:
+        """Turns a pyarrow schema into a list of parquet types."""
+        # SQL templates expect a list of parquet types. But the NLP code operates on Pyarrow
+        # schemas for the most part (with a smattering of pydantic).
+        #
+        # The easiest way to convert these is through pandas, because the DatabaseBackend class has
+        # a conversion method for that. and the easiest way through pandas is reading a parquet from
+        # disk.
+        #
+        # So we write an empty parquet to disk, have pandas read it, then have the database convert
+        # the pandas dtype to parquet types. Simple...
 
-    def _col_types_for_task(self, task: workflow.NlpTask) -> list[str]:
-        # If you change these, change the schema definition in nlp_builder.py too
-        return [
-            "VARCHAR",
-            "VARCHAR",
-            "VARCHAR",
-            "VARCHAR",
-            "INT",
-            "VARCHAR",
-            "VARCHAR",
-            "VARCHAR",  # TODO MIKE: this last one is a lie for now - convert to struct
-        ]
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            table = pyarrow.Table.from_pylist([], schema=schema)
+            pyarrow.parquet.write_table(table, tmpfile.name)
+            dtypes = pandas.read_parquet(tmpfile.name).dtypes
+
+        return db.col_parquet_types_from_pandas(dtypes.values)
 
     def prepare_queries(
         self,
@@ -188,15 +187,20 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         if not self._table_is_view(config):
             self._run_nlp(config)
 
-        self.queries = [
-            base_templates.get_ctas_empty_query(  # TODO MIKE: use _from_parquet
-                schema_name=config.schema,
-                table_name=driver.table_name_for_task(task, self._nlp_config),
-                table_cols=self._headers(),
-                table_cols_types=self._col_types_for_task(task),
+        for task in self._workflow_config.task:
+            table_schema = driver.schema_for_task(task)
+            location = str(driver.output_path_for_task(self._nlp_config.target, task, config.db))
+            remote_types = self._pyarrow_schema_to_parquet(table_schema, config.db)
+            self.queries.append(
+                base_templates.get_ctas_from_parquet_query(
+                    schema_name=config.schema,
+                    table_name=driver.table_name_for_task(task, self._nlp_config),
+                    local_location=location,
+                    remote_location=location,
+                    table_cols=table_schema.names,
+                    remote_table_cols_types=remote_types,
+                )
             )
-            for task in self._workflow_config.task
-        ]
 
     def post_execution(
         self,
@@ -205,5 +209,4 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         **kwargs,
     ):
         if self._table_is_view(config):
-            # TODO MIKE: add athena tests
-            self._run_nlp(config)  # pragma: no cover
+            self._run_nlp(config)

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -98,7 +98,11 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             match field:
                 case numpy.dtypes.ObjectDType():
                     output.append("STRING")
-                case pandas.core.arrays.integer.Int64Dtype() | numpy.dtypes.Int64DType():
+                case (
+                    pandas.core.arrays.integer.Int64Dtype()
+                    | numpy.dtypes.Int64DType()
+                    | numpy.dtypes.Int32DType()
+                ):
                     output.append("INT")
                 case numpy.dtypes.Float64DType():
                     output.append("DOUBLE")
@@ -112,11 +116,22 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                     )
         return output
 
+    def _get_result_config(self) -> dict:
+        workgroup = self.connection._client.get_work_group(WorkGroup=self.work_group)
+        return workgroup["WorkGroup"]["Configuration"]["ResultConfiguration"]
+
+    def _get_upload_subdir(self, study: str, topic: str) -> str:
+        return f"cumulus_user_uploads/{self.schema_name}/{study}/{topic}"
+
     def get_remote_path(self) -> str | None:
         """Retreives the base S3 path we use for file uploads from the S3 client"""
-        workgroup = self.connection._client.get_work_group(WorkGroup=self.work_group)
-        wg_conf = workgroup["WorkGroup"]["Configuration"]["ResultConfiguration"]
-        return wg_conf["OutputLocation"]
+        return self._get_result_config()["OutputLocation"]
+
+    def get_remote_upload_path(self, study: str, topic: str) -> str | None:
+        """Retrieves the target S3 path we use for file uploads from the S3 client"""
+        s3_path = self.get_remote_path()
+        subdir = self._get_upload_subdir(study, topic)
+        return f"{s3_path}{subdir}"
 
     def upload_file(
         self,
@@ -128,8 +143,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         force_upload=False,
     ) -> str | None:
         # We'll investigate the connection to get the relevant S3 upload path.
-        workgroup = self.connection._client.get_work_group(WorkGroup=self.work_group)
-        wg_conf = workgroup["WorkGroup"]["Configuration"]["ResultConfiguration"]
+        wg_conf = self._get_result_config()
         s3_path = wg_conf["OutputLocation"]
         bucket = "/".join(s3_path.split("/")[2:3])
         key_prefix = "/".join(s3_path.split("/")[3:])
@@ -142,7 +156,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 "Cumulus requires encryption as part of ensuring safety for limited data sets"
             )
         kms_arn = wg_conf.get("EncryptionConfiguration", {}).get("KmsKey", None)
-        s3_key = f"{key_prefix}cumulus_user_uploads/{self.schema_name}/{study}/{topic}"
+        s3_key = f"{key_prefix}{self._get_upload_subdir(study, topic)}"
         if not remote_filename:
             remote_filename = file.name
 

--- a/cumulus_library/databases/base.py
+++ b/cumulus_library/databases/base.py
@@ -215,6 +215,15 @@ class DatabaseBackend(abc.ABC):
         have an API for file upload (i.e. cloud databases)"""
         return None
 
+    def get_remote_upload_path(self, study: str, topic: str) -> str | None:
+        """Fetches the remote path for file upload
+
+        If not None, this will be a subpath of get_remote_path()
+
+        By default, this should return None. Only override this for databases that
+        have an API for file upload (i.e. cloud databases)"""
+        return None
+
     @abc.abstractmethod
     def export_table_as_parquet(
         self, table_name: str, file_name: str, location: pathlib.Path, *args, **kwargs

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -7,10 +7,13 @@ import os
 from unittest import mock
 
 import cumulus_fhir_support as cfs
+import fsspec.implementations.memory
+import pandas
 import pytest
 import respx
 
-from cumulus_library import cli, errors, note_utils
+import cumulus_library
+from cumulus_library import cli, databases, errors, note_utils
 from cumulus_library.builders import nlp_builder
 from tests import conftest, nlp_utils
 from tests.conftest import duckdb_args
@@ -61,6 +64,11 @@ def note_source(tmp_path) -> note_utils.NoteSource:
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
         add_dxr("hello", "hello world", f)
     yield note_utils.NoteSource([tmp_path])
+
+
+def read_rows(db, table: str) -> list[dict]:
+    df = db.db.connection.sql(f"SELECT * FROM {table} ORDER BY note_ref").df()
+    return json.loads(df.to_json(orient="records"))
 
 
 def test_unexpected_config_field(tmp_path, note_source):
@@ -140,7 +148,7 @@ def test_table_filter_but_no_salt(tmp_path, note_source, mock_db_config):
     builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
     err_msg = "Cannot calculate anonymized resource IDs without a PHI dir defined"
     with pytest.raises(RuntimeError, match=err_msg):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 def test_flattened_config(tmp_path, note_source):
@@ -228,8 +236,28 @@ def test_filter(tmp_path, mock_db_config):
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
     assert expected_stats in console_output.getvalue()
+
+
+@respx.mock
+def test_already_uploaded(tmp_path, mock_db_config, note_source):
+    """Verify that we skip notes that we've already uploaded before"""
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.got_response[0] == 1
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config(clean=False)
+    )
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.had_text == 1
+    assert builder.stats.considered[0] == 0
 
 
 @mock.patch.dict(os.environ, clear=True)
@@ -274,7 +302,7 @@ def test_unreachable_vllm(tmp_path, note_source, mock_db_config):
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
     with pytest.raises(errors.CumulusLibraryError, match="Try running 'docker compose up"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -287,7 +315,7 @@ def test_cached_response(tmp_path, mock_db_config):
                 {
                     "name": "hello_world",
                     "response_schema": '{"title":"test", "type": "object", '
-                    '"properties": {"hello": {"type": "string"}}}',
+                    '"properties": {"hello": {"type": "integer"}}}',
                 },
             ],
         },
@@ -300,23 +328,26 @@ def test_cached_response(tmp_path, mock_db_config):
     source = note_utils.NoteSource([tmp_path])
 
     model = nlp_utils.MockModel()
-    model.mock_openai_response({"hello": "world"})
+    model.mock_openai_response({"hello": 3})
 
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=source, nlp_config=model.nlp_config()
     )
-    builder.prepare_queries(config=mock_db_config)
+    builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 1
 
     # Confirm that we cache the response and don't hit the endpoint again
-    # (and add a new note to sanity check that we do actually fail on the new one)
     model.mock_openai_response({}, status_code=500)
 
+    # Add a new note to sanity check that we do actually fail on the new one
     with open(f"{tmp_path}/dxr.ndjson", "a", encoding="utf8") as f:
         add_dxr("2", "goodbye", f)
 
-    builder.prepare_queries(config=mock_db_config)
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=source, nlp_config=model.nlp_config()
+    )
+    builder.execute_queries(mock_db_config, None)
     assert builder.stats.considered[0] == 2
     assert builder.stats.got_response[0] == 1  # still got our cached result
 
@@ -374,10 +405,11 @@ def test_span_correction(tmp_path, mock_db_config):
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
-    assert builder.stats.got_response[0] == 1
-    assert "'spans': [(0, 5), (7, 21)]" in console_output.getvalue()
+    rows = read_rows(mock_db_config, "test__nlp2_hello_world")
+    assert rows[0]["result"] == {"parent_list": [{"parent_dict": {"spans": [[0, 5], [7, 21]]}}]}
+
     failure_msg = "Could not match span received from NLP server for DiagnosticReport/dxr: forth"
     assert failure_msg in console_output.getvalue()
 
@@ -401,16 +433,53 @@ def test_writes_out_at_note_limit(tmp_path, mock_db_config):
         nlp_config=config,
     )
 
-    with mock.patch("cumulus_library.builders.nlp.driver.NlpNotePool._write_to_disk") as mock_write:
+    with mock.patch("cumulus_library.builders.nlp.driver.add_upload_refs_for_task") as mock_write:
         # Fake an error too, to confirm we gracefully handle that and print message
         mock_write.side_effect = [RuntimeError("test1"), RuntimeError("test2")]
         console_output = io.StringIO()
         with contextlib.redirect_stdout(console_output):
-            builder.prepare_queries(config=mock_db_config)
+            builder.execute_queries(mock_db_config, None)
 
     assert mock_write.call_count == 2
     assert "Failed to process note: test1" in console_output.getvalue()
     assert "Failed to process note: test2" in console_output.getvalue()
+
+
+@respx.mock
+def test_various_value_types(tmp_path, mock_db_config, note_source):
+    workflow_path = conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "task": [
+                {
+                    "name": "test",
+                    "response_schema": '{"title":"test", "type": "object", "properties": {'
+                    '"float": {"type": "number"},'
+                    '"int": {"type": "integer"},'
+                    '"str": {"type": "string"},'
+                    '"bool": {"type": "boolean"},'
+                    '"enum": {"enum": ["red", "amber", "green"]}'
+                    "}}",
+                },
+            ],
+        },
+        "nlp.workflow",
+    )
+
+    results = {"float": 1.5, "int": 3, "str": "a", "bool": True, "enum": "red"}
+    model = nlp_utils.MockModel()
+    model.mock_openai_response(results)
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(),
+    )
+    builder.execute_queries(mock_db_config, None)
+
+    rows = read_rows(mock_db_config, "test__nlp2_test")
+    assert rows[0]["result"] == results
 
 
 @respx.mock
@@ -425,7 +494,7 @@ def test_no_batching_support(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="does not support batching"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -440,7 +509,7 @@ def test_no_phi_dir(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="Please provide a PHI dir"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -455,11 +524,11 @@ def test_bad_nlp_model(tmp_path, mock_db_config, note_source):
 
     config.model = "nope"
     with pytest.raises(errors.CumulusLibraryError, match="Unknown NLP model ID"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
     config.model = None
     with pytest.raises(errors.CumulusLibraryError, match="An NLP model ID must be provided"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -473,7 +542,7 @@ def test_missing_nlp_model(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="NLP server does not have model ID"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -488,7 +557,7 @@ def test_bad_stop(tmp_path, mock_db_config, note_source):
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 0
     assert "did not complete, with finish reason: bad_reason" in console_output.getvalue()
@@ -504,7 +573,7 @@ def test_cloud_model_but_local_provider(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="does not support the 'local' provider"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 @respx.mock
@@ -517,7 +586,7 @@ def test_azure_happy_path(tmp_path, mock_db_config, note_source):
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
 
-    builder.prepare_queries(config=mock_db_config)
+    builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
 
@@ -530,7 +599,7 @@ def test_azure_bad_model(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="does not support the 'azure' provider"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 def test_azure_no_env(tmp_path, mock_db_config, note_source):
@@ -542,7 +611,7 @@ def test_azure_no_env(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="Missing Azure environment variables"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 def test_bedrock_happy_path(tmp_path, mock_db_config, note_source):
@@ -553,7 +622,7 @@ def test_bedrock_happy_path(tmp_path, mock_db_config, note_source):
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
 
-    builder.prepare_queries(config=mock_db_config)
+    builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
 
@@ -568,7 +637,7 @@ def test_bedrock_bad_stop(tmp_path, mock_db_config, note_source):
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 0
     assert "did not complete, with stop reason: bad_reason" in console_output.getvalue()
@@ -583,7 +652,7 @@ def test_bedrock_bad_model(tmp_path, mock_db_config, note_source):
     )
 
     with pytest.raises(errors.CumulusLibraryError, match="does not support the 'bedrock' provider"):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
 
 def test_bedrock_skips_wrapper_in_response(tmp_path, mock_db_config, note_source):
@@ -609,13 +678,10 @@ def test_bedrock_skips_wrapper_in_response(tmp_path, mock_db_config, note_source
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
+    builder.execute_queries(mock_db_config, None)
 
-    console_output = io.StringIO()
-    with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
-
-    assert builder.stats.got_response[0] == 1
-    assert "'result': {'hello': 'world'}" in console_output.getvalue()
+    rows = read_rows(mock_db_config, "test__nlp2_hello_world")
+    assert rows[0]["result"] == {"hello": "world"}
 
 
 def test_bedrock_text_response(tmp_path, mock_db_config, note_source):
@@ -628,7 +694,7 @@ def test_bedrock_text_response(tmp_path, mock_db_config, note_source):
                 {
                     "name": "hello_world",
                     "response_schema": '{"title":"test", "type": "object", '
-                    '"properties": {"hello": {"type": "string"}}}',
+                    '"properties": {"hello": {"type": "number"}}}',
                 }
             ],
         },
@@ -641,7 +707,7 @@ def test_bedrock_text_response(tmp_path, mock_db_config, note_source):
 Preamble...
 
 ```json
-{"hello": "goodbye"}
+{"hello": 0.5}
 ```
 
 Summary.
@@ -653,12 +719,10 @@ Summary.
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
 
-    console_output = io.StringIO()
-    with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+    builder.execute_queries(mock_db_config, None)
 
-    assert builder.stats.got_response[0] == 1
-    assert "'result': {'hello': 'goodbye'}" in console_output.getvalue()
+    rows = read_rows(mock_db_config, "test__nlp2_hello_world")
+    assert rows[0]["result"] == {"hello": 0.5}
 
 
 def test_bedrock_no_response(tmp_path, mock_db_config, note_source):
@@ -672,7 +736,63 @@ def test_bedrock_no_response(tmp_path, mock_db_config, note_source):
 
     console_output = io.StringIO()
     with contextlib.redirect_stdout(console_output):
-        builder.prepare_queries(config=mock_db_config)
+        builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 0
     assert "Failed to process note: no response content found" in console_output.getvalue()
+
+
+@respx.mock
+@nlp_utils.mock_env()
+@mock.patch("botocore.client")
+def test_write_to_athena(mock_client, tmp_path, note_source):
+    db = databases.AthenaDatabaseBackend(
+        region="test",
+        work_group="test",
+        profile="test",
+        schema_name="testdb",
+    )
+    db.connection = mock.MagicMock()
+    bucket_info = {
+        "WorkGroup": {
+            "Configuration": {"ResultConfiguration": {"OutputLocation": "s3://testbucket/athena/"}}
+        }
+    }
+    db.connection._client.get_work_group.return_value = bucket_info
+
+    study_config = cumulus_library.StudyConfig(db=db, schema="main")
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel()
+
+    # Mock out FsPath's s3 filesystem (it should grow a fancier mock itself ideally)
+    mem_fs = fsspec.implementations.memory.MemoryFileSystem()
+    with mock.patch.dict(cfs.FsPath._fsspecs, {"s3": mem_fs}):
+        builder = nlp_builder.NlpBuilder(
+            toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+        )
+        builder.execute_queries(study_config, None)
+
+    assert builder.stats.got_response[0] == 1
+
+    # Confirm we wrote the parquet file out correctly
+    path = "s3://testbucket/athena/cumulus_user_uploads/testdb/test/nlp2_test_v0/nlp.0.parquet"
+    with mem_fs.open(path, "rb") as f:
+        df = pandas.read_parquet(f)
+        rows = json.loads(df.to_json(orient="records"))
+
+    assert len(rows) == 1
+    assert rows[0]["note_ref"] == "DiagnosticReport/hello"
+
+    # And the id file
+    id_path = "s3://testbucket/athena/cumulus_user_uploads/testdb/test/nlp2_test_v0.ids"
+    with mem_fs.open(id_path, "r") as f:
+        assert f.read() == "DiagnosticReport/hello\n"
+
+    # And confirm the query looks right
+    assert builder.queries == [
+        'CREATE TABLE IF NOT EXISTS "main"."test__nlp2_test" AS SELECT "note_ref", '
+        '"encounter_ref", "subject_ref", "generated_on", "task_version", "model", '
+        '"system_fingerprint", "result"\n'
+        "FROM read_parquet('memory://s3://testbucket/athena/cumulus_user_uploads/"
+        "testdb/test/nlp2_test_v0/*.parquet')"
+    ]

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -11,7 +11,8 @@ import respx
 from cumulus_library import note_utils
 from tests import conftest
 
-EMPTY_SCHEMA = '{"title":"test", "type": "object"}'
+# Not fully empty, because parquet doesn't like that. But just throw an unused property in there.
+EMPTY_SCHEMA = '{"title":"test", "type": "object", "properties": {"ignored": {"type": "string"}}}'
 
 
 def mock_env(provider: str = "local"):
@@ -82,17 +83,20 @@ class MockModel:
             f"--nlp-provider={config.provider}",
             f"--etl-phi-dir={config.phi_dir}",
         ]
+        if config.clean:
+            args.append("--clean-nlp")
         if config.use_batching:
             args.append("--batch-nlp")
         return args
 
-    def nlp_config(self, batching: bool = False) -> note_utils.NlpConfig:
+    def nlp_config(self, batching: bool = False, clean: bool = True) -> note_utils.NlpConfig:
         args = {
             "nlp_model": self.model_id,
             "nlp_provider": self.provider,
             "etl_phi_dir": self.phi,
             "target": "test",
             "batch_nlp": batching,
+            "clean_nlp": clean,
         }
         return note_utils.NlpConfig(args)
 


### PR DESCRIPTION
This does a few interesting new things:
- Tracks previously uploaded documents in a table_name_v1.ids file, stored in the parent directory of the parquet files. That is, the parquet layout will look like:
  - $BASE/cumulus_user_uploads/{db}/{study}/{table}_v2/*.parquet
  - $BASE/cumulus_user_uploads/{db}/{study}/{table}_v2.ids If we are scanning through notes, and the note is already in the .ids file, we skip it. This saves time and keeps the parquets from having duplicate content. (this exact pattern is used by the ETL, including the same file path)
- Adds actual code behind the --clean-nlp flag to clean up stored parquet files and .ids files for all existing versions of a given task. This is separate from normal Library clean operations, which only touch table data. (this is what the ETL does too, with its own "--clean" arg, which I felt was not specific enough in the Library case)
- Adds "spans" conversion code for model results, to switch from spans of text to spans of character offset integers. (this exact step is used by the ETL)
- Adds get_remote_upload_path(study, topic) to DatabaseBackend. This is very similar to get_remote_path(), but encodes the full path for uploading files.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json