### PR TITLE
Fallback to boto session for credentials

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -66,12 +66,15 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         if self.connect_kwargs == {} or not any(
             [self.connect_kwargs.get(x.lower()) is not None for x in AWS_ENV_VARS]
         ):
-            s = boto3.Session()
-            c = s.get_credentials()
-            self.connect_kwargs["aws_access_key_id"] = c.access_key
-            self.connect_kwargs["aws_secret_access_key"] = c.secret_key
-            self.connect_kwargs["aws_session_token"] = c.token
-            self.connect_kwargs.pop("profile_name", None)
+            session = boto3.Session()
+            creds = session.get_credentials()
+            if creds is not None:
+                self.connect_kwargs["aws_access_key_id"] = creds.access_key
+                self.connect_kwargs["aws_secret_access_key"] = creds.secret_key
+                self.connect_kwargs["aws_session_token"] = creds.token
+                # We'll remove the default profile arg, since it can interfere with
+                # boto lookups
+                self.connect_kwargs.pop("profile_name", None)
 
         self.connection = pyathena.connect(
             region_name=self.region,

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -71,6 +71,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             self.connect_kwargs["aws_access_key_id"] = c.access_key
             self.connect_kwargs["aws_secret_access_key"] = c.secret_key
             self.connect_kwargs["aws_session_token"] = c.token
+            self.connect_kwargs.pop("profile_name", None)
 
         self.connection = pyathena.connect(
             region_name=self.region,

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -23,6 +23,8 @@ from rich import progress
 from cumulus_library import base_utils, errors
 from cumulus_library.databases import base, utils
 
+AWS_ENV_VARS = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+
 
 class AthenaDatabaseBackend(base.DatabaseBackend):
     """Database backend that can talk to AWS Athena"""
@@ -56,13 +58,19 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         # are set. If both are present, the env vars take precedence
         if self.profile is not None:
             self.connect_kwargs["profile_name"] = self.profile
-        for aws_env_name in [
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_SESSION_TOKEN",
-        ]:
+        for aws_env_name in AWS_ENV_VARS:
             if aws_env_val := os.environ.get(aws_env_name):
                 self.connect_kwargs[aws_env_name.lower()] = aws_env_val
+
+        # if we don't have connection info, we'll try to get it from boto defaults
+        if self.connect_kwargs == {} or not any(
+            [self.connect_kwargs.get(x.lower()) is not None for x in AWS_ENV_VARS]
+        ):
+            s = boto3.Session()
+            c = s.get_credentials()
+            self.connect_kwargs["aws_access_key_id"] = c.access_key
+            self.connect_kwargs["aws_secret_access_key"] = c.secret_key
+            self.connect_kwargs["aws_session_token"] = c.token
 
         self.connection = pyathena.connect(
             region_name=self.region,

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -248,7 +248,6 @@ def test_boto_fallback(mock_session):
     )
     db.connect()
     assert db.connect_kwargs == {
-        "profile_name": "test",
         "aws_access_key_id": "access",
         "aws_secret_access_key": "secret",
         "aws_session_token": "token",

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -1,6 +1,7 @@
 """Edge case testing for Athena database support"""
 
 import json
+import os
 import pathlib
 import time
 from concurrent import futures
@@ -228,3 +229,27 @@ def test_get_remote_path(mock_client):
     }
     db.connection._client.get_work_group.side_effect = [bucket_info, bucket_info]
     assert db.get_remote_path() == "s3://testbucket/athena"
+
+
+@mock.patch.dict(
+    os.environ,
+    clear=True,
+)
+@mock.patch("botocore.session")
+def test_boto_fallback(mock_session):
+    mock_session.get_session.return_value.get_credentials.return_value = (
+        botocore.credentials.Credentials(access_key="access", secret_key="secret", token="token")
+    )
+    db = databases.AthenaDatabaseBackend(
+        region="test",
+        work_group="test",
+        profile="test",
+        schema_name="test",
+    )
+    db.connect()
+    assert db.connect_kwargs == {
+        "profile_name": "test",
+        "aws_access_key_id": "access",
+        "aws_secret_access_key": "secret",
+        "aws_session_token": "token",
+    }


### PR DESCRIPTION
Our current assumption was 'A user will provide credentials, either via AWS env vars, cli, or via `.aws/credentials` lookup, but this excludes a couple of trailing [valid boto credential options](https://docs.aws.amazon.com/boto3/latest/guide/credentials.html#configuring-credentials) - so if we don't find one via our current methods, we'll just spin up a boto session and call get_credentials, to see if we're in an EC2 and looking for IAM as a source.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json