### PR TITLE
Updated dependency versions

### DIFF
--- a/docs/documenting-data.md
+++ b/docs/documenting-data.md
@@ -47,11 +47,11 @@ You can specify a data dictionary in csv, json, or toml formats. Here's examples
 CSV:
 ```csv
 name,display,description,details,type
-table_name,"Table name","FHIR resource",,string
-column_name,"Column name","FHIR CodeableConcept","This may be a deeply nested path, depending on the location of the element in the FHIR spec",string
-code,"Code","Coding value",,string
-display,"Display","Display Text","When possible, consider using a known good source for this data, since it is not always consistent, depending on the EHR implementation",string
-system,"System","Coding System",,string
+table_name,"Table name","FHIR resource",,"string"
+column_name,"Column name","FHIR CodeableConcept","This may be a deeply nested path, depending on the location of the element in the FHIR spec","string"
+code,"Code","Coding value",,"string"
+display,"Display","Display text","When possible, consider using a known good source for this data, since it is not always consistent, depending on the EHR implementation","string"
+system,"System","Coding system",,"string"
 ```
 
 JSON:
@@ -60,31 +60,36 @@ JSON:
     "fields": [
         {
             "name": "table_name",
+            "display": "Table Name",
             "description": "FHIR resource",
             "details": "",
             "type": "string"
         },
         {
             "name": "column_name",
+            "display": "Column Name",
             "description": "FHIR CodeableConcept",
             "details": "This may be a deeply nested path, depending on the location of the element in the FHIR spec",
             "type": "string"
         },
         {
             "name": "code",
+            "display": "Code",
             "description": "Coding value",
             "details": "",
             "type": "string"
         },
         {
             "name": "display",
-            "description": "Display Text",
+            "display": "Display",
+            "description": "Display text",
             "details": "When possible, consider using a known good source for this data, since it is not always consistent, depending on the EHR implementation",
             "type": "string"
         },
         {
             "name": "system",
-            "description": "Coding System",
+            "display": "System",
+            "description": "Coding system",
             "details": "",
             "type": "string"
         }
@@ -96,31 +101,36 @@ TOML:
 ```toml
 [[fields]]
 name = "table_name"
+display = "Table Name"
 description = "FHIR resource"
 details = ""
 type = "string"
 
 [[fields]]
 name = "column_name"
+display = "Column Name"
 description = "FHIR CodeableConcept"
 details = "This may be a deeply nested path, depending on the location of the element in the FHIR spec"
 type = "string"
 
 [[fields]]
 name = "code"
+display = "Code"
 description = "Coding value"
 details = ""
 type = "string"
 
 [[fields]]
 name = "display"
-description = "Display Text"
+display = "Display"
+description = "Display text"
 details = "When possible, consider using a known good source for this data, since it is not always consistent, depending on the EHR implementation"
 type = "string"
 
 [[fields]]
 name = "system"
-description = "Coding System"
+display = "System"
+description = "Coding system"
 details = ""
 type = "string"
 ```
@@ -142,6 +152,7 @@ You can provide this in one of two ways:
 - As an entry in a
 [counts workflow](workflows/counts.md),
 as shown in this example from the core study, which is the preferred way of doing this:
+
 ```toml
 config_type = "counts"
 
@@ -164,6 +175,7 @@ table_cols = [
 ]
 ```
 - As an entry in the manifest, in the related export action. You can mix tables with and without descriptions.
+
 ```toml
 study_prefix = "my_study"
 [[stages.counts]]
@@ -180,6 +192,7 @@ type = "export:counts"
 In the manifest, you can also provide a description for the study as a whole. This is a good place to describe your research goals,
 and also to talk about any relevant inclusion criterion or information about your study cohort(s). Here's how we use this in the
 core study:
+
 ```toml
 study_prefix = "core"
 description = """This study aims to provide a flattened set of tables suitable for analysts

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -16,6 +16,7 @@ for use in Cumulus studies.
 
 - [Counts](workflows/counts.md)
 - [File Upload](workflows/file-upload.md)
+- [NLP](workflows/nlp.md)
 - [Propensity Score Matching](workflows/propensity-score-matching.md)
 - [Valueset Compilation](workflows/valueset.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "cumulus-library"
 requires-python = ">= 3.11"
 dependencies = [
     "awswrangler >= 3.11, < 4",
-    "boto3 >= 1.34.131",
-    "cumulus-fhir-support >= 1.12",
+    "boto3 >= 1.43",
+    "cumulus-fhir-support >= 1.12.2",
     "duckdb >= 1.4.1, <1.5.0",
     "jambo >= 0.1.7",
     "Jinja2 > 3",
@@ -14,7 +14,7 @@ dependencies = [
     "pandas <3, >=2.1.3",
     "platformdirs",
     "pyarrow >= 11.0",
-    "pyathena >= 2.23, < 3.15",
+    "pyathena <= 3.15, >3",
     "pytablewriter >= 1.2",
     "requests >= 2.28",
     "rich >= 13.2",
@@ -23,6 +23,9 @@ dependencies = [
     "sqlglot >= 27.29",
     "sqlparse >0.4",
     "tomli_w",
+    # Restrict fsspec/aiobotocore to prevent dependency churn
+    "fsspec[s3] >= 2026.4.0",
+    "aiobotocore >= 3.7"
 ]
 description = "Clinical study SQL generation for data derived from bulk FHIR"
 readme = "README.md"


### PR DESCRIPTION
This PR updates some of the depencencies around fsspec, getting them in a narrower band that should prevent churn when pip installing the library.

It also contains a few minor tweaks to the docs that were waiting around for a bugfix release.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json