### PR TITLE
NLP chunking, test cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           echo -e "[test]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
       - name: Test with pytest
         run: |
-          python -m pytest -n auto --dist loadgroup --cov-report xml --cov=cumulus_library tests
+          python -m pytest -n auto --cov-report xml --cov=cumulus_library tests
       - name: Log missing coverage
         run: |
           coverage report -m --skip-covered

--- a/cumulus_library/builders/nlp/driver.py
+++ b/cumulus_library/builders/nlp/driver.py
@@ -283,7 +283,7 @@ class NlpNotePool:
 
         # Do we have enough to write out?
         pending_notes = sum(len(x) for x in self._notes.values())
-        if pending_notes >= self._config.note_limit:
+        if pending_notes >= self._config.chunksize:
             self._write_notes_to_output()
 
     def _resume_existing_batches(self) -> None:

--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -515,7 +515,7 @@ class Model:
 
     def __init__(self, config: note_utils.NlpConfig):
         self.prices = None
-        self.max_batch_count = config.note_limit
+        self.max_batch_count = config.chunksize
 
         if config.provider == "azure":
             if not self.AZURE_ID:

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -174,6 +174,12 @@ def add_nlp_config(parser: argparse.ArgumentParser) -> None:
         help="Use NLP batching mode (saves money, might take longer, not all models support it)",
     )
     group.add_argument(
+        "--nlp-chunksize",
+        type=int,
+        dest="chunksize",
+        help="Number of notes to process before writing results out to storage",
+    )
+    group.add_argument(
         "--clean-nlp",
         action="store_true",
         help="Previous NLP task results will be deleted before uploading the new ones",

--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -118,6 +118,7 @@ class NlpConfig:
         self.provider = args.get("nlp_provider", "local")
         self.azure_deployment = args.get("azure_deployment")
         self.use_batching = args.get("batch_nlp", False)
+        self.chunksize = args.get("chunk_size", 100000)
         self.clean = args.get("clean_nlp", False)
         self.phi_dir = args.get("etl_phi_dir")
         self.target = args.get("target")
@@ -129,8 +130,3 @@ class NlpConfig:
             codebook = codebook_path.read_json(default={})
             if id_salt := codebook.get("id_salt"):
                 self.salt = binascii.unhexlify(id_salt)
-
-        # Hard code a global memory limit for now. This limit is the number of notes we're willing
-        # to hold in memory at once. Once we hit this limit, we write out the current notes.
-        # This can be configurable in the future, as needed.
-        self.note_limit = 100_000

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -41,12 +41,17 @@ def note_source(tmp_path) -> note_utils.NoteSource:
     yield note_utils.NoteSource([tmp_path])
 
 
+@pytest.fixture(autouse=True)
+def mock_cache_dir(tmp_path):
+    with mock.patch("cumulus_library.base_utils.get_user_cache_dir", return_value=tmp_path):
+        yield
+
+
 def read_rows(db, table: str) -> list[dict]:
     df = db.db.connection.sql(f"SELECT * FROM {table} ORDER BY note_ref").df()
     return json.loads(df.to_json(orient="records"))
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 def test_unexpected_config_field(tmp_path, note_source):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -61,7 +66,6 @@ def test_unexpected_config_field(tmp_path, note_source):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 def test_task_without_schema(tmp_path, note_source):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -75,14 +79,12 @@ def test_task_without_schema(tmp_path, note_source):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_source)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 def test_empty_note_dir(tmp_path):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     with pytest.raises(SystemExit, match="early because an NLP workflow was encountered"):
         nlp_builder.NlpBuilder(toml_config_path=workflow_path, notes=note_utils.NoteSource())
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env()
 @mock.patch("openai.OpenAI")
 def test_table_filter_but_no_salt(mock_client, tmp_path, note_source):
