### PR TITLE
Fix NLP parquet table schemas

### DIFF
--- a/cumulus_library/actions/importer.py
+++ b/cumulus_library/actions/importer.py
@@ -2,7 +2,7 @@ import pathlib
 import tempfile
 import zipfile
 
-import pandas
+import pyarrow.parquet
 
 from cumulus_library import base_utils, errors, study_manifest
 from cumulus_library.actions import cleaner
@@ -12,11 +12,8 @@ from cumulus_library.template_sql import base_templates
 def _create_table_from_parquet(archive, file, study_name, config):
     try:
         parquet_path = pathlib.Path(archive.extract(file), path=tempfile.TemporaryFile())
-        # While convenient to access, this exposes us to panda's type system,
-        # which is messy - this could be optionally be replaced by pyarrow if it
-        # becomes problematic.
-        table_types = pandas.read_parquet(parquet_path).dtypes
-        remote_types = config.db.col_parquet_types_from_pandas(table_types.values)
+        table_types = pyarrow.parquet.read_schema(parquet_path)
+        remote_types = config.db.col_parquet_types_from_pyarrow(table_types)
         s3_path = config.db.upload_file(
             file=parquet_path,
             study=study_name,
@@ -29,7 +26,7 @@ def _create_table_from_parquet(archive, file, study_name, config):
             table_name=parquet_path.stem.replace(".", "_"),
             local_location=f"{parquet_path.parent}",
             remote_location=s3_path,
-            table_cols=list(table_types.index),
+            table_cols=table_types.names,
             remote_table_cols_types=remote_types,
         )
         config.db.cursor().execute(query)

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -3,17 +3,14 @@
 import json
 import pathlib
 import sys
-import tempfile
 
 import cumulus_fhir_support as cfs
 import jambo
 import msgspec
-import pandas
-import pyarrow
 import rich
 
 import cumulus_library
-from cumulus_library import databases, note_utils
+from cumulus_library import note_utils
 from cumulus_library.builders.nlp import driver, workflow
 from cumulus_library.template_sql import base_templates
 
@@ -188,27 +185,6 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         # or a materialized table.
         return study_config.db.db_type == "athena"
 
