### PR TITLE
Add back batching support, ported from ETL

### DIFF
--- a/cumulus_library/builders/nlp/caching.py
+++ b/cumulus_library/builders/nlp/caching.py
@@ -8,21 +8,20 @@ import cumulus_fhir_support as cfs
 
 Obj = TypeVar("Obj")
 
-# TODO MIKE: add back when implementing batching
 
-# def _cache_metadata_path(cache_dir: cfs.FsPath, namespace: str, filename: str) -> cfs.FsPath:
-#     return cache_dir.joinpath(f"nlp-cache/{namespace}/{filename}")
-
-
-# def cache_metadata_write(cache_dir: cfs.FsPath, namespace: str, content: dict) -> None:
-#     path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
-#     path.parent.makedirs()
-#     path.write_json(content, indent=2)
+def _cache_metadata_path(cache_dir: cfs.FsPath, namespace: str, filename: str) -> cfs.FsPath:
+    return cache_dir.joinpath(f"nlp-cache/{namespace}/{filename}")
 
 
-# def cache_metadata_read(cache_dir: cfs.FsPath, namespace: str) -> dict:
-#     path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
-#     return path.read_json(default={})
+def cache_metadata_write(cache_dir: cfs.FsPath, namespace: str, content: dict) -> None:
+    path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
+    path.parent.makedirs()
+    path.write_json(content, indent=2)
+
+
+def cache_metadata_read(cache_dir: cfs.FsPath, namespace: str) -> dict:
+    path = _cache_metadata_path(cache_dir, namespace, "metadata.json")
+    return path.read_json(default={})
 
 
 def _cache_path(cache_dir: cfs.FsPath, namespace: str, checksum: str) -> cfs.FsPath:

--- a/cumulus_library/builders/nlp/driver.py
+++ b/cumulus_library/builders/nlp/driver.py
@@ -3,6 +3,7 @@ import enum
 import json
 import re
 import string
+import tempfile
 import types
 import typing
 
@@ -60,6 +61,7 @@ def run_nlp(
 
     # Loop through every note and add to the note pool for NLP processing
     pool = NlpNotePool(nlp_config, db=db, tables=tables)
+    pool.prepare(notes)
     for note_res in notes.progress_iter("Running NLP..."):
         stats.available += 1
 
@@ -177,25 +179,32 @@ class NlpNotePool:
     def token_prices(self) -> models.TokenStats:
         return self._model.prices
 
+    def prepare(self, notes: note_utils.NoteSource) -> None:
+        # In batching mode, we need to do some preparations.
+        # Namely, we (a) have to resume any previous batches.
+        # And (b) we need to send our own (new) batches off.
+        # Then when we do the normal loop of adding notes later, we'll get the cached results of
+        # both (a) and (b) above.
+        # We want to get it from the cache, because when we send batches off, we don't include
+        # enough metadata to generate a proper PromptResult (like the references and span
+        # conversion, etc).
+        # So we need to crawl through the input notes and match it up with the cached NLP results.
+
+        if self._config.use_batching:
+            self._resume_existing_batches()
+            self._create_new_batches(notes)
+
     def add_note(self, table_slug: str, note_res: dict, text: str) -> int:
         """Returns number of successfully processed notes. Might raise an exception."""
         task = self._tables[table_slug]
 
-        if self._config.use_batching:
-            # TODO MIKE: finish batching support
-            return 0  # pragma: no cover
-
-        prompt = self._make_prompt(task, text)
+        prompt = self._make_prompt(table_slug, task, text)
         response = self._model.prompt(prompt)
         self._add_response(table_slug, task, note_res, text, response)
         return 1
 
-    def finalize(self) -> int:
+    def finalize(self) -> None:
         """Returns number of successfully processed notes. Might raise an exception."""
-        if self._config.use_batching:
-            # TODO MIKE: finish batching support
-            return 0  # pragma: no cover
-
         try:
             self._write_notes_to_output()
         finally:
@@ -205,9 +214,16 @@ class NlpNotePool:
                 if self._next_parquet_path(table_slug, task).name == "nlp.0.parquet":
                     self._write_single_parquet(table_slug, task, [])
 
-        return 0
+    def _table_name(self, table_slug: str) -> str:
+        return table_name_for_task(table_slug, self._config)
 
-    def _make_prompt(self, task: workflow.NlpTask, text: str) -> models.Prompt:
+    def _cache_dir(self) -> cfs.FsPath:
+        return cfs.FsPath(self._config.phi_dir)
+
+    def _cache_namespace(self, table_slug: str, task: workflow.NlpTask) -> str:
+        return f"{self._table_name(table_slug)}_v{task.version}_{self._model.MODEL_ID}"
+
+    def _make_prompt(self, table_slug: str, task: workflow.NlpTask, text: str) -> models.Prompt:
         schema = task.response_schema.model_json_schema()
         system = task.system_prompt or ""
         system = system.replace("%JSON-SCHEMA%", json.dumps(schema))
@@ -219,13 +235,10 @@ class NlpNotePool:
             system=system,
             user=user,
             schema=task.response_schema,
-            cache_dir=cfs.FsPath(self._config.phi_dir),
-            cache_namespace=f"{self._table_name(task)}_v{task.version}",
+            cache_dir=self._cache_dir(),
+            cache_namespace=self._cache_namespace(table_slug, task),
             cache_checksum=caching.cache_checksum(text),
         )
