### PR TITLE
Only allow approved studies to run NLP workflows

### DIFF
--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import datetime
+import json
 import pathlib
 import shutil
 import zipfile
@@ -257,3 +258,18 @@ def pandas_types_from_hive_types(field_types: list[str]):
                     f"Field type {field} is not a supported hive data type"
                 )
     return new_types
+
+
+def get_study_allowlist() -> dict[str, str]:
+    """
+    Returns the set of studies that we know about and trust.
+
+    Trust in the sense of allowing to run arbitrary Python code by importing the study.
+    And in the sense that we will let the study run NLP.
+
+    Returns a dict of {study_prefix: module_name} (note: module_name might be None)
+    """
+    module_path = pathlib.Path(__file__).resolve().parents[0]
+    allowlist_path = module_path / "module_allowlist.json"
+    with open(allowlist_path, encoding="utf-8") as f:
+        return json.load(f)["allowlist"]

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -10,7 +10,7 @@ import msgspec
 import rich
 
 import cumulus_library
-from cumulus_library import note_utils
+from cumulus_library import base_utils, note_utils
 from cumulus_library.builders.nlp import driver, workflow
 from cumulus_library.template_sql import base_templates
 
@@ -148,11 +148,25 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
             if task.select_by_table
         }
 
-        if select_by_tables and not self._nlp_config.salt and not config.db.can_hold_original_ids():
-            raise RuntimeError(
-                "Cannot calculate anonymized resource IDs without a PHI dir defined. "
-                "Pass --etl-phi-dir and try again."
-            )
+        # Add some extra checks if we are writing to a database like Athena that does not hold PHI
+        if not config.db.can_hold_original_ids():
+            # Only let approved studies run NLP, just because NLP can easily allow PHI through,
+            # if you're careless with your prompts. Like having NLP quote directly from the note
+            # into a field that isn't named "spans" (we automatically convert "spans" at least).
+            study_allowlist = base_utils.get_study_allowlist()
+            if self._nlp_config.target not in study_allowlist:
+                raise RuntimeError(
+                    f"The '{self._nlp_config.target}' study is not authorized to run NLP against "
+                    "this database. Consider using a local duckdb database instead, or contact "
+                    "the Cumulus Library project to allow this study to use unrestricted NLP."
+                )
+
+            # In order to compare anonymized IDs, we need the salt.
+            if select_by_tables and not self._nlp_config.salt:
+                raise RuntimeError(
+                    "Cannot calculate anonymized resource IDs without a PHI dir defined. "
+                    "Pass --etl-phi-dir and try again."
+                )
 
         table_refs = {table: note_utils.get_table_refs(cursor, table) for table in select_by_tables}
         note_filters = [

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -3,7 +3,6 @@
 
 import copy
 import importlib.util
-import json
 import os
 import pathlib
 import sys
@@ -264,11 +263,8 @@ def get_study_dict(alt_dir_paths: list) -> dict[str, pathlib.Path] | None:
     paths = [pathlib.Path(cli_path, "studies")]
 
     # then, we'll get any installed public studies
-    with open(
-        pathlib.Path(cli_path, "./module_allowlist.json"), encoding="utf-8"
-    ) as study_allowlist_json:
-        study_allowlist = json.load(study_allowlist_json)["allowlist"]
-    for module_name in study_allowlist:
+    study_allowlist = base_utils.get_study_allowlist()
+    for module_name in filter(None, study_allowlist.values()):
         if spec := importlib.util.find_spec(module_name):
             paths += [pathlib.Path(x) for x in spec.submodule_search_locations]
 

--- a/cumulus_library/module_allowlist.json
+++ b/cumulus_library/module_allowlist.json
@@ -1,17 +1,18 @@
 {
-    "desc" : 
-        "this dict maps pip installable studies to expected paths inside site-packages",
-    "allowlist" : [
-        "cumulus_library_catalog",
-        "cumulus_library_covid",
-        "cumulus_library_data_metrics",
-        "cumulus_library_hypertension",
-        "cumulus_library_kidney_transplant",
-        "cumulus_library_loinc",
-        "cumulus_library_opioid",
-        "cumulus_library_rxnorm",
-        "cumulus_library_suicidality_los",
-        "cumulus_library_umls",
-        "cumulus_library_glioma"
-    ]
+    "desc":
+        "this dict lists which modules are allowed to be Python-imported (and their study_prefix)",
+    "allowlist": {
+        "catalog": "cumulus_library_catalog",
+        "covid_symptom": "cumulus_library_covid",
+        "data_metrics": "cumulus_library_data_metrics",
+        "example_nlp": null,
+        "glioma": "cumulus_library_glioma",
+        "htn": "cumulus_library_hypertension",
+        "irae": "cumulus_library_kidney_transplant",
+        "loinc": "cumulus_library_loinc",
+        "opioid": "cumulus_library_opioid",
+        "rxnorm": "cumulus_library_rxnorm",
+        "suicide_los": "cumulus_library_suicidality_los",
+        "umls": "cumulus_library_umls"
+    }
 }

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -98,7 +98,8 @@ def test_empty_note_dir(tmp_path):
 
 @pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env()
-def test_table_filter_but_no_salt(tmp_path, note_source):
+@mock.patch("openai.OpenAI")
+def test_table_filter_but_no_salt(mock_client, tmp_path, note_source):
     db, _schema = databases.create_db_backend(
         {
             "db_type": "athena",
@@ -123,7 +124,10 @@ def test_table_filter_but_no_salt(tmp_path, note_source):
         },
         "nlp.workflow",
     )
-    builder = nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
+    model = nlp_utils.MockModel(mock_client, make_codebook=False)
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
     err_msg = "Cannot calculate anonymized resource IDs without a PHI dir defined"
     with pytest.raises(RuntimeError, match=err_msg):
         builder.execute_queries(study_config, None)
@@ -399,7 +403,7 @@ def test_span_correction(mock_client, tmp_path, mock_db_config):
     with contextlib.redirect_stdout(console_output):
         builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "test__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__hello_world")
     assert rows[0]["result"] == {"parent_list": [{"parent_dict": {"spans": [[0, 5], [7, 21]]}}]}
 
     failure_msg = "Could not match span received from NLP server for DiagnosticReport/dxr: forth"