@@ -119,7 +121,6 @@ def test_table_filter_but_no_salt(mock_client, tmp_path, note_source):
         builder.execute_queries(study_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 def test_flattened_config(tmp_path, note_source):
     workflow_path = conftest.write_toml(
         tmp_path,
@@ -145,7 +146,6 @@ def test_flattened_config(tmp_path, note_source):
     assert builder._workflow_config.tables["fallthrough"].system_prompt == "hello"
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_filter(mock_client, tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
@@ -206,7 +206,6 @@ def test_filter(mock_client, tmp_path, mock_db_config):
     assert expected_stats in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_already_uploaded(mock_client, tmp_path, mock_db_config, note_source):
     """Verify that we skip notes that we've already uploaded before"""
@@ -227,7 +226,6 @@ def test_already_uploaded(mock_client, tmp_path, mock_db_config, note_source):
     assert builder.stats.considered[0] == 0
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 @mock.patch.dict(os.environ, clear=True)
 @mock.patch("cumulus_library.builders.nlp_builder.NlpBuilder")
@@ -274,7 +272,6 @@ def test_args_passed_down(mock_builder, mock_client, tmp_path):
     assert list(source.progress_iter("label")) == [dxr]
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_unreachable_vllm(mock_client, tmp_path, note_source, mock_db_config):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -287,7 +284,6 @@ def test_unreachable_vllm(mock_client, tmp_path, note_source, mock_db_config):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_cached_response(mock_client, tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
@@ -334,7 +330,6 @@ def test_cached_response(mock_client, tmp_path, mock_db_config):
     assert builder.stats.got_response[0] == 1  # still got our cached result
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_span_correction(mock_client, tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(
@@ -396,9 +391,8 @@ def test_span_correction(mock_client, tmp_path, mock_db_config):
     assert failure_msg in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
-def test_writes_out_at_note_limit(mock_client, tmp_path, mock_db_config):
+def test_writes_out_at_chunksize(mock_client, tmp_path, mock_db_config):
     with open(f"{tmp_path}/doc.ndjson", "w", encoding="utf8") as f:
         add_doc("1", "Note one", f)
         add_doc("2", "Note two", f)
@@ -408,7 +402,7 @@ def test_writes_out_at_note_limit(mock_client, tmp_path, mock_db_config):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(mock_client)
     config = model.nlp_config()
-    config.note_limit = 2
+    config.chunksize = 2
 
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path,
@@ -428,7 +422,6 @@ def test_writes_out_at_note_limit(mock_client, tmp_path, mock_db_config):
     assert "Failed to finalize notes: test2" in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_various_value_types(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = conftest.write_toml(
@@ -465,7 +458,6 @@ def test_various_value_types(mock_client, tmp_path, mock_db_config, note_source)
     assert rows[0]["result"] == results
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_no_batching_support(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -481,7 +473,6 @@ def test_no_batching_support(mock_client, tmp_path, mock_db_config, note_source)
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_no_phi_dir(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -497,7 +488,6 @@ def test_no_phi_dir(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_bad_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -517,7 +507,6 @@ def test_bad_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_missing_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -532,7 +521,6 @@ def test_missing_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_bad_stop(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -551,7 +539,6 @@ def test_bad_stop(mock_client, tmp_path, mock_db_config, note_source):
     assert "did not complete, with finish reason: content_filter" in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_disabling_stats(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -570,7 +557,6 @@ def test_disabling_stats(mock_client, tmp_path, mock_db_config, note_source):
     assert "Token usage:" not in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.OpenAI")
 def test_cloud_model_but_local_provider(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -584,7 +570,6 @@ def test_cloud_model_but_local_provider(mock_client, tmp_path, mock_db_config, n
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_happy_path(mock_client, tmp_path, mock_db_config, note_source):
@@ -599,7 +584,6 @@ def test_azure_happy_path(mock_client, tmp_path, mock_db_config, note_source):
     assert builder.stats.got_response[0] == 1
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_bad_model(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -613,7 +597,6 @@ def test_azure_bad_model(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_no_env(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -627,7 +610,6 @@ def test_azure_no_env(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_no_schema_support(mock_client, tmp_path, mock_db_config, note_source):
@@ -647,7 +629,6 @@ def test_azure_no_schema_support(mock_client, tmp_path, mock_db_config, note_sou
     assert last_kwargs["response_format"] == {"type": "json_object"}
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_happy_path(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -661,7 +642,6 @@ def test_bedrock_happy_path(mock_client, tmp_path, mock_db_config, note_source):
     assert builder.stats.got_response[0] == 1
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_bad_stop(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -680,7 +660,6 @@ def test_bedrock_bad_stop(mock_client, tmp_path, mock_db_config, note_source):
     assert "did not complete, with stop reason: content_filter" in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_bad_model(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -694,7 +673,6 @@ def test_bedrock_bad_model(mock_client, tmp_path, mock_db_config, note_source):
         builder.execute_queries(mock_db_config, None)
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_skips_wrapper_in_response(mock_client, tmp_path, mock_db_config, note_source):
     """Confirm we drop a "parameter" wrapper object in response"""
@@ -724,7 +702,6 @@ def test_bedrock_skips_wrapper_in_response(mock_client, tmp_path, mock_db_config
     assert rows[0]["result"] == {"hello": "world"}
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_text_response(mock_client, tmp_path, mock_db_config, note_source):
     """Confirm we find json inside a text response"""
@@ -766,7 +743,6 @@ Summary.
     assert rows[0]["result"] == {"hello": 0.5}
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch("boto3.client")
 def test_bedrock_no_response(mock_client, tmp_path, mock_db_config, note_source):
     workflow_path = nlp_utils.basic_workflow(tmp_path)
@@ -785,7 +761,6 @@ def test_bedrock_no_response(mock_client, tmp_path, mock_db_config, note_source)
     assert "Failed to process note: no response content found" in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env()
 @mock.patch("botocore.client")
 @mock.patch("openai.OpenAI")
@@ -884,7 +859,6 @@ def mock_files_content(model: nlp_utils.MockModel, contents: list | None = None)
     )
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_batching_happy_path(mock_client, tmp_path, mock_db_config, note_source):
@@ -935,7 +909,6 @@ def test_azure_batching_happy_path(mock_client, tmp_path, mock_db_config, note_s
     }
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_source):
@@ -967,7 +940,6 @@ def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_sourc
     assert rows[0]["result"] == {"ignored": "answer"}
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 @mock.patch("time.sleep", new=lambda x: None)
@@ -1036,7 +1008,6 @@ def test_azure_batching_errors(mock_client, tmp_path, mock_db_config, note_sourc
     assert "Unexpected response from NLP: missing data" in console_output.getvalue()
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @mock.patch.object(OpenAIProvider, "AZURE_MAX_BATCH_COUNT", 2)
 @mock.patch.object(OpenAIProvider, "AZURE_MAX_BATCH_BYTES", 6000)
 @nlp_utils.mock_env("azure")
@@ -1112,7 +1083,6 @@ def test_azure_splitting_batch(mock_client, tmp_path, mock_db_config):
     ]
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env("azure")
 @mock.patch("openai.AzureOpenAI")
 def test_azure_batches_with_bad_notes(mock_client, tmp_path, mock_db_config):
@@ -1168,7 +1138,6 @@ def test_aws_profile_env_is_set(mock_register, tmp_path):
     assert os.environ.get("AWS_PROFILE") == "test-profile"
 
 
-@pytest.mark.xdist_group(name="nlp_builder")
 @nlp_utils.mock_env()
 @mock.patch("openai.OpenAI")
 def test_invalid_study_name(mock_client, tmp_path, note_source):

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -87,6 +87,7 @@ class MockModel:
             f"--nlp-model={config.model}",
             f"--nlp-provider={config.provider}",
             f"--etl-phi-dir={config.phi_dir}",
+            f"--nlp-chunksize={config.chunksize}",
         ]
         if config.clean:
             args.append("--clean-nlp")


### PR DESCRIPTION
This adds a new cli arg, `--nlp-chunksize` (since batching is overloaded here) that allows control over how many results are kept locally before they are written out.

While we're here, this also does some cleanup to the nlp tests, which were all using the global cache directory and thus were behaving poorly when running concurrently.

Addresses #559 

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json