### PR TITLE
Allow actions to be skipped

### DIFF
--- a/cumulus_library/study_manifest.py
+++ b/cumulus_library/study_manifest.py
@@ -61,6 +61,7 @@ class ManifestAction(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=T
     label: str | None = None
     files: list[str] | None = None
     tables: list[str | ManifestExportTable] | None = None
+    skip_by_default: bool | None = False
 
 
 class ManifestAdvancedOptions(msgspec.Struct, forbid_unknown_fields=True, omit_defaults=True):
@@ -270,7 +271,7 @@ class StudyManifest:
                     all_actions.append(action)
             config["stages"][stage] = actions
 
-        config["stages"]["all"] = all_actions
+        config["stages"]["all"] = [x for x in all_actions if not x.get("skip_by_default")]
 
         # We'll set these to class vars now so we can reuse the class getters
         # to finish setup and validation

--- a/docs/study-configuration.md
+++ b/docs/study-configuration.md
@@ -135,6 +135,15 @@ files = [
   'cohort_by_gender.py'
 ]
 type = "build:parallel"
+# If we want to explicitly exclude an action from being run by default, we can use the
+# skip_by_default argument - this will only get run if the stage name is specified. This
+# is often useful in NLP contexts
+[[stages.run_nlp]]
+label = 'Kick off an NLP job'
+files = [
+  'run_nlp.py',
+]
+skip_by_default=true
 
 # Most cumulus exports should be count tables, created as powerset cubes for deid binning
 # purposes. A table can be defined two ways:

--- a/tests/test_study_manifest.py
+++ b/tests/test_study_manifest.py
@@ -537,3 +537,33 @@ def test_manifest_materialization(tmp_path):
             ],
         }
     ]
+
+
+def test_skippable_actions(tmp_path):
+    conftest.write_toml(
+        tmp_path,
+        {
+            "study_prefix": "test",
+            "stages": {
+                "stage_1": [{"type": "build:serial", "files": ["foo"]}],
+                "stage_two": [{"type": "build:serial", "files": ["bar"]}],
+                "stage_three": [
+                    {"type": "build:serial", "files": ["baz"], "skip_by_default": True},
+                    {"type": "build:serial", "files": ["foobar"]},
+                ],
+            },
+        },
+    )
+
+    manifest = study_manifest.StudyManifest(tmp_path)
+    stage = manifest.get_stage("all")
+    assert stage == [
+        {"type": "build:serial", "files": ["foo"]},
+        {"type": "build:serial", "files": ["bar"]},
+        {"type": "build:serial", "files": ["foobar"]},
+    ]
+    stage = manifest.get_stage("stage_three")
+    assert stage == [
+        {"type": "build:serial", "files": ["baz"], "skip_by_default": True},
+        {"type": "build:serial", "files": ["foobar"]},
+    ]


### PR DESCRIPTION
This allows marking actions as skippable in the manifest - those actions will not be run unless the stage is explicitly called. Addresses #580 

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json