@@ -471,7 +475,7 @@ def test_various_value_types(mock_client, tmp_path, mock_db_config, note_source)
     )
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "test__task")
+    rows = read_rows(mock_db_config, "example_nlp__task")
     assert rows[0]["result"] == results
 
 
@@ -730,7 +734,7 @@ def test_bedrock_skips_wrapper_in_response(mock_client, tmp_path, mock_db_config
     )
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "test__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__hello_world")
     assert rows[0]["result"] == {"hello": "world"}
 
 
@@ -772,7 +776,7 @@ Summary.
 
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "test__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__hello_world")
     assert rows[0]["result"] == {"hello": 0.5}
 
 
@@ -832,7 +836,7 @@ def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_so
     assert builder.stats.got_response[0] == 1
 
     # Confirm we wrote the parquet file out correctly
-    path = "s3://testbucket/athena/cumulus_user_uploads/testdb/test/task_v0/nlp.0.parquet"
+    path = "s3://testbucket/athena/cumulus_user_uploads/testdb/example_nlp/task_v0/nlp.0.parquet"
     with mem_fs.open(path, "rb") as f:
         df = pandas.read_parquet(f)
         rows = json.loads(df.to_json(orient="records"))
@@ -841,18 +845,18 @@ def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_so
     assert rows[0]["note_ref"] == "DiagnosticReport/hello"
 
     # And the id file
-    id_path = "s3://testbucket/athena/cumulus_user_uploads/testdb/test/task_v0.ids"
+    id_path = "s3://testbucket/athena/cumulus_user_uploads/testdb/example_nlp/task_v0.ids"
     with mem_fs.open(id_path, "r") as f:
         assert f.read() == "DiagnosticReport/hello\n"
 
     # And confirm the query looks right
     assert builder.queries == [
-        "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`test__task` ( note_ref STRING, "
+        "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`example_nlp__task` ( note_ref STRING, "
         "encounter_ref STRING, subject_ref STRING, generated_on STRING, task_version INT, "
         "model STRING, system_fingerprint STRING, result STRUCT<ignored: STRING>\n)\n"
         "STORED AS PARQUET\n"
         "LOCATION 'memory://s3://testbucket/athena/cumulus_user_uploads/"
-        "testdb/test/task_v0'\n"
+        "testdb/example_nlp/task_v0'\n"
         'tblproperties ("parquet.compression"="SNAPPY");'
     ]
 
