### PR TITLE
nlp: allow subfolders in response_schema

### DIFF
--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -64,11 +64,6 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
             if not task.response_schema:
                 raise ValueError(f"A response schema must be provided for table '{table_slug}'")
 
-            # Convert task schema filenames to the JSON schema itself.
-            # Be strict here, just for safety's sake - we can ease up if needed later.
-            if "/" in task.response_schema:
-                raise ValueError("response_schema must be a simple filename, no path elements")
-
             # Load and parse the response JSON schema into a pydantic model, but check first to
             # ensure we don't already have an inline JSON definition (useful in tests).
             if task.response_schema.lstrip().startswith("{"):

--- a/docs/workflows/nlp.md
+++ b/docs/workflows/nlp.md
@@ -77,7 +77,7 @@ Pydantic Schema:
 # be used (i.e. the default is `"%CLINICAL-NOTE%"`).
 user_prompt = ""
 
-# `response_schema` points at a file adjacent to this workflow file. It contains a JSON schema
+# `response_schema` points at a file relative to this workflow file. It contains a JSON schema
 # for the expected response from the LLM. If the LLM's response cannot be parsed into this format,
 # it will be ignored. This schema also helps defines the resulting table schema.
 # Often, studies will use a bit of Python code to generate this file from some Pydantic models.

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -76,20 +76,6 @@ def test_task_without_schema(tmp_path, note_source):
 
 
 @pytest.mark.xdist_group(name="nlp_builder")
-def test_sketch_schema_path(tmp_path, note_source):
-    workflow_path = conftest.write_toml(
-        tmp_path,
-        {
-            "config_type": "nlp",
-            "tables": {"test": {"response_schema": "../../../passwd"}},
-        },
-        "nlp.workflow",
-    )
-    with pytest.raises(ValueError, match="response_schema must be a simple filename"):
-        nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
-
-
-@pytest.mark.xdist_group(name="nlp_builder")
 def test_empty_note_dir(tmp_path):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     with pytest.raises(SystemExit, match="there are no notes to work with"):


### PR DESCRIPTION
As discussed in person, subfolders are kinda nice. And let's not worry about hackers trying to get us to json-parse a file in /etc/ - not even sure what all good that would do them. I was being overly paranoid. (Also, we allow-list who can even run nlp)

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json