### PR TITLE
When a file has changed locally and the file_upload workflow is in use, upload the changes to Athena, regardless of force upload flag

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -188,8 +188,10 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             if res["KeyCount"] > 0:
                 local_file_hash = hashlib.md5(file.read_bytes(), usedforsecurity=False).hexdigest()
 
-                if "ETag" in res and res["ETag"].strip('" ') == local_file_hash:
-                    return f"s3://{bucket}/{s3_key}"
+                if "Content" in res and "ETag" in res["Contents"][0]:
+                    etag = res["Contents"][0].get("ETag", "").strip('" ')
+                    if etag and etag == local_file_hash:
+                        return f"s3://{bucket}/{s3_key}"
 
                 res = s3_client.get_object(
                     Bucket=bucket,

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -186,15 +186,16 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 Prefix=f"{s3_key}/{remote_filename}",
             )
             if res["KeyCount"] > 0:
-                local_file_hash = hashlib.sha256(
-                    file.read_bytes(), usedforsecurity=False
-                ).hexdigest()
+                local_file_hash = hashlib.md5(file.read_bytes(), usedforsecurity=False).hexdigest()
+
+                if "ETag" in res and res["ETag"].strip() == local_file_hash:
+                    return f"s3://{bucket}/{s3_key}"
 
                 res = s3_client.get_object(
                     Bucket=bucket,
                     Key=f"{s3_key}/{remote_filename}",
                 )
-                res_hash = hashlib.sha256(res["Body"].read(), usedforsecurity=False).hexdigest()
+                res_hash = hashlib.md5(res["Body"].read(), usedforsecurity=False).hexdigest()
 
                 if res_hash == local_file_hash:
                     return f"s3://{bucket}/{s3_key}"

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -188,7 +188,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             if res["KeyCount"] > 0:
                 local_file_hash = hashlib.md5(file.read_bytes(), usedforsecurity=False).hexdigest()
 
