### PR TITLE
Added support for data dictionaries

### DIFF
--- a/cumulus_library/studies/discovery/data_dictionary.json
+++ b/cumulus_library/studies/discovery/data_dictionary.json
@@ -1,0 +1,29 @@
+{
+    "fields": [
+        {
+            "name": "table_name",
+            "description": "FHIR resource",
+            "details": ""
+        },
+        {
+            "name": "column_name",
+            "description": "FHIR CodeableConcept",
+            "details": "This may be a deeply nested path, depending on the location of the element in the FHIR spec"
+        },
+        {
+            "name": "code",
+            "description": "Coding value",
+            "details": ""
+        },
+        {
+            "name": "display",
+            "description": "Display Text",
+            "details": "When possible, consider using a known good source for this data, since it is not always consistent, depending on the EHR implementation"
+        },
+        {
+            "name": "system",
+            "description": "Coding System",
+            "details": ""
+        }
+    ]
+}

--- a/cumulus_library/studies/discovery/manifest.toml
+++ b/cumulus_library/studies/discovery/manifest.toml
@@ -1,4 +1,5 @@
 study_prefix = "discovery"
+data_dictionary="data_dictionary.json"
 
 [[stages.build_discovery]]
 label= "code detection"

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -438,9 +438,6 @@ class StudyManifest:
             return ""
         return self.get_study_prefix()
 
-    def get_data_dictionary(self) -> list[dict] | None:
-        return self._study_config.get("data_dictionary")
-
     def copy_manifest(self, path: pathlib.Path):
         """Writes a copy of the manifest to the provided path.
 

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -1,7 +1,9 @@
 """Class for loading study configuration data from manifest.toml files"""
 
 import copy
+import csv
 import dataclasses
+import json
 import pathlib
 import re
 import shutil
@@ -13,6 +15,17 @@ import msgspec
 
 from cumulus_library import enums, errors
 
+DASHBOARD_TYPES = [
+    "string",
+    "integer",
+    "float",
+    "boolean",
+    "day",
+    "week",
+    "month",
+    "year",
+]
+
 
 @dataclasses.dataclass(kw_only=True)
 class ManifestExport:
@@ -22,6 +35,18 @@ class ManifestExport:
 
 
 # These msgspec Structs define the expected formats for manifests & submanifests
+
+
+class DataDictionaryRow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    name: str
+    display: str | None = None
+    description: str | None = None
+    details: str | None = None
+    type: str | None = None
+
+
+class DataDictionary(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    fields: list[DataDictionaryRow] | None = None
 
 
 class ManifestExportTable(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
@@ -45,6 +70,7 @@ class ManifestAdvancedOptions(msgspec.Struct, forbid_unknown_fields=True, omit_d
 class ManifestConfig(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
     study_prefix: str | None = None
     description: str | None = None
+    data_dictionary: str | DataDictionary | None = None
     stages: dict[str, list[ManifestAction]] | None = None
     advanced_options: ManifestAdvancedOptions | None = None
 
@@ -156,6 +182,44 @@ class StudyManifest:
             action["label"] = action["description"]
         return action
 
+    def _load_data_dictionary(self):
+        if self._study_config.get("data_dictionary") is None:
+            return
+        dict_file = self._study_config["data_dictionary"]
+        try:
+            with open(self._study_path / dict_file) as file_buf:
+                if dict_file.endswith(".csv"):
+                    reader = csv.DictReader(file_buf)
+                    data_dict = {"fields": [row for row in reader]}
+                    # we'll round trip this through json to get it through msgspec validation
+                    data_dict = msgspec.json.encode(data_dict)
+                    data_dict = msgspec.json.decode(data_dict, type=DataDictionary)
+                elif dict_file.endswith(".json"):
+                    file = file_buf.read()
+                    data_dict = msgspec.json.decode(file, type=DataDictionary)
+                elif dict_file.endswith(".toml"):
+                    file = file_buf.read()
+                    data_dict = msgspec.toml.decode(file, type=DataDictionary)
+                else:
+                    raise errors.StudyManifestParsingError(
+                        f"{dict_file} is not a supported format. Expected formats: csv,json,toml"
+                    )
+        except msgspec.ValidationError as e:
+            if "name" in str(e):
+                raise errors.StudyManifestParsingError(
+                    f"Missing required field 'name' in {dict_file}."
+                )
+            raise errors.StudyManifestParsingError(
+                f"Found unexpected field '{str(e).split('`')[1]}' in {dict_file}."
+            )
+        self._study_config["data_dictionary"] = json.loads(msgspec.json.encode(data_dict.fields))
+        if "type" in self._study_config["data_dictionary"][0].keys():
+            for row in self._study_config["data_dictionary"]:
+                if row["type"] not in DASHBOARD_TYPES:
+                    raise errors.StudyManifestParsingError(
+                        f"Found unexpected type '{row['type']}'' for {row['name']} in {dict_file}"
+                    )
+
     ### toml parsing helper functions
     def _load_study_manifest(self, study_path: pathlib.Path, options: dict[str, str]) -> None:
         """Reads in a config object from a directory containing a manifest.toml
