### PR TITLE
fix: Report DATA_PACKAGE_VERSION during build export/upload stages

### DIFF
--- a/cumulus_library/actions/exporter.py
+++ b/cumulus_library/actions/exporter.py
@@ -4,7 +4,7 @@ import pandas
 import rich
 from rich.progress import track
 
-from cumulus_library import base_utils, study_manifest
+from cumulus_library import __version__, base_utils, study_manifest
 from cumulus_library.template_sql import base_templates
 
 # Database exporting functions
@@ -39,6 +39,7 @@ def export_study(
     :keyword archive: If true, get all study data and zip with timestamp
     :keyword chunksize: number of rows to export in a single transaction
     """
+    rich.print(f"[bold]cumulus-library version:[/] {__version__}")
     skipped_tables = []
     reset_counts_exports(manifest)
     manifest.materialize_counts_builder_exports()

--- a/cumulus_library/actions/uploader.py
+++ b/cumulus_library/actions/uploader.py
@@ -8,7 +8,7 @@ import requests
 import rich
 from pandas import read_parquet
 
-from cumulus_library import base_utils, const
+from cumulus_library import __version__, base_utils, const
 
 
 def upload_data(
@@ -111,6 +111,8 @@ def upload_files(args: dict):
         version = str(read_parquet(upload_archive.open(meta_version))["data_package_version"][0])
     except StopIteration:
         version = "0"
+    rich.print(f"[bold]cumulus-library version:[/] {__version__}")
+    rich.print(f"[bold]data package version:[/] {version}")
     # TODO: I looked into monitoring upload progress instead of completed files and it is
     # non-trivial - potential point for improvement later
     with base_utils.get_progress_bar() as progress_bar:


### PR DESCRIPTION
## Purpose

Closes #586

## Problem

It's easy to forget to update `DATA_PACKAGE_VERSION` during dev phases. There was no console output showing what version was being used during export or upload operations.

## Changes

- **exporter.py**: Added `__version__` import and a `rich.print` statement at the start of `export_study()` showing the cumulus-library version
- **uploader.py**: Added `__version__` import and two `rich.print` statements in `upload_files()` showing both the library version and the data package version being uploaded

Developers will now see output like:

```
cumulus-library version: 1!0.0.0
data package version: 42
```

during export and upload operations, making it trivial to verify they're working with the intended version.

## Verification

- [x] Exporter reports library version at start of export
- [x] Uploader reports library version and data package version before upload
- [x] Follows existing code style (rich.print for output)