### PR TITLE
Updated NLP exit message

### DIFF
--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -45,8 +45,9 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         self._notes = notes
         if not self._notes:
             sys.exit(
-                "NLP workflow requested, but there are no notes to work with. "
-                "Pass --note-dir to provide a folder with FHIR resources like DiagnosticReport "
+                "Finishing the build early because an NLP workflow was encountered.\n"
+                "If you want to run this study's NLP tasks, pass --note-dir to "
+                "provide a folder with FHIR resources like DiagnosticReport "
                 "or DocumentReference with inlined clinical notes."
             )
 

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -78,7 +78,7 @@ def test_task_without_schema(tmp_path, note_source):
 @pytest.mark.xdist_group(name="nlp_builder")
 def test_empty_note_dir(tmp_path):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
-    with pytest.raises(SystemExit, match="there are no notes to work with"):
+    with pytest.raises(SystemExit, match="early because an NLP workflow was encountered"):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_utils.NoteSource())
 
 


### PR DESCRIPTION
Wordsmithing this a bit to make it sound less like a failure case, since a common case may be 'run a study up to the NLP and then stop while we review the data before passing it off'.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json