-
-    def _table_name(self, table_slug: str) -> str:
-        return table_name_for_task(table_slug, self._config)
 
     def _add_response(
         self,
@@ -272,6 +285,87 @@ class NlpNotePool:
         pending_notes = sum(len(x) for x in self._notes.values())
         if pending_notes >= self._config.note_limit:
             self._write_notes_to_output()
+
+    def _resume_existing_batches(self) -> None:
+        # Maybe we got interrupted and need to resume.
+        # Check all tables for any existing batch file.
+        for table_slug, task in self._tables.items():
+            cache_namespace = self._cache_namespace(table_slug, task)
+            metadata = caching.cache_metadata_read(self._cache_dir(), cache_namespace)
+            batch_ids = metadata.get(f"batches-{self._config.provider}")
+            if batch_ids:
+                rich.print(f" Resuming previously created batches for '{table_slug}'.")
+                self._wait_for_batches(
+                    batch_ids,
+                    schema=task.response_schema,
+                    cache_namespace=cache_namespace,
+                )
+
+    def _create_new_batches(self, notes: note_utils.NoteSource) -> None:
+        table_batches = {}  # table_slug -> set[batch_id]
+        cache_dir = self._cache_dir()
+
+        # Feed every note into the provider
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for note_res in notes.progress_iter("Creating batches..."):
+                try:
+                    text = cfs.get_text_from_note_res(note_res)
+                except Exception:  # noqa: S112
+                    continue
+
+                for table_slug, task in self._tables.items():
+                    prompt = self._make_prompt(table_slug, task, text)
+                    batch_ids = table_batches.setdefault(table_slug, set())
+                    batch_ids.add(self._provider.add_to_batch(prompt, tmp_dir))
+
+            for table_slug, task in self._tables.items():
+                cache_namespace = self._cache_namespace(table_slug, task)
+                batch_ids.add(self._provider.finish_batch(cache_dir, cache_namespace))
+                batch_ids.discard(None)  # drop any None's from calls that didn't create a batch
+
+        # Now wait for all the results
+        for table_slug, task in self._tables.items():
+            if batch_ids := table_batches.get(table_slug):
+                rich.print(
+                    f" Waiting for batches for '{table_slug}' to finish "
+                    "(can be resumed if interrupted)."
+                )
+                self._wait_for_batches(
+                    batch_ids,
+                    cache_namespace=self._cache_namespace(table_slug, task),
+                    schema=task.response_schema,
+                )
+
+    def _wait_for_batches(
+        self,
+        batch_ids: set[str],
+        *,
+        schema: type[pydantic.BaseModel],
+        cache_namespace: str,
+    ) -> None:
+        status_box = rich.text.Text()
+        count = len(batch_ids)
+        cache_dir = self._cache_dir()
+
+        with rich.get_console().status(status_box):
+            for batch_id in batch_ids:
+                plural = "" if count == 1 else "es"
+                status_box.plain = (
+                    f"Waiting for {count} batch{plural} to finish… (may take up to a day)"
+                )
+
+                self._provider.wait_for_batch(
+                    batch_id,
+                    schema=schema,
+                    cache_dir=cache_dir,
+                    cache_namespace=cache_namespace,
+                )
+
+                count -= 1
+
+        count = len(batch_ids)
+        batch_plural = "" if count == 1 else "es"
+        rich.print(f" Waited for {count} batch{batch_plural}.")
 
     def _fix_spans(self, note_ref: str, text: str, parsed: dict) -> bool:
         """Converts string spans into integer spans."""

--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -5,12 +5,16 @@ import dataclasses
 import datetime
 import json
 import os
+import pathlib
+import tempfile
+import time
 from collections.abc import Iterable
 from typing import NoReturn, Self
 
 import boto3
 import cumulus_fhir_support as cfs
 import openai
+import rich
 from openai.types.chat import ParsedChatCompletion
 from pydantic import BaseModel
 
@@ -195,6 +199,7 @@ class OpenAIProvider(Provider):
 
     def __init__(
         self,
+        provider_name: str,
         model_name: str,
         client: openai.OpenAI,
         *,
@@ -203,13 +208,13 @@ class OpenAIProvider(Provider):
         deployment: str | None = None,
     ):
         super().__init__()
+        self.provider_name = provider_name
         self.model_name = model_name
         self.client = client
         self.supports_batches = max_batch_count is not None
         self.max_batch_count = self.AZURE_MAX_BATCH_COUNT
         if self.supports_batches:
-            # TODO MIKE: add coverage
-            self.max_batch_count = min(self.max_batch_count, max_batch_count)  # pragma: no cover
+            self.max_batch_count = min(self.max_batch_count, max_batch_count)
         self.supports_schema = supports_schema
         self.deployment = deployment or model_name
         self.batch_filename = None
@@ -292,153 +297,149 @@ class OpenAIProvider(Provider):
         response = self.client.chat.completions.parse(**prompt_args)
         return self._process_completion_result(response, schema)
 
-    # TODO MIKE: add back when implementing batching
+    def add_to_batch(self, prompt: Prompt, tmp_dir: str) -> str | None:
+        batch_id = None
 
-    # async def add_to_batch(self, prompt: Prompt, tmp_dir: str) -> str | None:
-    #     batch_id = None
+        # Check if we can early exit, because it's in cache already
+        cached = caching.cache_read(prompt.cache_dir, prompt.cache_namespace, prompt.cache_checksum)
+        if cached is not None:
+            return None
 
-    #     # Check if we can early exit, because it's in cache already
-    #     cached = caching.cache_read(prompt.cache_dir, prompt.cache_namespace,
-    #                                 prompt.cache_checksum)
-    #     if cached is not None:
-    #         return None
+        # Format new row
+        row = {
+            "custom_id": prompt.cache_checksum,
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": self._prompt_args(prompt.system, prompt.user, prompt.schema),
+        }
+        row = json.dumps(row) + "\n"
 
-    #     # Format new row
-    #     row = {
-    #         "custom_id": prompt.cache_checksum,
-    #         "method": "POST",
-    #         "url": "/v1/chat/completions",
-    #         "body": self._prompt_args(prompt.system, prompt.user, prompt.schema),
-    #     }
-    #     row = json.dumps(row) + "\n"
+        # Confirm we won't go past the size limit if we add this new row; send current batch if so
+        if self.batch_filename:
+            new_size = os.path.getsize(self.batch_filename) + len(row)
+            new_lines = self.batch_rows + 1
+            if new_size > self.AZURE_MAX_BATCH_BYTES or new_lines > self.AZURE_MAX_BATCH_COUNT:
+                # New row wouldn't fit, send old one first
+                batch_id = self._send_batch(prompt.cache_dir, prompt.cache_namespace)
 
-    #     # Confirm we won't go past the size limit if we add this new row; send current batch if so
-    #     if self.batch_filename:
-    #         new_size = os.path.getsize(self.batch_filename) + len(row)
-    #         new_lines = self.batch_rows + 1
-    #         if new_size > self.AZURE_MAX_BATCH_BYTES or new_lines > self.AZURE_MAX_BATCH_COUNT:
-    #             # New row wouldn't fit, send old one first
-    #             batch_id = await self._send_batch(prompt.cache_dir, prompt.cache_namespace)
+        # Are we continuing a WIP file, or do we need to create a new one?
+        if self.batch_filename:
+            tmp_file = open(self.batch_filename, "a", encoding="utf8")
+        else:
+            tmp_file = tempfile.NamedTemporaryFile("wt", dir=tmp_dir, delete=False, suffix=".jsonl")
+            self.batch_filename = tmp_file.name
 
-    #     # Are we continuing a WIP file, or do we need to create a new one?
-    #     if self.batch_filename:
-    #         tmp_file = open(self.batch_filename, "a", encoding="utf8")
-    #     else:
-    #         tmp_file = tempfile.NamedTemporaryFile(
-    #             "wt", dir=tmp_dir, delete=False, suffix=".jsonl")
-    #         self.batch_filename = tmp_file.name
+        # Add our new row
+        with tmp_file:
+            tmp_file.write(row)
+            self.batch_rows += 1
 
-    #     # Add our new row
-    #     with tmp_file:
-    #         tmp_file.write(row)
-    #         self.batch_rows += 1
+        return batch_id
 
-    #     return batch_id
+    def _send_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str:
+        prompt_file = self.client.files.create(
+            file=pathlib.Path(self.batch_filename),
+            purpose="batch",
+        )
 
-    # async def _send_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str:
-    #     prompt_file = await self.client.files.create(
-    #         file=pathlib.Path(self.batch_filename),
-    #         purpose="batch",
-    #     )
+        batch = self.client.batches.create(
+            completion_window="24h",
+            endpoint="/v1/chat/completions",
+            input_file_id=prompt_file.id,
+        )
 
-    #     batch = await self.client.batches.create(
-    #         completion_window="24h",
-    #         endpoint="/v1/chat/completions",
-    #         input_file_id=prompt_file.id,
-    #     )
+        os.unlink(self.batch_filename)
+        self.batch_filename = None
+        self.batch_rows = 0
 
-    #     os.unlink(self.batch_filename)
-    #     self.batch_filename = None
-    #     self.batch_rows = 0
+        # Save this batch ID for resuming later
+        metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
+        batch_key = f"batches-{self.provider_name}"
+        metadata[batch_key] = [*metadata.get(batch_key, []), batch.id]
+        caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
 
-    #     # Save this batch ID for resuming later
-    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
-    #     batch_key = f"batches-{_provider_name}"
-    #     metadata[batch_key] = [*metadata.get(batch_key, []), batch.id]
-    #     caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
+        return batch.id
 
-    #     return batch.id
+    def finish_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str | None:
+        if self.batch_filename:
+            return self._send_batch(cache_dir, cache_namespace)
+        return None
 
-    # async def finish_batch(self, cache_dir: cfs.FsPath, cache_namespace: str) -> str | None:
-    #     if self.batch_filename:
-    #         return await self._send_batch(cache_dir, cache_namespace)
-    #     return None
+    def wait_for_batch(
+        self, batch_id: str, *, schema: type[BaseModel], cache_dir: cfs.FsPath, cache_namespace: str
+    ) -> None:
+        # Poll the batches until completion
+        batch = self.client.batches.retrieve(batch_id=batch_id)
+        # You can see the list of valid statuses here:
+        # https://platform.openai.com/docs/guides/batch/2-uploading-your-batch-input-file
+        while batch.status in {"validating", "in_progress", "finalizing"}:
+            time.sleep(60 * 5)  # check every five minutes
+            batch = self.client.batches.retrieve(batch_id=batch_id)
 
-    # async def wait_for_batch(
-    #     self,
-    #     batch_id: str, *, schema: type[BaseModel], cache_dir: cfs.FsPath, cache_namespace: str
-    # ) -> None:
-    #     # Poll the batches until completion
-    #     batch = await self.client.batches.retrieve(batch_id=batch_id)
-    #     # You can see the list of valid statuses here:
-    #     # https://platform.openai.com/docs/guides/batch/2-uploading-your-batch-input-file
-    #     while batch.status in {"validating", "in_progress", "finalizing"}:
-    #         await asyncio.sleep(60 * 5)  # check every five minutes
-    #         batch = await self.client.batches.retrieve(batch_id=batch_id)
+        if batch.status != "completed":
+            rich.print(f"Batch did not complete, got status: '{batch.status}'")
+            # Don't exit function - process the errors and output that we do have, and remove the
+            # batch from our metadata cache like normal
 
-    #     if batch.status != "completed":
-    #         logging.warning(f"Batch did not complete, got status: '{batch.status}'")
-    #         # Don't exit function - process the errors and output that we do have, and remove the
-    #         # batch from our metadata cache like normal
+        # Check for errors
+        if batch.error_file_id:
+            error_file = self.client.files.content(file_id=batch.error_file_id)
+            for line in error_file.iter_lines():
+                try:
+                    line = json.loads(line)
+                    # Yes, error.message.error.message is really where this is kept.
+                    msg = line.get("error", {}).get("message", {}).get("error", {}).get("message")
+                    if msg:
+                        rich.print(f"Error from NLP: {msg}")
+                except json.JSONDecodeError:
+                    rich.print(f"Could not process error message: '{line}'")
 
-    #     # Check for errors
-    #     if batch.error_file_id:
-    #         error_file = await self.client.files.content(file_id=batch.error_file_id)
-    #         async for line in await error_file.aiter_lines():
-    #             try:
-    #                 line = json.loads(line)
-    #                 # Yes, error.message.error.message is really where this is kept.
-    #                 msg = line.get("error", {}).get("message", {}).get("error", {}).get("message")
-    #                 if msg:
-    #                     logging.warning(f"Error from NLP: {msg}")
-    #             except json.JSONDecodeError:
-    #                 logging.warning(f"Could not process error message: '{line}'")
+        # Get the results!
+        if batch.output_file_id:
+            contents = self.client.files.content(file_id=batch.output_file_id)
 
-    #     # Get the results!
-    #     if batch.output_file_id:
-    #         contents = await self.client.files.content(file_id=batch.output_file_id)
+            for line in contents.iter_lines():
+                line = json.loads(line)
+                # If an error happens, it seems to come in via the error_file_id above.
+                # But just for safety, we'll also check here.
+                if line.get("error") and (error := line["error"].get("message")):
+                    rich.print(f"Error from NLP: {error}")
+                    continue
+                status = line.get("response", {}).get("status_code", 200)
+                if status >= 300:
+                    rich.print(f"Unexpected status code from NLP: {status}")
+                    continue
+                checksum = line.get("custom_id")
+                body = line.get("response", {}).get("body")
+                if not body or not checksum:
+                    rich.print("Unexpected response from NLP: missing data")
+                    continue
 
-    #         async for line in await contents.aiter_lines():
-    #             line = json.loads(line)
-    #             # If an error happens, it seems to come in via the error_file_id above.
-    #             # But just for safety, we'll also check here.
-    #             if line.get("error") and (error := line["error"].get("message")):
-    #                 logging.warning(f"Error from NLP: {error}")
-    #                 continue
-    #             status = line.get("response", {}).get("status_code", 200)
-    #             if status >= 300:
-    #                 logging.warning(f"Unexpected status code from NLP: {status}")
-    #                 continue
-    #             checksum = line.get("custom_id")
-    #             body = line.get("response", {}).get("body")
-    #             if not body or not checksum:
-    #                 logging.warning("Unexpected response from NLP: missing data")
-    #                 continue
+                # Write each valid response to cache
+                result = ParsedChatCompletion.model_validate(body)
+                response = self._process_completion_result(result, schema)
+                caching.cache_write(
+                    cache_dir, cache_namespace, checksum, json.dumps(response.to_dict())
+                )
 
-    #             # Write each valid response to cache
-    #             result = ParsedChatCompletion.model_validate(body)
-    #             response = self._process_completion_result(result, schema)
-    #             caching.cache_write(
-    #                 cache_dir, cache_namespace, checksum, json.dumps(response.to_dict())
-    #             )
+        # We could clean up files here, but the batch, input file, and output file are cleaned
+        # automatically after 30 days, so let's not bother deleting them ourselves, in case we
+        # need to do some manual recovery.
 
-    #     # We could clean up files here, but the batch, input file, and output file are cleaned
-    #     # automatically after 30 days, so let's not bother deleting them ourselves, in case we
-    #     # need to do some manual recovery.
-
-    #     # Drop this batch ID from resume list
-    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
-    #     batch_key = f"batches-{_provider_name}"
-    #     batch_ids = metadata.get(batch_key, [])
-    #     if batch.id in batch_ids:
-    #         batch_ids.remove(batch.id)
-    #     metadata[batch_key] = batch_ids
-    #     caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
+        # Drop this batch ID from resume list
+        metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
+        batch_key = f"batches-{self.provider_name}"
+        batch_ids = metadata.get(batch_key, [])
+        if batch.id in batch_ids:
+            batch_ids.remove(batch.id)
+        metadata[batch_key] = batch_ids
+        caching.cache_metadata_write(cache_dir, cache_namespace, metadata)
 
 
 class AzureProvider(OpenAIProvider):
     def __init__(self, model_name: str, **kwargs):
         super().__init__(
+            "azure",
             model_name,
             openai.AzureOpenAI(api_version="2024-10-21"),
             **kwargs,
@@ -447,9 +448,10 @@ class AzureProvider(OpenAIProvider):
 
 class VllmProvider(OpenAIProvider):
     def __init__(self, compose_id, model_name: str, env_stem: str, port: int):
-        url = os.environ.get(f"CUMULUS_{env_stem}_URL")  # set by compose.yaml
+        url = os.environ.get(f"CUMULUS_{env_stem}_URL")  # set by compose-nlp.yaml
         url = url or f"http://localhost:{port}/v1"  # offer non-docker fallback
         super().__init__(
+            "local",
             model_name,
             openai.OpenAI(base_url=url, api_key="EMPTY"),
             supports_schema=True,
@@ -484,7 +486,7 @@ class Model:
     BEDROCK_CACHE = True  # turns on caching
     BEDROCK_SCHEMA = True  # turns on JSON schema support
 
-    COMPOSE_ID = None  # docker service name in compose.yaml
+    COMPOSE_ID = None  # docker service name in compose-nlp.yaml
     VLLM_INFO = None  # tuple of vLLM model name, env var stem use for URL, plus default port
 
     #########################################
@@ -544,8 +546,7 @@ class Model:
 
         if self.provider.supports_batches and config.use_batching:
             # Currently, both Azure and Bedrock charge 50% for batch mode.
-            # TODO MIKE: remove no cover
-            self.prices.multiplier = 0.5  # pragma: no cover
+            self.prices.multiplier = 0.5
 
     @property
     def stats(self) -> TokenStats:
@@ -567,90 +568,6 @@ class Model:
             prompt.user,
             prompt.schema,
         )
-
-    # TODO MIKE: add back when implementing batching (and move to driver.py?)
-
-    # async def prompt_via_batches_if_possible(
-    #     self,
-    #     *,
-    #     schema: type[BaseModel],
-    #     cache_dir: cfs.FsPath,
-    #     cache_namespace: str,
-    #     prompt_iter: AsyncIterator[Prompt],
-    # ) -> None:
-    #     """Will resume any previous batches, run new notes via batches, and save all in cache"""
-    #     if not _use_batch_mode:
-    #         return
-    #     if not self.provider.supports_batches:
-    #         raise errors.CumulusLibraryError(
-    #             f"Model {self.provider.model_name} does not support batching."
-    #         )
-
-    #     # First, resume any previously started batches
-    #     metadata = caching.cache_metadata_read(cache_dir, cache_namespace)
-    #     batch_ids = metadata.get(f"batches-{_provider_name}")
-    #     if batch_ids:
-    #         rich.print(" Resuming previously created batches.")
-    #         await self._wait_for_batches(
-    #             batch_ids, schema=schema, cache_dir=cache_dir, cache_namespace=cache_namespace
-    #         )
-
-    #     # Then, regardless of whether there were existing ones, make new batches for any new
-    #     # notes we now see.
-    #     batch_ids = set()
-    #     with tempfile.TemporaryDirectory() as tmp_dir:
-    #         async for prompt in prompt_iter:
-    #             batch_ids.add(await self.provider.add_to_batch(prompt, tmp_dir))
-    #         batch_ids.add(await self.provider.finish_batch(cache_dir, cache_namespace))
-    #     batch_ids.discard(None)  # drop any None's from calls that didn't create a batch
-    #     if batch_ids:
-    #         rich.print(" Waiting for batches to finish (can be resumed if interrupted).")
-    #         await self._wait_for_batches(
-    #             batch_ids,
-    #             cache_dir=cache_dir,
-    #             cache_namespace=cache_namespace,
-    #             schema=schema,
-    #         )
-
-    # async def _wait_for_batches(
-    #     self,
-    #     batch_ids: set[str],
-    #     *,
-    #     schema: type[BaseModel],
-    #     cache_dir: cfs.FsPath,
-    #     cache_namespace: str,
-    # ) -> None:
-    #     status_box = rich.text.Text()
-
-    #     count = len(batch_ids)
-
-    #     def update_text() -> None:
-    #         plural = "" if count == 1 else "es"
-    #         status_box.plain = (
-    #             f"Waiting for {count} batch{plural} to finish… (may take up to a day)"
-    #         )
-
-    #     async def run_batch(batch_id: str) -> None:
-    #         nonlocal count
-
-    #         await self.provider.wait_for_batch(
-    #             batch_id,
-    #             schema=schema,
-    #             cache_dir=cache_dir,
-    #             cache_namespace=cache_namespace,
-    #         )
-
-    #         count -= 1
-    #         update_text()
-
-    #     with rich.get_console().status(status_box):
-    #         update_text()
-    #         coroutines = [run_batch(batch_id) for batch_id in batch_ids]
-    #         await asyncio.gather(*coroutines)
-
-    #     count = len(batch_ids)
-    #     batch_plural = "" if count == 1 else "es"
-    #     rich.print(f" Waited for {count} batch{batch_plural}.")
 
 
 class Gpt35Model(Model):
@@ -738,7 +655,7 @@ class Llama4ScoutModel(Model):
         new_input_tokens=0.00017,
         output_tokens=0.00066,
     )
-    COMPOSE_ID = "llama4-scout"  # TODO MIKE: add compose file to repo & docs
+    COMPOSE_ID = "llama4-scout"
     VLLM_INFO = ("nvidia/Llama-4-Scout-17B-16E-Instruct-FP4", "LLAMA4_SCOUT", 8087)
 
 

--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -27,6 +27,15 @@ class UnreachableModel(errors.CumulusLibraryError):
     """Raised when a server can't be contacted"""
 
 
+def print_error(msg: str) -> None:
+    """Convenience method to avoid adding highlights to error messages.
+
+    They can be mildly misleading (numbers tend to appear in odd places) and also,
+    they interfere with tests checking stdout output.
+    """
+    rich.get_console().print(msg, highlight=False)
+
+
 @dataclasses.dataclass(kw_only=True)
 class Prompt:
     system: str
@@ -377,7 +386,7 @@ class OpenAIProvider(Provider):
             batch = self.client.batches.retrieve(batch_id=batch_id)
 
         if batch.status != "completed":
-            rich.print(f"Batch did not complete, got status: '{batch.status}'")
+            print_error(f"Batch did not complete, got status: '{batch.status}'")
             # Don't exit function - process the errors and output that we do have, and remove the
             # batch from our metadata cache like normal
 
@@ -390,9 +399,9 @@ class OpenAIProvider(Provider):
                     # Yes, error.message.error.message is really where this is kept.
                     msg = line.get("error", {}).get("message", {}).get("error", {}).get("message")
                     if msg:
-                        rich.print(f"Error from NLP: {msg}")
+                        print_error(f"Error from NLP: {msg}")
                 except json.JSONDecodeError:
-                    rich.print(f"Could not process error message: '{line}'")
+                    print_error(f"Could not process error message: '{line}'")
 
         # Get the results!
         if batch.output_file_id:
@@ -403,16 +412,16 @@ class OpenAIProvider(Provider):
                 # If an error happens, it seems to come in via the error_file_id above.
                 # But just for safety, we'll also check here.
                 if line.get("error") and (error := line["error"].get("message")):
-                    rich.print(f"Error from NLP: {error}")
+                    print_error(f"Error from NLP: {error}")
                     continue
                 status = line.get("response", {}).get("status_code", 200)
                 if status >= 300:
-                    rich.print(f"Unexpected status code from NLP: {status}")
+                    print_error(f"Unexpected status code from NLP: {status}")
                     continue
                 checksum = line.get("custom_id")
                 body = line.get("response", {}).get("body")
                 if not body or not checksum:
-                    rich.print("Unexpected response from NLP: missing data")
+                    print_error("Unexpected response from NLP: missing data")
                     continue
 
                 # Write each valid response to cache

--- a/docs/workflows/nlp.md
+++ b/docs/workflows/nlp.md
@@ -204,6 +204,21 @@ And then once satisfied, upload to Athena.
    The existing cache of NLP results sitting in the ETL PHI dir will prevent this second run from
    actually consuming LLM tokens.
 
+### Batching
+
+Some providers support NLP batching, which lets you bundle up a lot of requests at once and send
+them in one go to the LLM server at a discount.
+Then you wait up to day for the results.
+So you trade predictable timing for 50% cheaper tokens.
+
+As of this writing, Cumulus Library only supports batching with the Azure provider.
+Make sure you've set up a deployment that uses batching, and then pass in the following arguments:
+`--azure-deployment=xxx --batch-nlp`.
+
+Then be prepared to wait a little bit.
+Note that the 50% discount is mitigated somewhat by the fact that batching does not use token
+caching at all. So some of that discount is lost. But overall, you'll probably save money.
+
 ### Using a Local LLM
 
 For cost, reproducibility, or PHI-control reasons, you may prefer a locally-run LLM instead of a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dev = [
     "sqlfluff  >= 3",
 ]
 test = [
+    "httpx",
     "time-machine",
     "pytest",
     "pytest-cov",
     "pytest-xdist",
     "responses",
-    "respx",
 ]
 
 [project.urls]

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -1,20 +1,24 @@
 import base64
 import binascii
 import contextlib
+import hashlib
 import io
 import json
 import os
+from types import SimpleNamespace
 from unittest import mock
 
 import cumulus_fhir_support as cfs
 import fsspec.implementations.memory
+import httpx
+import openai
 import pandas
 import pytest
-import respx
 
 import cumulus_library
 from cumulus_library import cli, databases, errors, note_utils
 from cumulus_library.builders import nlp_builder
+from cumulus_library.builders.nlp.models import OpenAIProvider
 from tests import conftest, nlp_utils
 from tests.conftest import duckdb_args
 
@@ -162,7 +166,6 @@ def test_flattened_config(tmp_path, note_source):
     assert builder._workflow_config.tables["fallthrough"].system_prompt == "hello"
 
 
-@respx.mock
 def test_filter(tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -222,7 +225,6 @@ def test_filter(tmp_path, mock_db_config):
     assert expected_stats in console_output.getvalue()
 
 
-@respx.mock
 def test_already_uploaded(tmp_path, mock_db_config, note_source):
     """Verify that we skip notes that we've already uploaded before"""
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -279,7 +281,7 @@ def test_args_passed_down(mock_builder, tmp_path):
 def test_unreachable_vllm(tmp_path, note_source, mock_db_config):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
-    model.mock_openai_model_list(status_code=500)
+    model.mock_openai_model_list(fail=True)
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
     )
@@ -287,7 +289,6 @@ def test_unreachable_vllm(tmp_path, note_source, mock_db_config):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 def test_cached_response(tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -319,7 +320,7 @@ def test_cached_response(tmp_path, mock_db_config):
     assert builder.stats.got_response[0] == 1
 
     # Confirm that we cache the response and don't hit the endpoint again
-    model.mock_openai_response({}, status_code=500)
+    model.mock_openai_response({}, fail=True)
 
     # Add a new note to sanity check that we do actually fail on the new one
     with open(f"{tmp_path}/dxr.ndjson", "a", encoding="utf8") as f:
@@ -333,7 +334,6 @@ def test_cached_response(tmp_path, mock_db_config):
     assert builder.stats.got_response[0] == 1  # still got our cached result
 
 
-@respx.mock
 def test_span_correction(tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -394,7 +394,6 @@ def test_span_correction(tmp_path, mock_db_config):
     assert failure_msg in console_output.getvalue()
 
 
-@respx.mock
 def test_writes_out_at_note_limit(tmp_path, mock_db_config):
     with open(f"{tmp_path}/doc.ndjson", "w", encoding="utf8") as f:
         add_doc("1", "Note one", f)
@@ -425,7 +424,6 @@ def test_writes_out_at_note_limit(tmp_path, mock_db_config):
     assert "Failed to process note: test2" in console_output.getvalue()
 
 
-@respx.mock
 def test_various_value_types(tmp_path, mock_db_config, note_source):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -461,7 +459,6 @@ def test_various_value_types(tmp_path, mock_db_config, note_source):
     assert rows[0]["result"] == results
 
 
-@respx.mock
 def test_no_batching_support(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
@@ -476,7 +473,6 @@ def test_no_batching_support(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 def test_no_phi_dir(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
@@ -491,7 +487,6 @@ def test_no_phi_dir(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 def test_bad_nlp_model(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
@@ -510,7 +505,6 @@ def test_bad_nlp_model(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 def test_missing_nlp_model(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
@@ -524,11 +518,10 @@ def test_missing_nlp_model(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 def test_bad_stop(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
-    model.mock_openai_response({}, finish_reason="bad_reason")
+    model.mock_openai_response({}, finish_reason="content_filter")
 
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
@@ -539,10 +532,9 @@ def test_bad_stop(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 0
-    assert "did not complete, with finish reason: bad_reason" in console_output.getvalue()
+    assert "did not complete, with finish reason: content_filter" in console_output.getvalue()
 
 
-@respx.mock
 def test_disabling_stats(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel()
@@ -560,7 +552,6 @@ def test_disabling_stats(tmp_path, mock_db_config, note_source):
     assert "Token usage:" not in console_output.getvalue()
 
 
-@respx.mock
 def test_cloud_model_but_local_provider(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(model_id="gpt5")
@@ -573,7 +564,6 @@ def test_cloud_model_but_local_provider(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 @nlp_utils.mock_env("azure")
 def test_azure_happy_path(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -611,7 +601,6 @@ def test_azure_no_env(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@respx.mock
 @nlp_utils.mock_env("azure")
 def test_azure_no_schema_support(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -626,8 +615,8 @@ def test_azure_no_schema_support(tmp_path, mock_db_config, note_source):
     builder.execute_queries(mock_db_config, None)
 
     # Confirm that we requested just "give us json please" if model doesn't support schemas
-    last_json = json.loads(respx.calls.last.request.content)
-    assert last_json["response_format"] == {"type": "json_object"}
+    last_kwargs = model.openai.chat.completions.parse.call_args[1]
+    assert last_kwargs["response_format"] == {"type": "json_object"}
 
 
 def test_bedrock_happy_path(tmp_path, mock_db_config, note_source):
@@ -645,7 +634,7 @@ def test_bedrock_happy_path(tmp_path, mock_db_config, note_source):
 def test_bedrock_bad_stop(tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(provider="bedrock")
-    model.mock_bedrock_response({}, stop_reason="bad_reason")
+    model.mock_bedrock_response({}, stop_reason="content_filter")
 
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
@@ -656,7 +645,7 @@ def test_bedrock_bad_stop(tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
     assert builder.stats.got_response[0] == 0
-    assert "did not complete, with stop reason: bad_reason" in console_output.getvalue()
+    assert "did not complete, with stop reason: content_filter" in console_output.getvalue()
 
 
 def test_bedrock_bad_model(tmp_path, mock_db_config, note_source):
@@ -756,7 +745,6 @@ def test_bedrock_no_response(tmp_path, mock_db_config, note_source):
     assert "Failed to process note: no response content found" in console_output.getvalue()
 
 
-@respx.mock
 @nlp_utils.mock_env()
 @mock.patch("botocore.client")
 def test_write_to_athena(mock_client, tmp_path, note_source):
@@ -810,3 +798,291 @@ def test_write_to_athena(mock_client, tmp_path, note_source):
         "FROM read_parquet('memory://s3://testbucket/athena/cumulus_user_uploads/"
         "testdb/test/task_v0/*.parquet')"
     ]
+
+
+def batch_line(contents: str, answer: str = "answer") -> str:
+    checksum = hashlib.sha256(contents.encode("utf8"), usedforsecurity=False).hexdigest()
+    return json.dumps(
+        {
+            "custom_id": checksum,
+            "response": {
+                "body": {
+                    "id": f"blarg-{checksum}",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "finish_reason": "stop",
+                            "message": {
+                                "role": "assistant",
+                                "content": json.dumps({"ignored": answer}),
+                            },
+                        }
+                    ],
+                    "created": 1000000,
+                    "model": "gpt-4o",
+                    "object": "chat.completion",
+                },
+            },
+        },
+    )
+
+
+def mock_files_content(model: nlp_utils.MockModel, contents: list | None = None) -> None:
+    if contents is None:
+        contents = [
+            batch_line("hello world"),
+        ]
+    model.openai.files.content.return_value = openai.HttpxBinaryResponseContent(
+        httpx.Response(status_code=200, text="\n".join(contents)),
+    )
+
+
+@nlp_utils.mock_env("azure")
+def test_azure_batching_happy_path(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure", model_id="gpt4o")
+
+    def upload_file(**kwargs):
+        assert kwargs["purpose"] == "batch"
+        file_text = cfs.FsPath(str(kwargs["file"])).read_text()
+        lines = [json.loads(line) for line in file_text.split("\n") if line]
+        assert len(lines) == 1
+        assert (
+            lines[0]["custom_id"]
+            == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        )
+        assert lines[0]["method"] == "POST"
+        assert lines[0]["url"] == "/v1/chat/completions"
+        assert lines[0]["body"]["model"] == "gpt-4o"
+        assert lines[0]["body"]["messages"][1]["content"] == "hello world"
+        return SimpleNamespace(id="input")
+
+    model.openai.files.create = upload_file
+    model.openai.batches.create.return_value = SimpleNamespace(id="batch")
+    model.openai.batches.retrieve.return_value = SimpleNamespace(
+        id="batch", status="completed", error_file_id=None, output_file_id="output"
+    )
+    mock_files_content(model)
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.got_response[0] == 1
+
+    rows = read_rows(mock_db_config, "test__task")
+    assert rows[0]["result"] == {"ignored": "answer"}
+
+    assert model.openai.batches.create.call_args_list[0][1] == {
+        "completion_window": "24h",
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": "input",
+    }
+    assert model.openai.batches.retrieve.call_args_list[0][1] == {
+        "batch_id": "batch",
+    }
+
+
+@nlp_utils.mock_env("azure")
+def test_azure_resume_batching(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure", model_id="gpt4o")
+
+    path_dir = f"{model.phi}/nlp-cache/test__task_v0_gpt4o"
+    os.makedirs(path_dir)
+    with open(f"{path_dir}/metadata.json", "w", encoding="utf8") as f:
+        json.dump({"batches-azure": ["b1", "b2"]}, f)
+
+    # Just mock the retrieval bits, make the creation bits blow up
+    model.openai.files.create.side_effect = RuntimeError
+    model.openai.batches.retrieve.return_value = SimpleNamespace(
+        id="batch", status="completed", error_file_id=None, output_file_id="output"
+    )
+    mock_files_content(model)
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.got_response[0] == 1
+
+    rows = read_rows(mock_db_config, "test__task")
+    assert rows[0]["result"] == {"ignored": "answer"}
+
+
+@nlp_utils.mock_env("azure")
+@mock.patch("time.sleep", new=lambda x: None)
+def test_azure_batching_errors(tmp_path, mock_db_config, note_source):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure", model_id="gpt4o")
+
+    model.openai.files.create.return_value = SimpleNamespace(id="input")
+    model.openai.batches.create.return_value = SimpleNamespace(id="batch")
+    model.openai.batches.retrieve.side_effect = [
+        SimpleNamespace(id="batch", status="validating"),
+        SimpleNamespace(id="batch", status="in_progress"),
+        SimpleNamespace(id="batch", status="finalizing"),
+        SimpleNamespace(
+            # Will still process error/output files when failed, just prints a message
+            id="batch",
+            status="failed",
+            error_file_id="error",
+            output_file_id="output",
+        ),
+    ]
+    model.openai.files.content.side_effect = [
+        openai.HttpxBinaryResponseContent(  # error file
+            httpx.Response(
+                status_code=200,
+                text="\n".join(
+                    [
+                        # Test all the various ways we can stuff errors in there
+                        json.dumps({"error": {"message": {"error": {"message": "error1"}}}}),
+                        "{'blarg'",  # invalid json
+                    ],
+                ),
+            ),
+        ),
+        openai.HttpxBinaryResponseContent(  # output file
+            httpx.Response(
+                status_code=200,
+                text="\n".join(
+                    [
+                        # Test all the various ways we can stuff errors in there
+                        json.dumps({"error": {"message": "error2"}}),
+                        json.dumps({"response": {"status_code": 400}}),
+                        json.dumps({"response": {"body": {"model": "gpt-4o"}}}),  # no custom_id
+                        json.dumps({"custom_id": "xx", "response": {"id": "yy"}}),  # no body
+                    ],
+                ),
+            ),
+        ),
+    ]
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    console_output = io.StringIO()
+    with contextlib.redirect_stdout(console_output):
+        builder.execute_queries(mock_db_config, None)
+
+    assert "Batch did not complete, got status: 'failed'" in console_output.getvalue()
+    assert "Error from NLP: error1" in console_output.getvalue()
+    assert "Could not process error message: '{'blarg''" in console_output.getvalue()
+    assert "Error from NLP: error2" in console_output.getvalue()
+    assert "Unexpected status code from NLP: 400" in console_output.getvalue()
+    assert "Unexpected response from NLP: missing data" in console_output.getvalue()
+
+
+@mock.patch.object(OpenAIProvider, "AZURE_MAX_BATCH_COUNT", 2)
+@mock.patch.object(OpenAIProvider, "AZURE_MAX_BATCH_BYTES", 6000)
+@nlp_utils.mock_env("azure")
+def test_azure_splitting_batch(tmp_path, mock_db_config):
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure", model_id="gpt4o")
+
+    long_str = "a" * 5900  # very long string that hits size limit
+
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr("hello1", "world1", f)
+        add_dxr("hello2", "world2", f)
+        # Now there will be a break because of max count of 2 rows
+        add_dxr("hello3", long_str, f)
+        # Now there will be a break because of max byte limit
+        add_dxr("hello4", "world4", f)
+    note_source = note_utils.NoteSource([tmp_path])
+
+    model.openai.files.create.side_effect = [
+        SimpleNamespace(id="input1"),
+        SimpleNamespace(id="input2"),
+        SimpleNamespace(id="input3"),
+    ]
+    model.openai.batches.create.side_effect = [
+        SimpleNamespace(id="batch1"),
+        SimpleNamespace(id="batch2"),
+        SimpleNamespace(id="batch3"),
+    ]
+    model.openai.batches.retrieve.side_effect = [
+        SimpleNamespace(
+            id="batch1", status="completed", error_file_id=None, output_file_id="output1"
+        ),
+        SimpleNamespace(
+            id="batch2", status="completed", error_file_id=None, output_file_id="output2"
+        ),
+        SimpleNamespace(
+            id="batch3", status="completed", error_file_id=None, output_file_id="output3"
+        ),
+    ]
+    model.openai.files.content.side_effect = [
+        openai.HttpxBinaryResponseContent(
+            httpx.Response(
+                status_code=200,
+                text="\n".join(
+                    [batch_line("world1", answer="w1"), batch_line("world2", answer="w2")]
+                ),
+            ),
+        ),
+        openai.HttpxBinaryResponseContent(
+            httpx.Response(status_code=200, text=batch_line(long_str, answer="w3")),
+        ),
+        openai.HttpxBinaryResponseContent(
+            httpx.Response(status_code=200, text=batch_line("world4", answer="w4")),
+        ),
+    ]
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.got_response[0] == 4
+
+    rows = read_rows(mock_db_config, "test__task")
+    assert [row["result"] for row in rows] == [
+        {"ignored": "w1"},
+        {"ignored": "w2"},
+        {"ignored": "w3"},
+        {"ignored": "w4"},
+    ]
+
+
+@nlp_utils.mock_env("azure")
+def test_azure_batches_with_bad_notes(tmp_path, mock_db_config):
+    """Just confirm that the batch flow handles it gracefully too, since it iterates notes"""
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(provider="azure", model_id="gpt4o")
+
+    with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
+        add_dxr("hello1", None, f)
+        add_dxr("hello2", "world2", f)
+    note_source = note_utils.NoteSource([tmp_path])
+
+    model.openai.files.create.return_value = SimpleNamespace(id="input1")
+    model.openai.batches.create.return_value = SimpleNamespace(id="batch1")
+    model.openai.batches.retrieve.return_value = SimpleNamespace(
+        id="batch1", status="completed", error_file_id=None, output_file_id="output1"
+    )
+    model.openai.files.content.return_value = openai.HttpxBinaryResponseContent(
+        httpx.Response(status_code=200, text=batch_line("world2", answer="w2")),
+    )
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=model.nlp_config(batching=True),
+    )
+
+    builder.execute_queries(mock_db_config, None)
+    assert builder.stats.available == 2
+    assert builder.stats.got_response[0] == 1

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -4,9 +4,11 @@ import os
 import pathlib
 import tempfile
 import weakref
+from types import SimpleNamespace
 from unittest import mock
 
-import respx
+import openai
+from openai.types import chat, completion_usage
 
 from cumulus_library import note_utils
 from tests import conftest
@@ -57,24 +59,16 @@ class MockModel:
             client_mock.return_value = self._boto
             self.mock_bedrock_response({})
         else:
-            if provider == "azure":
-                url = "https://example.com/azure/openai"
-                chat_prefix = "/deployments/.*"
-                params = {"api-version": "2024-10-21"}
-            else:
-                urls = {
-                    "gpt-oss-120b": "http://localhost:8086/v1",
-                    "llama4-scout": "http://localhost:8087/v1",
-                }
-                url = urls.get(model_id, "nope://invalid")
-                chat_prefix = ""
-                params = {}
+            openai_patcher = mock.patch("openai.OpenAI")
+            weakref.finalize(self, openai_patcher.stop)
+            azure_patcher = mock.patch("openai.AzureOpenAI")
+            weakref.finalize(self, azure_patcher.stop)
+
+            self.openai = mock.MagicMock()
+            openai_patcher.start().return_value = self.openai
+            azure_patcher.start().return_value = self.openai
 
             # Do some basic always-on mocking
-            self._list_route = respx.get(f"{url}/models", params=params)
-            self._chat_route = respx.post(
-                url__regex=f"{url}{chat_prefix}/chat/completions", params=params
-            )
             self.mock_openai_model_list()
             self.mock_openai_response({})
 
@@ -127,50 +121,44 @@ class MockModel:
             response["output"] = {"message": {"content": []}}
         self._boto.converse.return_value = response
 
-    def mock_openai_model_list(
-        self, models: list[str] | None = None, status_code: int = 200
-    ) -> None:
+    def mock_openai_model_list(self, models: list[str] | None = None, fail: bool = False) -> None:
         if models is None:
             model_aliases = {
                 "gpt-oss-120b": ["gpt-oss-120b", "openai.gpt-oss-120b-1:0", "openai/gpt-oss-120b"],
                 "gpt35": ["gpt35", "gpt-35-turbo-0125"],
+                "gpt4o": ["gpt4o", "gpt-4o"],
             }
             models = model_aliases.get(self.model_id, [])
 
-        data = [{"id": alias} for alias in models]
-        self._list_route.respond(status_code=status_code, json={"object": "list", "data": data})
+        data = [SimpleNamespace(id=alias) for alias in models]
+        self.openai.models.list.return_value = data
+
+        if fail:
+            error = openai.APIError("test failure", mock.MagicMock(), body=None)
+            self.openai.models.list.side_effect = error
 
     def mock_openai_response(
-        self, value: dict, finish_reason: str = "stop", status_code: int = 200
+        self, value: dict, finish_reason: str = "stop", fail: bool = False
     ) -> None:
-        # https://developers.openai.com/api/reference/chat-completions/overview
-        self._chat_route.respond(
-            status_code=status_code,
-            json={
-                "id": "test-completion",
-                "object": "chat.completion",
-                "created": 1741569952,
-                "model": self.model_id,
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": json.dumps(value),
-                        },
-                        "finish_reason": finish_reason,
-                    },
-                ],
-                "usage": {
-                    "prompt_tokens": 19,
-                    "completion_tokens": 10,
-                    "total_tokens": 29,
-                    "prompt_tokens_details": {
-                        "cached_tokens": 5,
-                    },
-                },
-            },
+        message = chat.ParsedChatCompletionMessage(role="assistant", content=json.dumps(value))
+        self.openai.chat.completions.parse.return_value = chat.ParsedChatCompletion(
+            id="test-completion",
+            choices=[chat.ParsedChoice(finish_reason=finish_reason, index=0, message=message)],
+            usage=completion_usage.CompletionUsage(
+                completion_tokens=10,
+                prompt_tokens=19,
+                total_tokens=29,
+                prompt_tokens_details=completion_usage.PromptTokensDetails(cached_tokens=5),
+            ),
+            created=1741569952,
+            model=self.model_id,
+            object="chat.completion",
+            system_fingerprint="test-fp",
         )
+
+        if fail:
+            error = openai.APIError("test failure", mock.MagicMock(), body=None)
+            self.openai.chat.completions.parse.side_effect = error
 
 
 def basic_workflow(tmp_path) -> pathlib.Path:

--- a/tests/studies/test_example_nlp.py
+++ b/tests/studies/test_example_nlp.py
@@ -4,7 +4,6 @@ import json
 
 import duckdb
 import pandas
-import respx
 
 from cumulus_library import cli
 from tests import nlp_utils, testbed_utils
@@ -101,7 +100,6 @@ def test_merging_two_sources(tmp_path):
     ]
 
 
-@respx.mock
 def test_full_build(tmp_path):
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
         json.dump({"resourceType": "DiagnosticReport", "id": "1"}, f)


### PR DESCRIPTION
This supports resuming, by dropping a file in the PHI dir cache with in-progress IDs.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json