### PR TITLE
'cohorts' is now a reserved study name

### DIFF
--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -473,7 +473,7 @@ def main(cli_args=None):
     if args["action"] is None:
         sys.exit("No actions selected. Run 'cumulus-library -h' for details about actions.")
 
-    if args["target"] is not None and args["target"].lower() == "cohorts":
+    if args.get("target") and args["target"].lower() == "cohorts":
         exit_msg = "'cohorts' is a reserved study name. Please choose a different target."
         if args["action"] == "clean":
             exit_msg += (

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -473,7 +473,7 @@ def main(cli_args=None):
     if args["action"] is None:
         sys.exit("No actions selected. Run 'cumulus-library -h' for details about actions.")
 
-    if args["target"].lower() == "cohorts":
+    if args["target"] is not None and args["target"].lower() == "cohorts":
         exit_msg = "'cohorts' is a reserved study name. Please choose a different target."
         if args["action"] == "clean":
             exit_msg += (

--- a/cumulus_library/cli.py
+++ b/cumulus_library/cli.py
@@ -473,6 +473,16 @@ def main(cli_args=None):
     if args["action"] is None:
         sys.exit("No actions selected. Run 'cumulus-library -h' for details about actions.")
 
+    if args["target"].lower() == "cohorts":
+        exit_msg = "'cohorts' is a reserved study name. Please choose a different target."
+        if args["action"] == "clean":
+            exit_msg += (
+                "\nIf you want to remove all manually created cohorts, you can use the args "
+                "'--prefix --target cohorts__' to delete these tables. Note that there is "
+                "no way to undo this action."
+            )
+        sys.exit(exit_msg)
+
     if args["action"] == "version":
         table = rich.table.Table(title=f"cumulus-library version: {__version__}")
         table.add_column("Study Name", style="green")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1220,3 +1220,14 @@ def test_env_vs_default_arg_handling(mock_run, tmp_path):
     os.environ["CUMULUS_LIBRARY_DB_TYPE"] = "duckdb"
     cli.main(cli_args=["clean", "-t", "core"])
     assert mock_run.call_args[0][0]["db_type"] == "duckdb"
+
+
+@mock.patch.dict(
+    os.environ,
+    clear=True,
+)
+def test_cohorts_protected():
+    with pytest.raises(SystemExit):
+        cli.main(cli_args=["build", "-t", "cohorts"])
+    with pytest.raises(SystemExit, match="no way to undo"):
+        cli.main(cli_args=["clean", "-t", "cohorts"])


### PR DESCRIPTION
This now prevents users from interacting with a study named `cohorts` under most conditions.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json