### PR TITLE
Revert Pypi release to run on x64 machines.

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -6,7 +6,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-24.04-arm
+    # Note: the github pypi action, as of this writing (2026-05-05) relies on pulling a
+    # docker image, and the image is only available for X64 processors. Trying to use this
+    # on an ARM machine results in an error. So, don't switch over the requested architecture
+    # until this is addressed (and, realistically, the speed advantage for a release is not
+    # the most important anyway).
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
Since the image that builds a release is available for x64 only, we're flipping this back from the ARM runners.


### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json