### PR TITLE
Ensure file exists before uploading to Athena

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -172,6 +172,9 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         remote_filename: str | None = None,
         force_upload=False,
     ) -> str | None:
+        if not file.exists():
+            raise errors.FileUploadError(f"File {file} does not exist, cannot upload.")
+
         # We'll investigate the connection to get the relevant S3 upload path.
         wg_conf = self._get_result_config()
         s3_path = wg_conf["OutputLocation"]

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -14,7 +14,7 @@ import pandas
 import pyathena
 import pytest
 
-from cumulus_library import base_utils, databases, study_manifest
+from cumulus_library import base_utils, databases, errors, study_manifest
 from tests import conftest
 
 
@@ -85,6 +85,32 @@ def test_upload_parquet_response_handling(mock_session):
     assert resp == (
         "s3://cumulus-athena-123456789012-us-east-1/results/cumulus_user_uploads/db_schema/test_study/count_patient"
     )
+
+
+@mock.patch("botocore.session.Session")
+def test_upload_file_does_not_exist(mock_session):
+    path = pathlib.Path(__file__).resolve().parents[1]
+    db = databases.AthenaDatabaseBackend(
+        region="us-east-1",
+        work_group="work_group",
+        profile="profile",
+        schema_name="db_schema",
+    )
+    db.connect()
+    client = mock.MagicMock()
+    with open(path / "test_data/aws/boto3.client.athena.get_work_group.json") as f:
+        client.get_work_group.return_value = json.load(f)
+    db.connection._client = client
+    s3_client = mock.MagicMock()
+
+    mock_session.return_value.create_client.return_value = s3_client
+    with pytest.raises(errors.FileUploadError):
+        db.upload_file(
+            file=path / "test_data/upload/missing_file.parquet",
+            study="test_study",
+            topic="missing_file",
+            remote_filename="missing_file.cube.parquet",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #601 

Note: I think the likelihood that we fall into this scenario is extremely rare because it should be caught earlier in the code when data is loaded into the pandas data frame. 

### Checklist
- [ ] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [ ] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [ ] Update template repo if there are changes to study configuration in `manifest.toml`
- [ ] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json