### PR TITLE
Add --select-table and --select-by-table CLI args for NLP builds

### DIFF
--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -40,7 +40,14 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         except Exception as e:
             sys.exit(f"The NLP workflow at {toml_config_path!s} is invalid: \n{e}")
 
+        if select_table := self._nlp_config.select_table:
+            self._filter_tables(select_table)
+
         self._flatten_config(toml_config_path.parent)
+
+        if select_by_table := self._nlp_config.select_by_table:
+            for task in self._workflow_config.tables.values():
+                task.select_by_table = select_by_table
 
         self._notes = notes
         if not self._notes:
@@ -50,6 +57,19 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
                 "provide a folder with FHIR resources like DiagnosticReport "
                 "or DocumentReference with inlined clinical notes."
             )
+
+    def _filter_tables(self, select_table: list[str]) -> None:
+        """Restricts this workflow's tables to just the ones requested via --select-table"""
+        available = self._workflow_config.tables
+        unknown = [name for name in select_table if name not in available]
+        if unknown:
+            sys.exit(
+                f"Unknown NLP table(s) requested via --select-table: {unknown}\n"
+                f"Available tables in this workflow: {sorted(available)}"
+            )
+        self._workflow_config.tables = {
+            name: task for name, task in available.items() if name in select_table
+        }
 
     def _flatten_config(self, config_dir: pathlib.Path) -> None:
         """Takes any non-specified task values from the [shared] table"""

--- a/cumulus_library/cli_parser.py
+++ b/cumulus_library/cli_parser.py
@@ -190,6 +190,30 @@ def add_nlp_config(parser: argparse.ArgumentParser) -> None:
         action="store_false",
         help="Disable printing of NLP note and token statistics",
     )
+    group.add_argument(
+        "--select-table",
+        dest="select_table",
+        action="append",
+        metavar="TABLE",
+        help=(
+            "Restrict this build to only the given NLP table(s) within a workflow "
+            "(matches a `[tables.X]` entry's name in an NLP workflow config). Can be "
+            "repeated to select more than one table. Most useful combined with "
+            "--builder to target a single workflow file."
+        ),
+    )
+    group.add_argument(
+        "--select-by-table",
+        dest="select_by_table",
+        metavar="TABLE",
+        help=(
+            "Overrides the `select_by_table` config value for every NLP table being "
+            "built in this run, regardless of what's set in the workflow file. Handy "
+            "for quickly pointing NLP at a different candidate-notes table during "
+            "study development, without editing (and accidentally checking in changes "
+            "to) the workflow file."
+        ),
+    )
 
 
 def add_stage_argument(parser: argparse.ArgumentParser) -> None:

--- a/cumulus_library/note_utils.py
+++ b/cumulus_library/note_utils.py
@@ -123,6 +123,8 @@ class NlpConfig:
         self.phi_dir = args.get("etl_phi_dir")
         self.target = args.get("target")
         self.show_stats = args.get("nlp_stats")
+        self.select_table = args.get("select_table")
+        self.select_by_table = args.get("select_by_table")
 
         self.salt = None
         if self.phi_dir:

--- a/docs/workflows/nlp.md
+++ b/docs/workflows/nlp.md
@@ -165,6 +165,15 @@ You can pass these to Cumulus Library when building a study and any NLP workflow
   will be much cheaper
 - `--clean-nlp`: if set, previous NLP results for the workflow will be deleted first
 - `--no-nlp-stats`: if set, note and token stats will not be printed to the console