-    def _pyarrow_schema_to_parquet(
-        self, schema: pyarrow.Schema, db: databases.DatabaseBackend
-    ) -> list:
-        """Turns a pyarrow schema into a list of parquet types."""
-        # SQL templates expect a list of parquet types. But the NLP code operates on Pyarrow
-        # schemas for the most part (with a smattering of pydantic).
-        #
-        # The easiest way to convert these is through pandas, because the DatabaseBackend class has
-        # a conversion method for that. and the easiest way through pandas is reading a parquet from
-        # disk.
-        #
-        # So we write an empty parquet to disk, have pandas read it, then have the database convert
-        # the pandas dtype to parquet types. Simple...
-
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            table = pyarrow.Table.from_pylist([], schema=schema)
-            pyarrow.parquet.write_table(table, tmpfile.name)
-            dtypes = pandas.read_parquet(tmpfile.name).dtypes
-
-        return db.col_parquet_types_from_pandas(dtypes.values)
-
     def prepare_queries(
         self,
         *args,
@@ -223,7 +199,7 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
             location = str(
                 driver.output_path_for_task(self._nlp_config.target, table_slug, task, config.db)
             )
-            remote_types = self._pyarrow_schema_to_parquet(table_schema, config.db)
+            remote_types = config.db.col_parquet_types_from_pyarrow(table_schema)
             self.queries.append(
                 base_templates.get_ctas_from_parquet_query(
                     schema_name=config.schema,

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -12,8 +12,8 @@ from concurrent import futures
 import awswrangler
 import boto3
 import botocore
-import numpy
 import pandas
+import pyarrow
 import pyathena
 from pyathena.async_cursor import AsyncCursor as AthenaAsyncCursor
 from pyathena.common import BaseCursor as AthenaCursor
@@ -92,29 +92,46 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
     def operational_errors(self) -> tuple[type[Exception], ...]:
         return (pyathena.OperationalError,)
 
-    def col_parquet_types_from_pandas(self, field_types: list) -> list:
-        output = []
-        for field in field_types:
-            match field:
-                case numpy.dtypes.ObjectDType():
-                    output.append("STRING")
-                case (
-                    pandas.core.arrays.integer.Int64Dtype()
-                    | numpy.dtypes.Int64DType()
-                    | numpy.dtypes.Int32DType()
-                ):
-                    output.append("INT")
-                case numpy.dtypes.Float64DType():
-                    output.append("DOUBLE")
-                case numpy.dtypes.BoolDType():
-                    output.append("BOOLEAN")
-                case numpy.dtypes.DateTime64DType():
-                    output.append("TIMESTAMP")
-                case _:
-                    raise errors.CumulusLibraryError(
-                        f"Unsupported pandas type {type(field)} found."
-                    )
-        return output
+    def col_parquet_types_from_pyarrow(self, schema: pyarrow.Schema) -> list[str]:
+        return self._pyarrow_schema_to_athena_cols(schema)
+
+    def _pyarrow_schema_to_athena_cols(
+        self, schema: pyarrow.DataType, is_dict: bool = False
+    ) -> list[str]:
+        cols = []
+
+        is_schema = isinstance(schema, pyarrow.Schema)
+        field_count = len(schema.names) if is_schema else schema.num_fields
+        for i in range(field_count):
+            field = schema.field(i)
+            athena_type = ""
+            if pyarrow.types.is_string(field.type):
+                athena_type = "STRING"
+            elif pyarrow.types.is_integer(field.type):
+                athena_type = "INT"
+            elif pyarrow.types.is_floating(field.type):
+                athena_type = "DOUBLE"
+            elif pyarrow.types.is_boolean(field.type):
+                athena_type = "BOOLEAN"
+            elif pyarrow.types.is_timestamp(field.type):
+                athena_type = "TIMESTAMP"
+            elif pyarrow.types.is_list(field.type) or pyarrow.types.is_fixed_size_list(field.type):
+                inner_cols = self._pyarrow_schema_to_athena_cols(field.type)
+                athena_type = "ARRAY<" + ", ".join(inner_cols) + ">"
+            elif pyarrow.types.is_struct(field.type):
+                inner_cols = self._pyarrow_schema_to_athena_cols(field.type, is_dict=True)
+                athena_type = "STRUCT<" + ", ".join(inner_cols) + ">"
+            else:
+                raise errors.CumulusLibraryError(
+                    f"Unsupported pyarrow type {type(field.type)} found."
+                )
+
+            if is_dict:
+                cols.append(f"{field.name}: {athena_type}")
+            else:
+                cols.append(athena_type)
+
+        return cols
 
     def _get_result_config(self) -> dict:
         workgroup = self.connection._client.get_work_group(WorkGroup=self.work_group)

--- a/cumulus_library/databases/base.py
+++ b/cumulus_library/databases/base.py
@@ -15,6 +15,7 @@ import pathlib
 from typing import Any, Protocol
 
 import pandas
+import pyarrow
 from rich import progress
 
 
@@ -172,33 +173,15 @@ class DatabaseBackend(abc.ABC):
         """
         return ()  # pragma: no cover
 
-    def col_parquet_types_from_pandas(self, field_types: list) -> list:
+    def col_parquet_types_from_pyarrow(self, schema: pyarrow.Schema) -> list[str]:
         """Returns appropriate types for creating tables based from parquet.
 
         By default, returns an empty list (which assumes that the DB infers directly
         from parquet data types). Only override if your DB uses an explicit SerDe
         format, or otherwise needs a modified typing to inject directly into a query."""
 
-        # The following example shows the types we're expecting to catch with this
-        # approach and the rough type to cast them to.
-        # TODO: consider handling complex types.
-        # output = []
-        # for field in field_types:
-        #     match field:
-        #         case numpy.dtypes.ObjectDType():
-        #             output.append('string')
-        #         case pandas.core.arrays.integer.Int64Dtype():
-        #             output.append('int')
-        #         case numpy.dtypes.Float64DType():
-        #             output.append('float')
-        #         case numpy.dtypes.BoolDType():
-        #             output.append('bool')
-        #         case numpy.dtypes.DateTime64DType():
-        #             output.append('date')
-        #         case _:
-        #             raise errors.CumulusLibraryError(
-        #                 f"Unsupported type {type(field)} found."
-        #             )
+        # See AthenaBackend for an example of what implementing this would look like.
+
         return []
 
     def upload_file(

--- a/cumulus_library/studies/example_nlp/calculate_ranges.sql
+++ b/cumulus_library/studies/example_nlp/calculate_ranges.sql
@@ -4,7 +4,10 @@ SELECT
     src.subject_ref,
     CASE
         -- Based on MeSH age groups: https://www.ncbi.nlm.nih.gov/mesh/68009273
-        WHEN src.result.age < 0 OR src.result.age > 120 THEN 'unknown'
+        WHEN
+            src.result.age IS NULL
+            OR src.result.age < 0
+            OR src.result.age > 120 THEN 'unknown'
         WHEN src.result.age < 2 THEN 'infant (0-1)'
         WHEN src.result.age < 13 THEN 'child (2-12)'
         WHEN src.result.age < 19 THEN 'adolescent (13-18)'

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -99,11 +99,14 @@ def test_empty_note_dir(tmp_path):
 @pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env()
 def test_table_filter_but_no_salt(tmp_path, note_source):
-    db = databases.AthenaDatabaseBackend(
-        region="test",
-        work_group="test",
-        profile="test",
-        schema_name="testdb",
+    db, _schema = databases.create_db_backend(
+        {
+            "db_type": "athena",
+            "region": "test",
+            "work_group": "test",
+            "profile": "test",
+            "schema_name": "testdb",
+        }
     )
     db.connection = mock.MagicMock()
     study_config = cumulus_library.StudyConfig(db=db, schema="main")
@@ -797,11 +800,14 @@ def test_bedrock_no_response(mock_client, tmp_path, mock_db_config, note_source)
 @mock.patch("botocore.client")
 @mock.patch("openai.OpenAI")
 def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_source):
-    db = databases.AthenaDatabaseBackend(
-        region="test",
-        work_group="test",
-        profile="test",
-        schema_name="testdb",
+    db, _schema = databases.create_db_backend(
+        {
+            "db_type": "athena",
+            "region": "test",
+            "work_group": "test",
+            "profile": "test",
+            "schema_name": "testdb",
+        }
     )
     db.connection = mock.MagicMock()
     bucket_info = {
@@ -841,11 +847,13 @@ def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_so
 
     # And confirm the query looks right
     assert builder.queries == [
-        'CREATE TABLE IF NOT EXISTS "main"."test__task" AS SELECT "note_ref", '
-        '"encounter_ref", "subject_ref", "generated_on", "task_version", "model", '
-        '"system_fingerprint", "result"\n'
-        "FROM read_parquet('memory://s3://testbucket/athena/cumulus_user_uploads/"
-        "testdb/test/task_v0/*.parquet')"
+        "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`test__task` ( note_ref STRING, "
+        "encounter_ref STRING, subject_ref STRING, generated_on STRING, task_version INT, "
+        "model STRING, system_fingerprint STRING, result STRUCT<ignored: STRING>\n)\n"
+        "STORED AS PARQUET\n"
+        "LOCATION 'memory://s3://testbucket/athena/cumulus_user_uploads/"
+        "testdb/test/task_v0'\n"
+        'tblproperties ("parquet.compression"="SNAPPY");'
     ]
 
 

--- a/tests/databases/test_databases.py
+++ b/tests/databases/test_databases.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import duckdb
 import pandas
+import pyarrow
 import pyathena
 import pytest
 
@@ -28,47 +29,62 @@ DUCKDB_KWARGS = {
 
 
 @pytest.mark.parametrize(
-    "db,data,expected,raises",
+    "db,schema,expected,raises",
     [
         (
             databases.AthenaDatabaseBackend(**ATHENA_KWARGS),
-            pandas.DataFrame(
-                {
-                    "str": ["str"],
-                    "int": [123],
-                    "float": [1.23],
-                    "bool": [True],
-                    "datetime": [datetime.datetime.now()],
-                }
+            pyarrow.schema(
+                [
+                    pyarrow.field("str", pyarrow.string()),
+                    pyarrow.field("int", pyarrow.int32()),
+                    pyarrow.field("float", pyarrow.float32()),
+                    pyarrow.field("bool", pyarrow.bool_()),
+                    pyarrow.field("datetime", pyarrow.timestamp("s")),
+                    pyarrow.field("list", pyarrow.list_(pyarrow.float32())),
+                    pyarrow.field("fixed_list", pyarrow.list_(pyarrow.int8(), 2)),
+                    pyarrow.field("struct", pyarrow.struct([("str", pyarrow.string())])),
+                ]
             ),
-            ["STRING", "INT", "DOUBLE", "BOOLEAN", "TIMESTAMP"],
+            [
+                "STRING",
+                "INT",
+                "DOUBLE",
+                "BOOLEAN",
+                "TIMESTAMP",
+                "ARRAY<DOUBLE>",
+                "ARRAY<INT>",
+                "STRUCT<str: STRING>",
+            ],
             does_not_raise(),
         ),
         (
             databases.DuckDatabaseBackend(**DUCKDB_KWARGS),
-            pandas.DataFrame(
-                {
-                    "str": ["str"],
-                    "int": [123],
-                    "float": [1.23],
-                    "bool": [True],
-                    "datetime": [datetime.datetime.now()],
-                }
+            pyarrow.schema(
+                [
+                    pyarrow.field("str", pyarrow.string()),
+                    pyarrow.field("int", pyarrow.int32()),
+                    pyarrow.field("float", pyarrow.float32()),
+                    pyarrow.field("bool", pyarrow.bool_()),
+                    pyarrow.field("datetime", pyarrow.timestamp("s")),
+                    pyarrow.field("list", pyarrow.list_(pyarrow.float32())),
+                    pyarrow.field("fixed_list", pyarrow.list_(pyarrow.int8(), 2)),
+                    pyarrow.field("struct", pyarrow.struct([("str", pyarrow.string())])),
+                ]
             ),
             [],
             does_not_raise(),
         ),
         (
             databases.AthenaDatabaseBackend(**ATHENA_KWARGS),
-            pandas.DataFrame({"cat": pandas.Series(["a"], dtype="category")}),
-            ["STRING", "INT", "DOUBLE", "BOOLEAN", "TIMESTAMP"],
+            pyarrow.schema([pyarrow.field("cat", pyarrow.duration("s"))]),
+            [],
             pytest.raises(errors.CumulusLibraryError),
         ),
     ],
 )
-def test_col_types_from_pandas(db, data, expected, raises):
+def test_col_types_from_pyarrow(db, schema, expected, raises):
     with raises:
-        vals = db.col_parquet_types_from_pandas(data.dtypes)
+        vals = db.col_parquet_types_from_pyarrow(schema)
         assert set(expected) == set(vals)
 
 


### PR DESCRIPTION
Now databases can handle nested schemas and lists.


### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json