### PR TITLE
added description to manifest export_list

### DIFF
--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -18,17 +18,23 @@ from cumulus_library import enums, errors
 class ManifestExport:
     name: str
     export_type: str
+    description: str | None = None
 
 
 # These msgspec Structs define the expected formats for manifests & submanifests
 
 
+class ManifestExportTable(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    name: str
+    description: str
+
+
 class ManifestAction(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
     type: str | None = None
-    description: str | None = None
+    description: str | None = None  # deprecated
     label: str | None = None
     files: list[str] | None = None
-    tables: list[str] | None = None
+    tables: list[str | ManifestExportTable] | None = None
 
 
 class ManifestAdvancedOptions(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
@@ -284,7 +290,7 @@ class StudyManifest:
             raise errors.StudyManifestParsingError(f"No files matching '{continue_from}' found")
         return files
 
-    def get_export_table_list(self, stage_name: str = "default") -> list[ManifestExport] | None:
+    def get_export_table_list(self, stage_name: str = "all") -> list[ManifestExport] | None:
         """Reads the exportable tables from the manifest
 
         :param stage_name: if present, just search the stages defined in the stage_name list
@@ -301,9 +307,17 @@ class StudyManifest:
             if export_type == "counts":
                 # the aggregator is looking for the cube keyword, so we'll swap it out
                 export_type = "cube"
-            for table in action.get("tables", []):
+            for str_or_dict in action.get("tables", []):
+                if isinstance(str_or_dict, str):
+                    table = str_or_dict
+                    description = None
+                else:
+                    table = str_or_dict.get("name")
+                    description = str_or_dict.get("description")
                 if table.startswith(f"{self.get_study_prefix()}__"):
-                    export_table_list.append(ManifestExport(name=table, export_type=export_type))
+                    export_table_list.append(
+                        ManifestExport(name=table, export_type=export_type, description=description)
+                    )
                 elif "__" in table:  # has a prefix, just the wrong one
                     raise errors.StudyManifestParsingError(
                         f"{table} in export list does not start with prefix "
@@ -314,7 +328,9 @@ class StudyManifest:
                     # is not known ahead of time)
                     export_table_list.append(
                         ManifestExport(
-                            name=f"{self.get_study_prefix()}__{table}", export_type=export_type
+                            name=f"{self.get_study_prefix()}__{table}",
+                            export_type=export_type,
+                            description=description,
                         )
                     )
 

--- a/docs/study-configuration.md
+++ b/docs/study-configuration.md
@@ -91,7 +91,7 @@ study with some descriptive text. \
 #    This behavior can't be overriden.
 
 # A stage is a list of actions. Actions can have the following fields:
-#   - 'description', which will be displayed in the CLI while the action is being run
+#   - 'label', which will be displayed in the CLI while the action is being run
 #   - 'type', which determines what the action does, and which parts of the library CLI the
 #     action is invoked by. Valid types:
 #      - 'build:serial' (default if action_type is not specified) runs the files in order, one at a time
@@ -109,7 +109,7 @@ study with some descriptive text. \
 
 # This double bracket defines a new array inside of stages, define_population
 [[stages.define_population]]
-description = 'Upload files defining some conditions & select patients'
+label = 'Upload files defining some conditions & select patients'
 type= 'build:parallel'
 files = [
   'file_upload_workflow_definition.toml',
@@ -117,19 +117,19 @@ files = [
 # Using this same name again inside a double bracket causes a new item to be added
 # to the end of the define_population list.
 [[stages.define_population]]
-description = 'Select patients by characteristics'
+label = 'Select patients by characteristics'
 type= 'build:serial'
 files = [
   'select_patients.sql',
 ]
 [[stages.select_cohorts]]
-description = 'Define cohorts'
+label = 'Define cohorts'
 files = [
   'cohort_submanifest.toml'
 ]
 type = "submanifest"
 [[stages.count_cohorts]]
-description = 'Define cohorts'
+label = 'Define cohorts'
 files = [
   'cohort_by_age.py',
   'cohort_by_gender.py'
@@ -137,13 +137,18 @@ files = [
 type = "build:parallel"
 
 # Most cumulus exports should be count tables, created as powerset cubes for deid binning
-# purposes.
+# purposes. A table can be defined two ways:
+#   - As a string, in which case the string is an assumed name
+#   - As a dictionary, with two keys: 'name', which is the name of the table, and
+#     'description', which is text that describes what the table is about. The description
+#     can be used by a UI to expose this information to an end user.
 
 [[stages.count_cohorts]]
-description = 'Export patient counts'
+label = 'Export patient counts'
 type = 'export:counts'
 tables = [
     "my_study__count_influenza_test_month",
+    {name = "my_study__count_influenza_test_week", description = "Influenza testing by test type"}
 ]
 
 # In some cases, you may want to annotate count data with metadata from another
@@ -151,7 +156,7 @@ tables = [
 # display value or code system) from another source.
 
 [[stages.count_cohorts]]
-description = 'Export patient symptoms w/ LOINC codes'
+label = 'Export patient symptoms w/ LOINC codes'
 type = 'export:annotated_counts'
 tables = [
     "my_study__count_influenza_test_month_annotated",
@@ -162,7 +167,7 @@ tables = [
 # categorization
 
 [[stages.count_cohorts]]
-description = 'Export summary statistics'
+label = 'Export summary statistics'
 type = 'export:flat'
 tables = [
     "my_study__q_influenza",
@@ -176,7 +181,7 @@ tables = [
 # these tables.
 
 [[stages.count_cohorts]]
-description = 'Export metadata'
+label = 'Export metadata'
 type = 'export:meta'
 tables = [
   "my_study__meta_date",
@@ -220,15 +225,15 @@ Here's an example submanifest (note that this is optional and you don't have to 
 # A submanifest contains a top level list of actions, and then uses the same action
 # syntax. At runtime, we'll map it into the stage the submanifest was referenced from.
 [[actions]]
-description = "Select cohorts by age"
+label = "Select cohorts by age"
 files = ['age_cohort.sql']
 type = 'build:serial'
 [[actions]]
-description = "Create cohorts by medications"
+label = "Create cohorts by medications"
 files = ['cohort_rx_1.py', 'cohort_rx_2.py']
 type = 'build:parallel'
 [[actions]]
-description = 'Export patient medication counts'
+label = 'Export patient medication counts'
 type = 'export:counts'
 tables = [
     "my_study__count_patient_rx",

--- a/docs/workflows/counts.md
+++ b/docs/workflows/counts.md
@@ -7,7 +7,7 @@ nav_order: 1
 # type: reference
 ---
 
-# File Upload
+# Counts
 
 This document aims to provide help in configuring counts workflows as part of a
 Cumulus Library study

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -271,7 +271,10 @@ def test_formatted_study_prefix(tmp_path):
             pytest.raises(errors.StudyManifestParsingError, match="expected key, 'files'"),
         ),
         (
-            {"type": "export:counts", "files": ["table__name"]},
+            {
+                "type": "export:counts",
+                "files": ["table__name", {"name": "table__other_name", "description": "text"}],
+            },
             pytest.raises(errors.StudyManifestParsingError, match="expected key, 'tables'"),
         ),
         (
@@ -284,3 +287,122 @@ def test_validate_action(action, raises, tmp_path):
     with raises:
         manifest = study_manifest.StudyManifest()
         manifest._validate_action(action=action, source=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "stages,stage,expected,raises",
+    [
+        (
+            {
+                "stage_one": [
+                    {
+                        "type": "export:counts",
+                        "tables": ["test__name", {"name": "test__name2", "description": "text"}],
+                    }
+                ]
+            },
+            None,
+            [
+                study_manifest.ManifestExport(
+                    name="test__name", export_type="cube", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__name2", export_type="cube", description="text"
+                ),
+            ],
+            does_not_raise(),
+        ),
+        (
+            {
+                "stage_one": [
+                    {
+                        "type": "export:counts",
+                        "tables": ["test__name", {"name": "test__name2", "description": "text"}],
+                    }
+                ]
+            },
+            "stage_one",
+            [
+                study_manifest.ManifestExport(
+                    name="test__name", export_type="cube", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__name2", export_type="cube", description="text"
+                ),
+            ],
+            does_not_raise(),
+        ),
+        (
+            {
+                "stage_one": [{"type": "export:counts", "tables": ["test__name"]}],
+                "stage_two": [{"type": "export:counts", "tables": ["test__name2"]}],
+            },
+            "stage_one",
+            [
+                study_manifest.ManifestExport(
+                    name="test__name", export_type="cube", description=None
+                ),
+            ],
+            does_not_raise(),
+        ),
+        (
+            {
+                "stage_one": [{"type": "export:counts", "tables": ["test__name"]}],
+                "stage_two": [{"type": "export:counts", "tables": ["test__name2"]}],
+            },
+            "all",
+            [
+                study_manifest.ManifestExport(
+                    name="test__name", export_type="cube", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__name2", export_type="cube", description=None
+                ),
+            ],
+            does_not_raise(),
+        ),
+        (
+            {
+                "stage_one": [{"type": "export:counts", "tables": ["bad_prefix__name"]}],
+            },
+            None,
+            [],
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+        (
+            {
+                "stage_one": [
+                    {"type": "export:counts", "tables": ["test__counts"]},
+                    {"type": "export:annotated_counts", "tables": ["test__annotated_counts"]},
+                    {"type": "export:flat", "tables": ["test__flat"]},
+                    {"type": "export:meta", "tables": ["test__meta"]},
+                ],
+            },
+            None,
+            [
+                study_manifest.ManifestExport(
+                    name="test__counts", export_type="cube", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__annotated_counts", export_type="annotated_counts", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__flat", export_type="flat", description=None
+                ),
+                study_manifest.ManifestExport(
+                    name="test__meta", export_type="meta", description=None
+                ),
+            ],
+            does_not_raise(),
+        ),
+    ],
+)
+def test_export_list(stages, stage, expected, raises, tmp_path):
+    with raises:
+        conftest.write_toml(tmp_path, {"study_prefix": "test", "stages": stages})
+        manifest = study_manifest.StudyManifest(tmp_path)
+        if stage is None:
+            export_list = manifest.get_export_table_list()
+        else:
+            export_list = manifest.get_export_table_list(stage)
+        assert export_list == expected


### PR DESCRIPTION
This PR partially addresses #530 by adding a manifest hook for handling the presence of a description field. Future work as part of #529 will handle the routing of the data to the desired storage destination.

This also does some light cleanup on the docs, fixing a title and renaming a reference to a deprecated field.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml` <- waiting on this until the data dictionary piece is in
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json