+- `--select-table=TABLE`: restrict the build to only the given table(s) within the workflow (i.e.
+  a single `[tables.X]` entry). Can be repeated to select more than one table. This is most useful
+  during study development, when you want to iterate on one NLP table without building the whole
+  workflow every time. Combine with `--builder=my_workflow.workflow` to target a specific workflow
+  file if your study has more than one.
+- `--select-by-table=TABLE`: overrides the `select_by_table` config value for every NLP table being
+  built in this run, regardless of what's set in the workflow file. Handy for quickly testing NLP
+  against a different candidate-notes table while you're still iterating on it, without editing (or
+  forgetting to revert) the workflow file itself.
 
 ### What Data Gets Sent Where
 

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -146,6 +146,82 @@ def test_flattened_config(tmp_path, note_source):
     assert builder._workflow_config.tables["fallthrough"].system_prompt == "hello"
 
 
+def _workflow_with_two_tables(tmp_path):
+    return conftest.write_toml(
+        tmp_path,
+        {
+            "config_type": "nlp",
+            "shared": {
+                "select_by_table": "shared_table",
+            },
+            "tables": {
+                "age": {
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+                "race": {
+                    "select_by_table": "race_table",
+                    "response_schema": nlp_utils.EMPTY_SCHEMA,
+                },
+            },
+        },
+        "nlp.workflow",
+    )
+
+
+def test_select_table_filter(tmp_path, note_source):
+    """--select-table should restrict which [tables.X] entries get built"""
+    workflow_path = _workflow_with_two_tables(tmp_path)
+    nlp_config = note_utils.NlpConfig({"select_table": ["age"]})
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=nlp_config
+    )
+    assert list(builder._workflow_config.tables) == ["age"]
+
+
+def test_select_table_filter_multiple(tmp_path, note_source):
+    """--select-table can be repeated to build more than one table"""
+    workflow_path = _workflow_with_two_tables(tmp_path)
+    nlp_config = note_utils.NlpConfig({"select_table": ["age", "race"]})
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=nlp_config
+    )
+    assert set(builder._workflow_config.tables) == {"age", "race"}
+
+
+def test_select_table_unknown(tmp_path, note_source):
+    """An unknown --select-table value should exit with a helpful message"""
+    workflow_path = _workflow_with_two_tables(tmp_path)
+    nlp_config = note_utils.NlpConfig({"select_table": ["bogus"]})
+    with pytest.raises(SystemExit, match=r"(?s)Unknown NLP table\(s\).*bogus.*age.*race"):
+        nlp_builder.NlpBuilder(
+            toml_config_path=workflow_path, notes=note_source, nlp_config=nlp_config
+        )
+
+
+def test_select_by_table_override(tmp_path, note_source):
+    """--select-by-table should override select_by_table for every built table"""
+    workflow_path = _workflow_with_two_tables(tmp_path)
+    nlp_config = note_utils.NlpConfig({"select_by_table": "override_table"})
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=nlp_config
+    )
+    assert builder._workflow_config.tables["age"].select_by_table == "override_table"
+    assert builder._workflow_config.tables["race"].select_by_table == "override_table"
+
+
+def test_select_table_and_select_by_table_combined(tmp_path, note_source):
+    """The two new CLI args can be combined to build one table against a new select target"""
+    workflow_path = _workflow_with_two_tables(tmp_path)
+    nlp_config = note_utils.NlpConfig(
+        {"select_table": ["race"], "select_by_table": "override_table"}
+    )
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=nlp_config
+    )
+    assert list(builder._workflow_config.tables) == ["race"]
+    assert builder._workflow_config.tables["race"].select_by_table == "override_table"
+
+
 @mock.patch("openai.OpenAI")
 def test_filter(mock_client, tmp_path, mock_db_config):
     workflow_path = conftest.write_toml(


### PR DESCRIPTION
### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - Added details for `--select-table` and `--select-by-table` to `docs/workflows/nlp.md`.
  - (N/A) If you've changed the structure of a table, you may need to run `generate-md`
  - (N/A) If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - (N/A) If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [ ] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
  - Added robust unit tests to `tests/builders/test_nlp_builder.py` for both flags and their combinations.
- [ ] Update template repo if there are changes to study configuration in `manifest.toml`
- [ ] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json
