### PR TITLE
Fix the 'note scanning' progress bar to be accurate

### DIFF
--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -1,9 +1,11 @@
 import argparse
 import binascii
+import io
 import pathlib
 from collections.abc import Generator
 
 import cumulus_fhir_support as cfs
+import rich
 
 from cumulus_library import base_utils, databases
 
@@ -43,6 +45,7 @@ class NoteSource:
         if self._files is not None:
             return  # already scanned
 
+        rich.print("Scanning note dir...")
         self._files = self._flatten_note_dirs()
         self._total_size = sum(self._files.values())
 
@@ -59,11 +62,18 @@ class NoteSource:
         for one_dir in self._note_dirs or []:
             fspath = cfs.FsPath(one_dir)
 
-            # Actually scan for matching files
+            # Actually scan for matching files and grab their size
             paths = list(cfs.list_multiline_json_in_dir(fspath, note_types, recursive=True))
-            sizes = fspath.fs.sizes(paths)
             for idx, path in enumerate(paths):
-                infos[cfs.FsPath(path)] = sizes[idx]
+                path = cfs.FsPath(path)
+                with path.open() as f:
+                    # There doesn't seem to be a reliable way to get the uncompressed size of
+                    # gzip'd files, so we'll open and seek to the end. We want the uncompressed
+                    # size, because when iterating through it, cfs will give us the byte_offset
+                    # of the uncompressed stream. This can take time for big files, but accurate
+                    # progress bars are super helpful feedback.
+                    size = f.seek(0, io.SEEK_END)
+                infos[path] = size
 
         return infos
 


### PR DESCRIPTION
This does make it slower though.
I've filed https://github.com/smart-on-fhir/cumulus-library/issues/551 to talk about possible improvements.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json