### PR TITLE
Disable ref logging, switch to ARM for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11","3.12","3.13"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
 
@@ -56,7 +56,7 @@ jobs:
 
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 
@@ -78,7 +78,7 @@ jobs:
 
   # Note: regression job should not be matrixed due to remote db concurrency issue
   regression:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
 

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -155,7 +155,9 @@ def build_study(
             for file in data_dir.iterdir():
                 z.write(file, file.relative_to(data_dir))
     else:
-        log_ref_summary(config, manifest)
+        # TODO: rethink this approach
+        # log_ref_summary(config, manifest)
+        pass
 
 
 def build_matching_files(
@@ -636,6 +638,9 @@ def _run_workflow(
 
 def log_ref_summary(config: base_utils.StudyConfig, manifest: study_manifest.StudyManifest):
     """Updates the study ref_summary table with build results.
+
+    # TODO: switch to a sqlglot-based parsing to get the table/column data from the queries
+    # themselves, rather than fetching them from the db.
 
     The goal here is to do the following:
     - Find every table in a study containing a ref field

--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -636,7 +636,9 @@ def _run_workflow(
     return builder.queries, bool(builder and builder.parallel_allowed)
 
 
-def log_ref_summary(config: base_utils.StudyConfig, manifest: study_manifest.StudyManifest):
+def log_ref_summary(
+    config: base_utils.StudyConfig, manifest: study_manifest.StudyManifest
+):  # pragma: no cover
     """Updates the study ref_summary table with build results.
 
     # TODO: switch to a sqlglot-based parsing to get the table/column data from the queries

--- a/cumulus_library/template_sql/base_templates.py
+++ b/cumulus_library/template_sql/base_templates.py
@@ -509,7 +509,7 @@ def get_select_from_single_query(
     where_clauses: list[list[str]] | None = None,
     distinct: bool = False,
 ):
-    if not where_clauses:
+    if not where_clauses:  # pragma: no cover
         where_clauses = []
     return get_template(
         "select_from_single",

--- a/tests/actions/test_builder.py
+++ b/tests/actions/test_builder.py
@@ -260,6 +260,8 @@ def test_invalid_stage(mock_db_config, tmp_path):
 
 
 def test_ref_summary(tmp_path):
+    # TODO: Update after ref rework
+    return
     manifest = study_manifest.StudyManifest(
         pathlib.Path(pathlib.Path(__file__).parents[2] / "cumulus_library/studies/core")
     )


### PR DESCRIPTION
The existing *_ref change log approach seems to break down for large studies - data metrics specifically has a :very: long run time. It also ends up hitting more tables than necessary due to crossing a pagination threshold, which for some reason is also hitting unrelated tables in the table schema, some of which don't have deltalakes behind them, causing queries to error out.

While we're here, we're also updating to ARM runners for performance reasons.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json