### PR TITLE
Dtp/fix nlp model name resolution

### DIFF
--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -237,9 +237,17 @@ class OpenAIProvider(Provider):
             raise UnreachableModel(f"NLP server is unreachable: {exc}") from exc
 
         if self.model_name not in names:
-            raise errors.CumulusLibraryError(
-                f"NLP server does not have model ID '{self.model_name}'."
-            )
+            # Instead of failing, let's do a request to check if the deployment works.
+            # (This is a workaround for Azure, which uses deployment names instead of model names.)
+            try:
+                self.client.chat.completions.create(
+                    model=self.deployment,
+                    messages=[{"role": "system", "content": "Hello"}],
+                )
+            except openai.APIError as exc:
+                raise errors.CumulusLibraryError(
+                    f"NLP server does not have model ID '{self.model_name}'."
+                )
 
     @staticmethod
     def pydantic_to_response_format(schema: type[BaseModel]):

--- a/cumulus_library/builders/nlp/models.py
+++ b/cumulus_library/builders/nlp/models.py
@@ -246,7 +246,7 @@ class OpenAIProvider(Provider):
                 )
             except openai.APIError as exc:
                 raise errors.CumulusLibraryError(
-                    f"NLP server does not have model ID '{self.model_name}'."
+                    f"NLP server does not have model ID '{self.model_name}: {exc}'."
                 )
 
     @staticmethod

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -508,10 +508,28 @@ def test_bad_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
 
 
 @mock.patch("openai.OpenAI")
-def test_missing_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
+def test_missing_nlp_model_but_deployment_works(mock_client, tmp_path, mock_db_config, note_source):
+    # The model ID isn't in the server's model list, but the deployment fallback request
+    # succeeds (the Azure workaround), so we should proceed without error.
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(mock_client)
     model.mock_openai_model_list(models=[])
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()
+    )
+
+    builder.execute_queries(mock_db_config, None)
+
+
+@mock.patch("openai.OpenAI")
+def test_missing_nlp_model(mock_client, tmp_path, mock_db_config, note_source):
+    # The model ID isn't in the server's model list, and the deployment fallback request also
+    # fails with an APIError, so we should surface a CumulusLibraryError.
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(mock_client)
+    model.mock_openai_model_list(models=[])
+    model.mock_openai_deployment_check(fail=True)
 
     builder = nlp_builder.NlpBuilder(
         toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config()

--- a/tests/nlp_utils.py
+++ b/tests/nlp_utils.py
@@ -150,6 +150,18 @@ class MockModel:
             error = openai.APIError("test failure", mock.MagicMock(), body=None)
             self.openai.models.list.side_effect = error
 
+    def mock_openai_deployment_check(self, fail: bool = False) -> None:
+        """Controls the Azure-style deployment fallback request in post_init_check.
+
+        This is the request made when a model ID isn't in the server's model list, to check
+        whether a deployment of that name still works (a workaround for Azure).
+        """
+        if fail:
+            error = openai.APIError("test failure", mock.MagicMock(), body=None)
+            self.openai.chat.completions.create.side_effect = error
+        else:
+            self.openai.chat.completions.create.side_effect = None
+
     def _completion_for_value(
         self, value: dict, finish_reason: str = "stop"
     ) -> chat.ParsedChatCompletion:


### PR DESCRIPTION
It appears like sometime in the past few months (maybe April?) there was a shift in the alignment between model ids and actual deployment ids in the OpenAI API wrapper. The result is that trying to run the latest library's NLP processes fails (just try running any NLP with `gpt54-nano` as the model id CLI arg). This PR sidesteps an unnecessary failure by just checking to see if a simple request is achieved against the model before failing. 

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json