@@ -221,9 +285,10 @@ class StudyManifest:
             raise errors.StudyManifestParsingError(f"Invalid prefix in manifest at {study_path}")
         self._study_prefix = self._study_prefix.lower()
 
-        # Finally, let's see if we're using a sampling workflow
+        # Finally, let's see if we're using a sampling workflow or have a data dictionary
 
         self._has_stats = self._has_stats_workflows()
+        self._load_data_dictionary()
 
     def get_study_prefix(self) -> str | None:
         """Reads the name of a study prefix from the in-memory study config
@@ -372,6 +437,9 @@ class StudyManifest:
         if self.get_dedicated_schema():
             return ""
         return self.get_study_prefix()
+
+    def get_data_dictionary(self) -> list[dict] | None:
+        return self._study_config.get("data_dictionary")
 
     def copy_manifest(self, path: pathlib.Path):
         """Writes a copy of the manifest to the provided path.

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -205,7 +205,7 @@ class StudyManifest:
                         f"{dict_file} is not a supported format. Expected formats: csv,json,toml"
                     )
         except msgspec.ValidationError as e:
-            if "name" in str(e):
+            if "required field `name`" in str(e):
                 raise errors.StudyManifestParsingError(
                     f"Missing required field 'name' in {dict_file}."
                 )

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -1,9 +1,11 @@
 """tests for study parser against mocks in test_data"""
 
+import json
 import pathlib
 from contextlib import nullcontext as does_not_raise
 
 import pytest
+import tomli_w
 
 from cumulus_library import errors, study_manifest
 from tests import conftest
@@ -406,3 +408,83 @@ def test_export_list(stages, stage, expected, raises, tmp_path):
         else:
             export_list = manifest.get_export_table_list(stage)
         assert export_list == expected
+
+
+@pytest.mark.parametrize(
+    "data,file_type,expected,raises",
+    [
+        ("name,display\na,b", "csv", [{"display": "b", "name": "a"}], does_not_raise()),
+        (
+            {"fields": [{"name": "a", "display": "b"}]},
+            "json",
+            [{"display": "b", "name": "a"}],
+            does_not_raise(),
+        ),
+        (
+            {"fields": [{"name": "a", "display": "b"}]},
+            "toml",
+            [{"display": "b", "name": "a"}],
+            does_not_raise(),
+        ),
+        (
+            {
+                "fields": [
+                    {
+                        "name": "a",
+                        "display": "b",
+                        "description": "c",
+                        "details": "d",
+                        "type": "string",
+                    }
+                ]
+            },
+            "json",
+            [{"name": "a", "display": "b", "description": "c", "details": "d", "type": "string"}],
+            does_not_raise(),
+        ),
+        (
+            {"fields": [{"name": "a", "foo": "bar"}]},
+            "json",
+            None,
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+        (
+            {"fields": [{"name": "a", "display": "b"}]},
+            "docx",
+            None,
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+        (
+            {"fields": [{"description": "b"}]},
+            "json",
+            None,
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+        (
+            {"fields": [{"name": "a", "type": "EnterpriseBeanFactory"}]},
+            "json",
+            None,
+            pytest.raises(errors.StudyManifestParsingError),
+        ),
+    ],
+)
+def test_data_dictionary(tmp_path, data, file_type, expected, raises):
+    with raises:
+        with open(tmp_path / f"data.{file_type}", "w") as f:
+            match file_type:
+                case "csv":
+                    f.write(data)
+                case "json":
+                    f.write(json.dumps(data))
+                case "toml":
+                    f.write(tomli_w.dumps(data))
+        conftest.write_toml(
+            tmp_path,
+            {
+                "study_prefix": "test",
+                "data_dictionary": f"data.{file_type}",
+                "stages": {"stage_one": [{"type": "export:counts", "tables": ["test__name"]}]},
+            },
+        )
+        manifest = study_manifest.StudyManifest(tmp_path)
+        assert expected == manifest._study_config["data_dictionary"]


### PR DESCRIPTION
This adds a new data construct available to load from the manifest, a 'data dictionary'. This format is a list of metadata associated with a given column name. If an item in the dictionary has the same name as an item in one of the export tables,
downstream the aggregator will (eventually) make this available to the dashboard.

This addresses #529, and starts progress on https://github.com/smart-on-fhir/cumulus-aggregator/issues/210

### Checklist
- [ ] Consider if documentation in `docs/` needs to be updated <- this will be done after some other issues in the feature are in
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml` <- deferred as above
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json