### PR TITLE
Reading workflows to populate export configs

### DIFF
--- a/cumulus_library/actions/exporter.py
+++ b/cumulus_library/actions/exporter.py
@@ -41,6 +41,7 @@ def export_study(
     """
     skipped_tables = []
     reset_counts_exports(manifest)
+    manifest.materialize_counts_builder_exports()
     if manifest.get_dedicated_schema():
         prefix = f"{manifest.get_dedicated_schema()}."
     else:
@@ -56,6 +57,7 @@ def export_study(
         table_list = manifest.get_export_table_list(config.stage)
     path = pathlib.Path(f"{data_path}/{manifest.get_study_prefix()}/")
     path.mkdir(parents=True, exist_ok=True)
+
     for table in track(
         table_list,
         description=f"Exporting {manifest.get_study_prefix()} data...",

--- a/cumulus_library/actions/importer.py
+++ b/cumulus_library/actions/importer.py
@@ -9,7 +9,9 @@ from cumulus_library.actions import cleaner
 from cumulus_library.template_sql import base_templates
 
 
-def _create_table_from_parquet(archive, file, study_name, config):
+def _create_table_from_parquet(
+    archive: zipfile.ZipFile, file: str, study_name: str, config: base_utils.StudyConfig
+):
     try:
         parquet_path = pathlib.Path(archive.extract(file), path=tempfile.TemporaryFile())
         table_types = pyarrow.parquet.read_schema(parquet_path)

--- a/cumulus_library/builders/counts_builder.py
+++ b/cumulus_library/builders/counts_builder.py
@@ -1,12 +1,11 @@
 """Class for generating counts tables from templates"""
 
 import pathlib
-import sys
 
-import msgspec
 import rich
 
 from cumulus_library import BaseTableBuilder, base_utils, errors, study_manifest
+from cumulus_library.builders import counts_utils
 from cumulus_library.builders.statistics_templates import counts_templates
 
 # Defined here for easy overriding by tests
@@ -14,42 +13,8 @@ DEFAULT_MIN_SUBJECT = 10
 
 
 # Counts can be driven by a workflow config. See docs/workflows/counts.md for more details
-# on syntax and expectations.
-
-
-class CountsWorkflowAnnotation(msgspec.Struct, forbid_unknown_fields=True):
-    field: str
-    join_table: str
-    join_field: str
-    columns: list[list[str]]
-    alt_target: str | None = None
-
-
-class CountsFilterColumn(msgspec.Struct, forbid_unknown_fields=True):
-    name: str
-    values: list[str]
-    include_nulls: bool
-
-
-class CountsWorkflowTable(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
-    source_table: str
-    table_cols: list
-
-    description: str | None = None
-    where_clauses: list[str] | None = None
-    min_subject: int | None = None
-    primary_id: str | None = None
-    secondary_table: str | None = None
-    secondary_cols: list[str] | None = None
-    secondary_id: str | None = None
-    alt_secondary_join_id: str | None = None
-    annotation: CountsWorkflowAnnotation | None = None
-    filter_cols: list[CountsFilterColumn] | None = None
-
-
-class CountsWorkflow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
-    config_type: str
-    tables: dict[str, CountsWorkflowTable]
+# on syntax and expectations. Loading is handled via the separate counts_utils modules to
+# prevent circular imports, since it is also used in the export action to look for tables.
 
 
 class CountsBuilder(BaseTableBuilder):
@@ -66,29 +31,7 @@ class CountsBuilder(BaseTableBuilder):
 
         self.study_prefix = manifest.get_study_prefix()
         if toml_config_path:
-            try:
-                with open(toml_config_path, "rb") as file:
-                    file_bytes = file.read()
-                    self._workflow_config = msgspec.to_builtins(
-                        msgspec.toml.decode(file_bytes, type=CountsWorkflow)
-                    )
-            except msgspec.ValidationError as e:
-                sys.exit(
-                    f"The counts workflow at {toml_config_path!s} contains an unexpected param: \n"
-                    f"{e}"
-                )
-
-            # for cases where we want to load a portion of a parseed dict into objects
-            for table_name, contents in self._workflow_config["tables"].items():
-                if annotation := contents.get("annotation"):
-                    self._workflow_config["tables"][table_name]["annotation"] = (
-                        counts_templates.CountAnnotation(**annotation)
-                    )
-                if filter_cols := contents.get("filter_cols"):
-                    parsed_filters = []
-                    for col in filter_cols:
-                        parsed_filters.append(counts_templates.FilterColumn(**col))
-                    self._workflow_config["tables"][table_name]["filter_cols"] = parsed_filters
+            self._workflow_config = counts_utils.load_toml_config(toml_config_path)
         else:
             self._workflow_config = None
 

--- a/cumulus_library/builders/counts_utils.py
+++ b/cumulus_library/builders/counts_utils.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+
+import msgspec
+
+from cumulus_library.builders.statistics_templates import counts_templates
+
+
+class CountsWorkflowAnnotation(msgspec.Struct, forbid_unknown_fields=True):
+    field: str
+    join_table: str
+    join_field: str
+    columns: list[list[str]]
+    alt_target: str | None = None
+
+
+class CountsFilterColumn(msgspec.Struct, forbid_unknown_fields=True):
+    name: str
+    values: list[str]
+    include_nulls: bool
+
+
+class CountsWorkflowTable(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    source_table: str
+    table_cols: list
+
+    description: str | None = None
+    where_clauses: list[str] | None = None
+    min_subject: int | None = None
+    primary_id: str | None = None
+    secondary_table: str | None = None
+    secondary_cols: list[str] | None = None
+    secondary_id: str | None = None
+    alt_secondary_join_id: str | None = None
+    annotation: CountsWorkflowAnnotation | None = None
+    filter_cols: list[CountsFilterColumn] | None = None
+
+
+class CountsWorkflow(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
+    config_type: str
+    tables: dict[str, CountsWorkflowTable]
+
+
+def load_toml_config(toml_config_path: pathlib.Path) -> dict:
+    try:
+        with open(toml_config_path, "rb") as file:
+            file_bytes = file.read()
+            workflow_config = msgspec.to_builtins(
+                msgspec.toml.decode(file_bytes, type=CountsWorkflow)
+            )
+    except msgspec.ValidationError as e:
+        sys.exit(f"The counts workflow at {toml_config_path!s} contains an unexpected param: \n{e}")
+
+    # for cases where we want to load a portion of a parseed dict into objects
+    for table_name, contents in workflow_config["tables"].items():
+        if annotation := contents.get("annotation"):
+            workflow_config["tables"][table_name]["annotation"] = counts_templates.CountAnnotation(
+                **annotation
+            )
+        if filter_cols := contents.get("filter_cols"):
+            parsed_filters = []
+            for col in filter_cols:
+                parsed_filters.append(counts_templates.FilterColumn(**col))
+            workflow_config["tables"][table_name]["filter_cols"] = parsed_filters
+    return workflow_config

--- a/cumulus_library/studies/core/manifest.toml
+++ b/cumulus_library/studies/core/manifest.toml
@@ -74,22 +74,7 @@ type = "build:parallel"
 
 [[stages.build_core]]
 tables = [
-    "core__count_allergyintolerance_month",
-    "core__count_condition_month",
-    "core__count_diagnosticreport_month",
-    "core__count_documentreference_month",
-    "core__count_encounter_month",
-    "core__count_encounter_all_types",
-    "core__count_encounter_all_types_month",
-    "core__count_encounter_service_month",
-    "core__count_encounter_priority_month",
-    "core__count_encounter_type_month",
-    "core__count_medicationrequest_month",
-    "core__count_observation_lab_month",
-    "core__count_patient",
-    "core__count_procedure_month",
-    "core__count_servicerequest_month",
-    "core__count_specimen_month",
+    "count_core.workflow"
 ]
 type = "export:counts"
 [[stages.build_core]]

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -369,7 +369,7 @@ class StudyManifest:
             found_configs = []
             for str_or_dict in action.get("tables", []):
                 if isinstance(str_or_dict, dict):
-                    continue
+                    continue  # pragma: no cover
                 if str_or_dict.endswith(".toml") or str_or_dict.endswith(".workflow"):
                     workflow = counts_utils.load_toml_config(self._study_path / str_or_dict)
 

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -14,6 +14,7 @@ import tomllib
 import msgspec
 
 from cumulus_library import enums, errors
+from cumulus_library.builders import counts_utils
 
 DASHBOARD_TYPES = [
     "string",
@@ -354,6 +355,31 @@ class StudyManifest:
         if continue_from and len(files) == 0:
             raise errors.StudyManifestParsingError(f"No files matching '{continue_from}' found")
         return files
+
+    def materialize_counts_builder_exports(self, stage_name: str = "all"):
+        """Replaces refs to counts builders in the exports with the tables they contain
+
+        Note that this modifies the manifest structure. It's assumed you will only need this
+        during export, when you'll be working with a copy of the manifest object."""
+        stage = self.get_stage(stage_name)
+        for action in stage:
+            if not action.get("type", "").startswith("export:"):
+                continue
+            new_tables = []
+            found_configs = []
+            for str_or_dict in action.get("tables", []):
+                if isinstance(str_or_dict, dict):
+                    continue
+                if str_or_dict.endswith(".toml") or str_or_dict.endswith(".workflow"):
+                    workflow = counts_utils.load_toml_config(self._study_path / str_or_dict)
+
+                    for table, data in workflow["tables"].items():
+                        new_tables.append({"name": table, "description": data.get("description")})
+                    found_configs.append(str_or_dict)
+            for config in found_configs:
+                action["tables"].remove(config)
+            for table in new_tables:
+                action["tables"].append(table)
 
     def get_export_table_list(self, stage_name: str = "all") -> list[ManifestExport] | None:
         """Reads the exportable tables from the manifest

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -369,7 +369,7 @@ class StudyManifest:
             found_configs = []
             for str_or_dict in action.get("tables", []):
                 if isinstance(str_or_dict, dict):
-                    continue  # pragma: no cover
+                    continue
                 if str_or_dict.endswith(".toml") or str_or_dict.endswith(".workflow"):
                     workflow = counts_utils.load_toml_config(self._study_path / str_or_dict)
 

--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -374,7 +374,12 @@ class StudyManifest:
                     workflow = counts_utils.load_toml_config(self._study_path / str_or_dict)
 
                     for table, data in workflow["tables"].items():
-                        new_tables.append({"name": table, "description": data.get("description")})
+                        new_tables.append(
+                            {
+                                "name": f"{self._study_prefix}__{table}",
+                                "description": data.get("description"),
+                            }
+                        )
                     found_configs.append(str_or_dict)
             for config in found_configs:
                 action["tables"].remove(config)

--- a/docs/workflows/counts.md
+++ b/docs/workflows/counts.md
@@ -39,7 +39,7 @@ if it's correctly formatted, but starting from the template can help you avoid p
 
 # config_type should be "counts" - we use this to distinguish from other
 # configurable workflows
-type="counts"
+config_type="counts"
 
 [tables.name] # the table in db will be called 'study_prefix__name', snaked cased for sql compatibility
 # The following keys must be defined in all cases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     # if you update the ruff version, also update .pre-commit-config.yaml
     "ruff < 0.15",
     "pre-commit",
-    "sqlfluff  >= 3",
+    "sqlfluff  >= 3, < 4.2",
 ]
 test = [
     "httpx",

--- a/tests/studies/core/manifest.toml
+++ b/tests/studies/core/manifest.toml
@@ -1,0 +1,150 @@
+study_prefix = "core"
+description = "This study aims to provide a flattened set of tables suitable for analysts\nfrom the tables created from FHIR ndjson by Cumulus ETL.\n\nMost studies should use these tables as the base for their work. For more info about the\ncore study, see https://docs.smarthealthit.org/cumulus/library/core-study-details.html\n"
+
+[[stages.build_core]]
+type = "build:parallel"
+label = "FHIR support tables"
+files = [
+    "version.sql",
+    "fhir_lookup_tables.sql",
+    "fhir_mapping_tables.sql",
+]
+
+[[stages.build_core]]
+type = "build:parallel"
+label = "FHIR nested resource flattening"
+files = [
+    "builder_allergyintolerance_prereq.py",
+    "builder_condition_prereq.py",
+    "builder_diagnosticreport_prereq.py",
+    "builder_documentreference_prereq.py",
+    "builder_encounter_prereq.py",
+    "builder_episodeofcare_prereq.py",
+    "builder_location_prereq.py",
+    "builder_medicationrequest_prereq.py",
+    "builder_observation_prereq.py",
+    "builder_organization_prereq.py",
+    "builder_patient_prereq.py",
+    "builder_practitioner_prereq.py",
+    "builder_practitionerrole_prereq.py",
+    "builder_procedure_prereq.py",
+    "builder_servicerequest_prereq.py",
+    "builder_specimen_prereq.py",
+]
+
+[[stages.build_core]]
+type = "build:serial"
+label = "Patient"
+files = [
+    "builder_patient.py",
+]
+
+[[stages.build_core]]
+type = "build:parallel"
+label = "Other FHIR resource tables"
+files = [
+    "builder_allergyintolerance.py",
+    "builder_condition.py",
+    "builder_diagnosticreport.py",
+    "builder_documentreference.py",
+    "builder_encounter.py",
+    "builder_episodeofcare.py",
+    "builder_location.py",
+    "builder_medicationrequest.py",
+    "builder_observation.py",
+    "builder_organization.py",
+    "builder_practitioner.py",
+    "builder_practitionerrole.py",
+    "builder_procedure.py",
+    "builder_servicerequest.py",
+    "builder_specimen.py",
+]
+
+[[stages.build_core]]
+type = "build:parallel"
+label = "Tables derived from FHIR resource tables"
+files = [
+    "observation_type.sql",
+    "meta_date.sql",
+]
+
+[[stages.build_core]]
+type = "build:parallel"
+label = "Summary counts of FHIR resources"
+files = [
+    "count_core.workflow",
+]
+
+[[stages.build_core]]
+type = "export:counts"
+
+[[stages.build_core.tables]]
+name = "count_allergyintolerance_month"
+description = "A general count of patient allergic reactions by month.\n\nThis table provides a summary snapshot of all allergic reactions for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by intolerance category,\nintolerance code, the reaction manifestation, and the month the reaction was observed in. \nIt is primarily intended as a validation tool to ensure that data has been successfully extracted \nfrom a source system via the FHIR data format.\n"
+
+[[stages.build_core.tables]]
+name = "count_condition_month"
+description = "A general count of observed conditions by month.\n\nThis table provides a summary snapshot of all conditions observed in the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by condition category,\ncondition code, and the month the condition was observed in. It is primarily intended as a\nvalidation tool to ensure that data has been successfully extracted from a source system via \nthe FHIR data format.\n"
+
+[[stages.build_core.tables]]
+name = "count_diagnosticreport_month"
+description = "A general count of patient's diagnostic reports by month.\n\nThis table provides a summary snapshot of all diagnostic reports for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by diagnostic category,\ndiagnostic code, and the month the diagnostic was performed in. It is primarily intended as a\nvalidation tool to ensure that data has been successfully extracted from a source system via \nthe FHIR data format.\n"
+
+[[stages.build_core.tables]]
+name = "count_documentreference_month"
+description = "A general count of documents related to a patient by month.\n\nThis table provides a summary snapshot of all documents for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by document type\nand the month the document was written in. It includes the related encounter class by joining\nwith the associated enounter resource, and filters all documents that are not in a current state,\nor in a final or amended document state. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_month"
+description = "A general count of encounters by month.\n\nThis table provides a summary snapshot of all encounters for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by encounter class,\nage at visit, gender, the CDC's Race & Ethnicity valueset, and the month of the encounter. \nIt filters out all encounters that are not in a finished state. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_all_types"
+description = "A general count of encounter states.\n\nThis table provides a summary snapshot of all encounters for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by encounter class,\nencounter type, service type, and encounter priority. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_all_types_month"
+description = "A general count of encounter states by month.\n\nThis table provides a summary snapshot of all encounter states for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by encounter class,\nencounter type, service type, encounter priority, and the month of the encounter. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_type_month"
+description = "A general count of encounter types by month.\n\nThis table provides a summary snapshot of all encounter types for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by encounter class,\nencounter type, and the month of the encounter. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_priority_month"
+description = "A general count of encounter priorities by month.\n\nThis table provides a summary snapshot of all encounter priorities for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by encounter class,\nencounter priority, and the month of the encounter. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_encounter_service_month"
+description = "A general count of encounter service types by month.\n\nThis table provides a summary snapshot of all the enounters for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by value,\nobservation code, and the date of the lab. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_medicationrequest_month"
+description = "A general count of patients with medication requests by month.\n\nThis table provides a summary snapshot of all the medication requests for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by medication name,\nrequest status, intent of medication, and the date of the request authoring. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_observation_lab_month"
+description = "A general count of patient's lab observations by month.\n\nThis table provides a summary snapshot of all the labs for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by value,\nobservation code, and the date of the lab. It also joins the encounter class from the associated\necnounter. It is primarily intended as a validation tool to ensure that data has been \nsuccessfully extracted from a source system via the FHIR data format.\n"
+
+[[stages.build_core.tables]]
+name = "count_patient"
+description = "A general patient population count.\n\nThis table provides a summary snapshot of the entire patient population that has been\nloaded into a database for use by the Cumulus ecosystem. It provides binning based on\ngender and the CDC's Race & Ethnicity valueset. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_procedure_month"
+description = "A count of patient's general procedures by month.\n\nThis table provides a summary snapshot of all the procedures for the entire patient population\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by category,\nprocedure code, and the date of procedure. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_servicerequest_month"
+description = "A count of patients with service requests by month.\n\nThis table provides a summary snapshot of the entire patient population with service requests\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by category,\nservice request code, and the author date. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core.tables]]
+name = "count_specimen_month"
+description = "A count of patients with specimens by month.\n\nThis table provides a summary snapshot of the entire patient population with specimens\nthat have been loaded into a database for use by the Cumulus ecosystem. It bins by category,\nservice request code, and the author date. It is primarily intended as a validation\ntool to ensure that data has been successfully extracted from a source system via the FHIR\ndata format.\n"
+
+[[stages.build_core]]
+type = "export:meta"
+tables = [
+    "core__meta_date",
+    "core__meta_version",
+]

--- a/tests/studies/core/test_core.py
+++ b/tests/studies/core/test_core.py
@@ -129,13 +129,19 @@ def test_core_count_missing_data(tmp_path):
 
 
 def test_core_counts_exported(mock_db_core):
-    with open(f"{conftest.LIBRARY_ROOT}/studies/core/manifest.toml", "rb") as f:
+    folder_path = pathlib.Path(__file__).parent
+    # Use for regenerating expected manifest if the counts workflow changes
+    # manifest = StudyManifest(f"{conftest.LIBRARY_ROOT}/studies/core/manifest.toml")
+    # manifest.materialize_counts_builder_exports()
+    # manifest.write_manifest(folder_path/"manifest.toml")
+    with open(folder_path / "manifest.toml", "rb") as f:
         manifest = tomllib.load(f)
     actions = manifest["stages"]["build_core"]
     expected_count_tables = []
     for action in actions:
         if action["type"] == "export:counts":
-            expected_count_tables = expected_count_tables + action["tables"]
+            for table in action["tables"]:
+                expected_count_tables.append(f"core__{table['name']}")
     count_tables = (
         mock_db_core.cursor()
         .execute(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -581,9 +581,10 @@ def test_cli_executes_queries(
             else:
                 manifest_dir = cli.get_study_dict([cli.get_abs_path(build_args[4])])[build_args[2]]
 
-            config = StudyManifest(f"{manifest_dir}/manifest.toml")
+            manifest = StudyManifest(f"{manifest_dir}/manifest.toml")
+            manifest.materialize_counts_builder_exports()
             csv_files = glob.glob(f"{tmp_path}/export/{build_args[2]}/*.csv")
-            export_list = [t.name for t in config.get_export_table_list()]
+            export_list = [t.name for t in manifest.get_export_table_list()]
             for export_table in export_list:
                 if export_table not in expected_missing:
                     assert any(export_table in x for x in csv_files)

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -497,7 +497,14 @@ def test_manifest_materialization(tmp_path):
             "study_prefix": "test",
             "stages": {
                 "stage_one": [
-                    {"type": "export:counts", "tables": ["test__name", "counts.workflow"]}
+                    {
+                        "type": "export:counts",
+                        "tables": [
+                            "test__name",
+                            {"name": "test__name2", "description": "desc"},
+                            "counts.workflow",
+                        ],
+                    }
                 ]
             },
         },
@@ -524,8 +531,9 @@ def test_manifest_materialization(tmp_path):
             "type": "export:counts",
             "tables": [
                 "test__name",
-                {"name": "count_1", "description": "A table"},
-                {"name": "count_2", "description": None},
+                {"name": "test__name2", "description": "desc"},
+                {"name": "test__count_1", "description": "A table"},
+                {"name": "test__count_2", "description": None},
             ],
         }
     ]

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -488,3 +488,44 @@ def test_data_dictionary(tmp_path, data, file_type, expected, raises):
         )
         manifest = study_manifest.StudyManifest(tmp_path)
         assert expected == manifest._study_config["data_dictionary"]
+
+
+def test_manifest_materialization(tmp_path):
+    conftest.write_toml(
+        tmp_path,
+        {
+            "study_prefix": "test",
+            "stages": {
+                "stage_one": [
+                    {"type": "export:counts", "tables": ["test__name", "counts.workflow"]}
+                ]
+            },
+        },
+    )
+    conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "counts",
+            "tables": {
+                "count_1": {
+                    "source_table": "patient",
+                    "description": "A table",
+                    "table_cols": ["foo"],
+                },
+                "count_2": {"source_table": "patient", "table_cols": ["foo"]},
+            },
+        },
+        "counts.workflow",
+    )
+    manifest = study_manifest.StudyManifest(tmp_path)
+    manifest.materialize_counts_builder_exports()
+    assert manifest._study_config["stages"]["all"] == [
+        {
+            "type": "export:counts",
+            "tables": [
+                "test__name",
+                {"name": "count_1", "description": "A table"},
+                {"name": "count_2", "description": None},
+            ],
+        }
+    ]


### PR DESCRIPTION
This allows a workflow to be used in exports, allowing a study author to keep all the relevant data in the workflow itself and not worry about the manifest for managing exports.

As a byproduct of this, it breaks out the parsing logic into its own module to prevent circular imports between the CountsBuilder and the StudyManifest.

Finishes #530 and resolves #533 by just updating the manifest itself with the data.

### Checklist
- [ ] Consider if documentation in `docs/` needs to be updated <- will do standalone after this
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml` <- will do standalone after docs
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json