-                if "ETag" in res and res["ETag"].strip() == local_file_hash:
+                if "ETag" in res and res["ETag"].strip('" ') == local_file_hash:
                     return f"s3://{bucket}/{s3_key}"
 
                 res = s3_client.get_object(

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -5,6 +5,7 @@ features, like pyathena's async cursors, to simplify cross-db behavior.
 """
 
 import collections
+import hashlib
 import os
 import pathlib
 from concurrent import futures
@@ -185,7 +186,26 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 Prefix=f"{s3_key}/{remote_filename}",
             )
             if res["KeyCount"] > 0:
-                return f"s3://{bucket}/{s3_key}"
+                if not file.exists():
+                    return f"s3://{bucket}/{s3_key}"
+
+                local_file_hash = hashlib.sha256(
+                    file.read_bytes(), usedforsecurity=False
+                ).hexdigest()
+
+                res = s3_client.get_object(
+                    Bucket=bucket,
+                    Key=f"{s3_key}/{remote_filename}",
+                )
+
+                local_file_hash = hashlib.sha256(
+                    file.read_bytes(), usedforsecurity=False
+                ).hexdigest()
+                res_hash = hashlib.sha256(res["Body"].read(), usedforsecurity=False).hexdigest()
+
+                if res_hash == local_file_hash:
+                    return f"s3://{bucket}/{s3_key}"
+
         with open(file, "rb") as b_file:
             s3_client.put_object(
                 Bucket=bucket,

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -188,11 +188,6 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             if res["KeyCount"] > 0:
                 local_file_hash = hashlib.md5(file.read_bytes(), usedforsecurity=False).hexdigest()
 
-                if "Content" in res and "ETag" in res["Contents"][0]:
-                    etag = res["Contents"][0].get("ETag", "").strip('" ')
-                    if etag and etag == local_file_hash:
-                        return f"s3://{bucket}/{s3_key}"
-
                 res = s3_client.get_object(
                     Bucket=bucket,
                     Key=f"{s3_key}/{remote_filename}",

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -186,8 +186,6 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 Prefix=f"{s3_key}/{remote_filename}",
             )
             if res["KeyCount"] > 0:
-                if not file.exists():
-                    return f"s3://{bucket}/{s3_key}"
 
                 local_file_hash = hashlib.sha256(
                     file.read_bytes(), usedforsecurity=False
@@ -197,10 +195,6 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                     Bucket=bucket,
                     Key=f"{s3_key}/{remote_filename}",
                 )
-
-                local_file_hash = hashlib.sha256(
-                    file.read_bytes(), usedforsecurity=False
-                ).hexdigest()
                 res_hash = hashlib.sha256(res["Body"].read(), usedforsecurity=False).hexdigest()
 
                 if res_hash == local_file_hash:

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -186,7 +186,6 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 Prefix=f"{s3_key}/{remote_filename}",
             )
             if res["KeyCount"] > 0:
-
                 local_file_hash = hashlib.sha256(
                     file.read_bytes(), usedforsecurity=False
                 ).hexdigest()

--- a/docs/api.md
+++ b/docs/api.md
@@ -151,7 +151,7 @@ your builder will be passed one of these via the CLI. We're only including metho
 that are relevant to clinical studies, rather than data prep/execution.
 
 See 
-[Creating studies](creating-studies.md) 
+[Creating studies](example.md) 
 for more info about what goes into a manifest and why.
 
 ### get_study_prefix

--- a/docs/core-study-details.md
+++ b/docs/core-study-details.md
@@ -22,7 +22,7 @@ for validating the integrity of the data you're extracting from your EHR system
 If you are authoring a study, and are focused only on clinical analysis (i.e. you
 aren't working on data quality/data governance issues), we **strongly** recommend you
 use the core study as the starting point for your own work. See 
-[Creating Studies](./creating-studies.md)
+[Creating Studies](./example.md)
 for more information.
 
 ## Design philosophy

--- a/docs/creating-sql-with-python.md
+++ b/docs/creating-sql-with-python.md
@@ -9,7 +9,7 @@ nav_order: 11
 # Creating SQL with python
 
 Before jumping into this doc, take a look at 
-[Creating Studies](examplemd).
+[Creating Studies](example.md).
 If you're just working with the
 [Core study tables](core-study-details.md)
 related to the US Core FHIR profiles, you may not be interested in this.

--- a/docs/creating-sql-with-python.md
+++ b/docs/creating-sql-with-python.md
@@ -9,7 +9,7 @@ nav_order: 11
 # Creating SQL with python
 
 Before jumping into this doc, take a look at 
-[Creating Studies](creating-studies.md).
+[Creating Studies](examplemd).
 If you're just working with the
 [Core study tables](core-study-details.md)
 related to the US Core FHIR profiles, you may not be interested in this.

--- a/docs/first-time-setup.md
+++ b/docs/first-time-setup.md
@@ -29,7 +29,7 @@ Installing adds a `cumulus-library` command for interacting with Athena.
 It provides several actions for users:
 
 - `build` will create new study tables, replacing previously created versions
-(more information on this in [Creating studies](./creating-studies.md)).
+(more information on this in [Creating studies](./example.md)).
 - `clean` will remove studies from Athena, in case you no longer need them
 - `export` will output the data in the tables to both a `.csv` and
 `.parquet` file. The former is intended for human review, while the latter is
@@ -79,7 +79,7 @@ and their associated CLI args:
 ## Example usage: building and exporting the core study
 
 Let's walk through configuring and creating the core study in Athena. With
-this completed, you'll be ready to move on to [Creating studies](./creating-studies.md)).
+this completed, you'll be ready to move on to [Creating studies](./example.md)).
 
 - First, follow the instructions in the readme of the 
 [Sample Database](https://github.com/smart-on-fhir/cumulus-library-sample-database),
@@ -109,4 +109,4 @@ of what kind of output to expect.
 
 ## Next steps
 
-Now that you are all set up, you can learn how to [create studies](./creating-studies.md) of your own!
+Now that you are all set up, you can learn how to [create studies](./example.md) of your own!

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -1,5 +1,6 @@
 """Edge case testing for Athena database support"""
 
+import io
 import json
 import pathlib
 import time
@@ -10,6 +11,7 @@ import awswrangler
 import botocore
 import pandas
 import pyathena
+import pytest
 
 from cumulus_library import base_utils, databases, study_manifest
 from tests import conftest
@@ -78,6 +80,111 @@ def test_upload_parquet_response_handling(mock_session):
     assert resp == (
         "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/count_patient"
     )
+
+
+@pytest.mark.parametrize(
+    """force_upload,
+list_objects_result,
+remote_body,
+local_bytes,
+expected_get_object_call_count,
+expected_put_object_call_count
+""",
+    [
+        pytest.param(
+            False,
+            {"KeyCount": 1},
+            b"same-content",
+            b"same-content",
+            1,
+            0,
+            id="remote-file-and-local-same-content",
+        ),
+        pytest.param(
+            False,
+            {"KeyCount": 1},
+            b"old-content",
+            b"new-content",
+            1,
+            1,
+            id="remote-file-and-local-different-content",
+        ),
+        pytest.param(
+            True,
+            {"KeyCount": 1},
+            b"same-content",
+            b"same-content",
+            0,
+            1,
+            id="same-content-force-upload-does-not-call-get-object",
+        ),
+        pytest.param(
+            True,
+            {"KeyCount": 1},
+            b"old-content",
+            b"new-content",
+            0,
+            1,
+            id="different-content-force-upload-does-not-call-get-object",
+        ),
+        pytest.param(
+            False, {"KeyCount": 0}, None, b"new-content", 0, 1, id="basic-upload-no-remote-file"
+        ),
+    ],
+)
+@mock.patch("botocore.session.Session")
+def test_upload_file_behavior(
+    mock_session,
+    tmp_path,
+    force_upload,
+    list_objects_result,
+    remote_body,
+    local_bytes,
+    expected_get_object_call_count,
+    expected_put_object_call_count,
+):
+    path = pathlib.Path(__file__).resolve().parents[1]
+    local_file = tmp_path / "count.parquet"
+    local_file.write_bytes(local_bytes)
+
+    db = databases.AthenaDatabaseBackend(
+        region="us-east-1",
+        work_group="work_group",
+        profile="profile",
+        schema_name="db_schema",
+    )
+    db.connect()
+
+    client = mock.MagicMock()
+    with open(path / "test_data/aws/boto3.client.athena.get_work_group.json") as f:
+        client.get_work_group.return_value = json.load(f)
+    db.connection._client = client
+
+    s3_client = mock.MagicMock()
+    s3_client.list_objects_v2.return_value = list_objects_result
+
+    if remote_body is not None:
+        s3_client.get_object.return_value = {"Body": io.BytesIO(remote_body)}
+    else:
+        s3_client.get_object.return_value = None
+
+    mock_session.return_value.create_client.return_value = s3_client
+
+    resp = db.upload_file(
+        file=local_file,
+        study="test_study",
+        topic="count_patient",
+        remote_filename="count.csv",
+        force_upload=force_upload,
+    )
+
+    assert resp == (
+        "s3://cumulus-athena-123456789012-us-east-1/results/"
+        "cumulus_user_uploads/db_schema/test_study/count_patient"
+    )
+
+    s3_client.get_object.call_count = expected_get_object_call_count
+    s3_client.put_object.call_count = expected_put_object_call_count
 
 
 @mock.patch("botocore.client")

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -120,16 +120,7 @@ expected_put_object_call_count
             b"same-content",
             0,
             1,
-            id="same-content-force-upload-does-not-call-get-object",
-        ),
-        pytest.param(
-            True,
-            {"KeyCount": 1},
-            b"old-content",
-            b"new-content",
-            0,
-            1,
-            id="different-content-force-upload-does-not-call-get-object",
+            id="force-upload-does-not-call-get-object",
         ),
     ],
 )

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -136,7 +136,7 @@ def test_upload_file_behavior(
     expected_put_object_call_count,
 ):
     path = pathlib.Path(__file__).resolve().parents[1]
-    local_file = tmp_path / "count.parquet"
+    local_file = tmp_path / "upload_file_behavior.csv"
     local_file.write_bytes(local_bytes)
 
     db = databases.AthenaDatabaseBackend(
@@ -161,14 +161,14 @@ def test_upload_file_behavior(
     resp = db.upload_file(
         file=local_file,
         study="test_study",
-        topic="count_patient",
-        remote_filename="count.csv",
+        topic="upload_file_behavior",
+        remote_filename="upload_file_behavior.csv",
         force_upload=force_upload,
     )
 
     assert resp == (
         "s3://cumulus-athena-123456789012-us-east-1/results/"
-        "cumulus_user_uploads/db_schema/test_study/count_patient"
+        "cumulus_user_uploads/db_schema/test_study/upload_file_behavior"
     )
 
     s3_client.get_object.call_count = expected_get_object_call_count

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -71,12 +71,10 @@ def test_upload_parquet_response_handling(mock_session):
     with open(path / "test_data/aws/boto3.client.s3.list_objects_v2.json") as f:
         s3_client.list_objects_v2.return_value = json.load(f)
 
-    parquet_path = path / "test_data/file_upload/upload.parquet"
-    parquet_bytes = parquet_path.read_bytes()
-    s3_client.get_object.return_value = {"Body": io.BytesIO(parquet_bytes)}
+    with open(path / "test_data/file_upload/upload.parquet", "rb") as f:
+        s3_client.get_object.return_value = {"Body": io.BytesIO(f.read())}
 
     mock_session.return_value.create_client.return_value = s3_client
-    print(path)
     resp = db.upload_file(
         file=path / "test_data/file_upload/upload.parquet",
         study="test_study",
@@ -84,7 +82,7 @@ def test_upload_parquet_response_handling(mock_session):
         remote_filename="upload.parquet",
     )
     assert resp == (
-        "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/count_patient"
+        "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/upload"
     )
 
 
@@ -104,7 +102,7 @@ expected_put_object_call_count
             b"same-content",
             1,
             0,
-            id="remote-file-and-local-same-content",
+            id="remote-file-and-local-same-content-does-not-call-put-object",
         ),
         pytest.param(
             False,
@@ -113,7 +111,7 @@ expected_put_object_call_count
             b"new-content",
             1,
             1,
-            id="remote-file-and-local-different-content",
+            id="remote-file-and-local-different-content-calls-put-object",
         ),
         pytest.param(
             True,

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -101,7 +101,11 @@ def test_upload_parquet_response_handling(mock_session):
             False,
             {
                 "KeyCount": 1,
-                "ETag": hashlib.md5(b"same-content", usedforsecurity=False).hexdigest(),
+                "Contents": [
+                    {
+                        "ETag": hashlib.md5(b"same-content", usedforsecurity=False).hexdigest(),
+                    }
+                ],
             },
             b"same-content",
             b"same-content",

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -127,9 +127,6 @@ expected_put_object_call_count
             1,
             id="different-content-force-upload-does-not-call-get-object",
         ),
-        pytest.param(
-            False, {"KeyCount": 0}, None, b"new-content", 0, 1, id="basic-upload-no-remote-file"
-        ),
     ],
 )
 @mock.patch("botocore.session.Session")
@@ -162,11 +159,7 @@ def test_upload_file_behavior(
 
     s3_client = mock.MagicMock()
     s3_client.list_objects_v2.return_value = list_objects_result
-
-    if remote_body is not None:
-        s3_client.get_object.return_value = {"Body": io.BytesIO(remote_body)}
-    else:
-        s3_client.get_object.return_value = None
+    s3_client.get_object.return_value = {"Body": io.BytesIO(remote_body)}
 
     mock_session.return_value.create_client.return_value = s3_client
 

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -99,22 +99,6 @@ def test_upload_parquet_response_handling(mock_session):
     [
         pytest.param(
             False,
-            {
-                "KeyCount": 1,
-                "Contents": [
-                    {
-                        "ETag": hashlib.md5(b"same-content", usedforsecurity=False).hexdigest(),
-                    }
-                ],
-            },
-            b"same-content",
-            b"same-content",
-            0,
-            0,
-            id="remote-file-etag-and-local-hash-match-does-not-call-get-or-put-object",
-        ),
-        pytest.param(
-            False,
             {"KeyCount": 1},
             b"same-content",
             b"same-content",

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -70,12 +70,18 @@ def test_upload_parquet_response_handling(mock_session):
     s3_client = mock.MagicMock()
     with open(path / "test_data/aws/boto3.client.s3.list_objects_v2.json") as f:
         s3_client.list_objects_v2.return_value = json.load(f)
+
+    parquet_path = path / "test_data/file_upload/upload.parquet"
+    parquet_bytes = parquet_path.read_bytes()
+    s3_client.get_object.return_value = {"Body": io.BytesIO(parquet_bytes)}
+
     mock_session.return_value.create_client.return_value = s3_client
+    print(path)
     resp = db.upload_file(
-        file=path / "test_data/count_synthea_patient.parquet",
+        file=path / "test_data/file_upload/upload.parquet",
         study="test_study",
-        topic="count_patient",
-        remote_filename="count_synthea_patient.parquet",
+        topic="upload",
+        remote_filename="upload.parquet",
     )
     assert resp == (
         "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/count_patient"

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -1,5 +1,6 @@
 """Edge case testing for Athena database support"""
 
+import hashlib
 import io
 import json
 import pathlib
@@ -71,18 +72,18 @@ def test_upload_parquet_response_handling(mock_session):
     with open(path / "test_data/aws/boto3.client.s3.list_objects_v2.json") as f:
         s3_client.list_objects_v2.return_value = json.load(f)
 
-    with open(path / "test_data/file_upload/upload.parquet", "rb") as f:
+    with open(path / "test_data/upload/upload__count_synthea_patient.cube.parquet", "rb") as f:
         s3_client.get_object.return_value = {"Body": io.BytesIO(f.read())}
 
     mock_session.return_value.create_client.return_value = s3_client
     resp = db.upload_file(
-        file=path / "test_data/file_upload/upload.parquet",
+        file=path / "test_data/upload/upload__count_synthea_patient.cube.parquet",
         study="test_study",
-        topic="upload",
-        remote_filename="upload.parquet",
+        topic="count_patient",
+        remote_filename="count_synthea_patient.cube.parquet",
     )
     assert resp == (
-        "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/upload"
+        "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/count_patient"
     )
 
 
@@ -95,6 +96,18 @@ expected_get_object_call_count,
 expected_put_object_call_count
 """,
     [
+        pytest.param(
+            False,
+            {
+                "KeyCount": 1,
+                "ETag": hashlib.md5(b"same-content", usedforsecurity=False).hexdigest(),
+            },
+            b"same-content",
+            b"same-content",
+            0,
+            0,
+            id="remote-file-etag-and-local-hash-match-does-not-call-get-or-put-object",
+        ),
         pytest.param(
             False,
             {"KeyCount": 1},

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -88,13 +88,14 @@ def test_upload_parquet_response_handling(mock_session):
 
 
 @pytest.mark.parametrize(
-    """force_upload,
-list_objects_result,
-remote_body,
-local_bytes,
-expected_get_object_call_count,
-expected_put_object_call_count
-""",
+    (
+        "force_upload,"
+        "list_objects_result,"
+        "remote_body,"
+        "local_bytes,"
+        "expected_get_object_call_count,"
+        "expected_put_object_call_count"
+    ),
     [
         pytest.param(
             False,

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -1,6 +1,5 @@
 """Edge case testing for Athena database support"""
 
-import hashlib
 import io
 import json
 import pathlib

--- a/tests/databases/test_databases.py
+++ b/tests/databases/test_databases.py
@@ -3,6 +3,7 @@
 This is intended to exercise edge cases not covered via more integrated testing"""
 
 import datetime
+import io
 import os
 import pathlib
 from contextlib import nullcontext as does_not_raise
@@ -237,6 +238,8 @@ def test_upload_file_athena(mock_botocore, args, sse, keycount, expected, raises
     mock_clientobj = mock_botocore.ClientCreator.return_value.create_client.return_value
     mock_clientobj.get_work_group.return_value = mock_data
     mock_clientobj.list_objects_v2.return_value = {"KeyCount": keycount}
+    if keycount > 0:
+        mock_clientobj.get_object.return_value = {"Body": io.BytesIO(args["file"].read_bytes())}
     db = databases.AthenaDatabaseBackend(**ATHENA_KWARGS)
     db.connect()
     with raises:


### PR DESCRIPTION
Resolves #589 
### Testing
- I followed the steps in https://docs.smarthealthit.org/cumulus/library/example.html
   - Manually edited one of the lines in the `snomed_bronchitis.csv`, verified the change was uploaded to S3 + Athena. 

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [ ] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml`
- [ ] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json