@@ -932,7 +936,7 @@ def test_azure_batching_happy_path(mock_client, tmp_path, mock_db_config, note_s
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
-    rows = read_rows(mock_db_config, "test__task")
+    rows = read_rows(mock_db_config, "example_nlp__task")
     assert rows[0]["result"] == {"ignored": "answer"}
 
     assert model.openai.batches.create.call_args_list[0][1] == {
@@ -952,7 +956,7 @@ def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_sourc
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(mock_client, provider="azure", model_id="gpt4o")
 
-    path_dir = f"{model.phi}/nlp-cache/test__task_v0_gpt4o"
+    path_dir = f"{model.phi}/nlp-cache/example_nlp__task_v0_gpt4o"
     os.makedirs(path_dir)
     with open(f"{path_dir}/metadata.json", "w", encoding="utf8") as f:
         json.dump({"batches-azure": ["b1", "b2"]}, f)
@@ -973,7 +977,7 @@ def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_sourc
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
-    rows = read_rows(mock_db_config, "test__task")
+    rows = read_rows(mock_db_config, "example_nlp__task")
     assert rows[0]["result"] == {"ignored": "answer"}
 
 
@@ -1113,7 +1117,7 @@ def test_azure_splitting_batch(mock_client, tmp_path, mock_db_config):
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 4
 
-    rows = read_rows(mock_db_config, "test__task")
+    rows = read_rows(mock_db_config, "example_nlp__task")
     assert [row["result"] for row in rows] == [
         {"ignored": "w1"},
         {"ignored": "w2"},
@@ -1176,3 +1180,32 @@ def test_aws_profile_env_is_set(mock_register, tmp_path):
         cli.main(cli_args=build_args)
 
     assert os.environ.get("AWS_PROFILE") == "test-profile"
+
+
+@pytest.mark.xdist_group(name="nlp_builder")
+@nlp_utils.mock_env()
+@mock.patch("openai.OpenAI")
+def test_invalid_study_name(mock_client, tmp_path, note_source):
+    db, _schema = databases.create_db_backend(
+        {
+            "db_type": "athena",
+            "region": "test",
+            "work_group": "test",
+            "profile": "test",
+            "schema_name": "testdb",
+        }
+    )
+    db.connection = mock.MagicMock()
+    study_config = cumulus_library.StudyConfig(db=db, schema="main")
+
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(mock_client)
+    nlp_config = model.nlp_config()
+    nlp_config.target = "blarg"
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path,
+        notes=note_source,
+        nlp_config=nlp_config,
+    )
+    with pytest.raises(RuntimeError, match="The 'blarg' study is not authorized to run NLP"):
+        builder.execute_queries(study_config, None)

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -103,7 +103,7 @@ class MockModel:
             "nlp_model": self.model_id,
             "nlp_provider": self.provider,
             "etl_phi_dir": self.phi,
-            "target": "test",
+            "target": "example_nlp",  # use the example_nlp name, so we pass the allowlisting
             "batch_nlp": batching,
             "clean_nlp": clean,
             "nlp_stats": stats,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,10 +126,10 @@ def test_cli_path_mapping(mock_load_json, monkeypatch, tmp_path, args, raises, e
         monkeypatch.syspath_prepend(f"{Path(__file__).resolve().parents[0]}/test_data/")
         mock_load_json.return_value = {
             "__desc__": "",
-            "allowlist": [
-                "study_python_valid",
-                "study_bad_manifest",
-            ],
+            "allowlist": {
+                "valid": "study_python_valid",
+                "bad": "study_bad_manifest",
+            },
         }
         args = duckdb_args(args, tmp_path)
         cli.main(cli_args=args)


### PR DESCRIPTION
This is something we talked about doing a while back. I think it still makes sense?

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json