### PR TITLE
NLP: Results Tables Follow ETL's Naming Convention, Closing #596

### DIFF
--- a/cumulus_library/actions/builder.py
+++ b/cumulus_library/actions/builder.py
@@ -89,6 +89,7 @@ def build_study(
         queries = []
         explicit_serial_queries = []
         for file in action["files"]:
+            nlp_prefix_allowed = False
             if file not in file_list:
                 continue
             if file.endswith(".py"):
@@ -112,7 +113,7 @@ def build_study(
                     # the total number of manually executed queries.
                     explicit_serial_queries += b_queries
             elif file.endswith(".toml") or file.endswith(".workflow"):
-                w_queries, parallel_allowed = _run_workflow(
+                w_queries, parallel_allowed, nlp_prefix_allowed = _run_workflow(
                     config=config,
                     manifest=manifest,
                     filename=file,
@@ -139,7 +140,7 @@ def build_study(
             else:
                 raise errors.StudyManifestParsingError(f"Unexpected filetype in manifest: {file}")
             for query in queries:
-                _check_query_for_errors(config, manifest, query, file)
+                _check_query_for_errors(config, manifest, query, file, nlp_prefix_allowed)
         if parallel:
             query_count += len(queries)
             if query_count > 0:
@@ -551,7 +552,7 @@ def _run_workflow(
     notes: note_utils.NoteSource | None = None,
     nlp_config: note_utils.NlpConfig | None = None,
     parallel: bool = False,
-) -> tuple[list[str], bool]:
+) -> tuple[list[str], bool, bool]:
     """Loads workflow config from toml definitions and executes workflow
 
     :param config: a StudyConfig object
@@ -564,8 +565,10 @@ def _run_workflow(
     :keyword query_count: if prepare is true, the number of queries already rendered
     :keyword stage_name: the stage in the build currently being processed
     :keyword parallel; If true, execute queries in parallel if workflow allows
-    :returns: a list of queries
+    :returns: a list of queries, a bool flag for parallel being allowed, a bool flag
+        for allowing use of the `nlp_` table prefix
     """
+    nlp_prefix_allowed = False
     toml_path = pathlib.Path(f"{manifest._study_path}/{filename}")
     if prepare:
         with open(toml_path, encoding="utf-8") as file:
@@ -579,7 +582,7 @@ def _run_workflow(
             query_count,
             is_toml=True,
         )
-        return ([], False)
+        return ([], False, False)
 
     # This open is a bit redundant with the open inside of the PSM builder,
     # but we're letting it slide so that builders function similarly
@@ -601,6 +604,7 @@ def _run_workflow(
                 toml_config_path=toml_path,
             )
         case "nlp":
+            nlp_prefix_allowed = True
             builder = nlp_builder.NlpBuilder(
                 manifest=manifest,
                 toml_config_path=toml_path,
@@ -619,7 +623,7 @@ def _run_workflow(
                     .fetchall()
                 )
             if (target_table,) in existing_stats and not config.stats_build:
-                return ([], False)
+                return ([], False, False)
             builder = psm_builder.PsmBuilder(
                 toml_config_path=toml_path,
                 config=config,
@@ -658,7 +662,7 @@ def _run_workflow(
                 table_name=f"{target_table}_{safe_timestamp}",
                 view_name=target_table,
             )
-    return builder.queries, bool(builder and builder.parallel_allowed)
+    return builder.queries, bool(builder and builder.parallel_allowed), nlp_prefix_allowed
 
 
 def log_ref_summary(
@@ -832,6 +836,7 @@ def _check_query_for_errors(
     manifest: study_manifest.StudyManifest,
     query: str,
     filename: str,
+    nlp_prefix_allowed: bool = False,
 ):
     try:
         table = str(sqlglot.parse_one(query, dialect=config.db.db_type).find(sqlglot.exp.Table))
@@ -856,9 +861,11 @@ def _check_query_for_errors(
             "This query does not contain the study prefix. All tables should "
             f"start with a string like `{manifest.get_schema_aware_prefix_with_seperator()}`.",
         )
+    protected_keywords = [x for x in enums.ProtectedTableKeywords]
+    if nlp_prefix_allowed:
+        protected_keywords.remove(enums.ProtectedTableKeywords.NLP)
     if any(
-        f"{manifest.get_study_prefix()}__{word.value}_" in table
-        for word in enums.ProtectedTableKeywords
+        f"{manifest.get_study_prefix()}__{word.value}_" in table for word in protected_keywords
     ) and isinstance(
         sqlglot.parse_one(query, dialect=config.db.db_type), sqlglot.expressions.Create
     ):

--- a/cumulus_library/builders/nlp/driver.py
+++ b/cumulus_library/builders/nlp/driver.py
@@ -47,15 +47,16 @@ def run_nlp(
             # We wanna clean out all previous uploads for this table.
             # Do this before making the pool because that looks at the files in the folder to
             # get the first batch number to use.
-            root = output_path_for_task(nlp_config.target, table_slug, task, db).parent
-            table_with_version = re.compile(rf"/{table_slug}_v[0-9]+(\.ids)?$")
+            root = output_path_for_task(nlp_config, table_slug, task, db).parent
+            slug = table_slug_for_task(table_slug, nlp_config)
+            table_with_version = re.compile(rf"/{re.escape(slug)}_v[0-9]+(\.ids)?$")
             for folder in root.ls():
                 if table_with_version.search(str(folder)):
                     folder.rm()
 
     # Read ID refs for any already-uploaded notes
     prev_upload_refs = [
-        read_upload_refs_for_task(nlp_config.target, table_slug, task, db)
+        read_upload_refs_for_task(nlp_config, table_slug, task, db)
         for table_slug, task in tables.items()
     ]
 
@@ -97,8 +98,39 @@ def run_nlp(
     return stats
 
 
+def model_slug(nlp_config: note_utils.NlpConfig) -> str:
+    """Converts an NLP model ID into a slug that is safe for SQL names and file paths"""
+    if not nlp_config.model:
+        # Same message that models.create_model() gives, but we need a model name earlier than
+        # that (when naming the tables we're going to create).
+        raise errors.CumulusLibraryError("An NLP model ID must be provided (using --nlp-model).")
+    return nlp_config.model.replace("-", "_")
+
+
+def table_slug_for_task(table_slug: str, nlp_config: note_utils.NlpConfig) -> str:
+    """Returns the study-relative name for a task, like 'nlp_age_gpt_oss_120b'
+
+    This mirrors how Cumulus ETL names its own NLP tables and upload folders, so that
+    downstream consumers can treat library-generated and ETL-generated NLP results the same:
+    an 'nlp' prefix, the task name, and the model used.
+    """
+    return f"nlp_{table_slug}_{model_slug(nlp_config)}"
+
+
 def table_name_for_task(table_slug: str, nlp_config: note_utils.NlpConfig) -> str:
-    return f"{nlp_config.target}__{table_slug}"
+    """Returns the full database table name for a task, like 'my_study__nlp_age_gpt_oss_120b'"""
+    return f"{nlp_config.target}__{table_slug_for_task(table_slug, nlp_config)}"
+
+
+def upload_slug_for_task(
+    table_slug: str, task: workflow.NlpTask, nlp_config: note_utils.NlpConfig
+) -> str:
+    """Returns the upload folder name for a task, like 'nlp_age_gpt_oss_120b_v1'
+
+    Unlike the table name, the upload folder is version-specific, so that results from
+    different task versions don't get mixed together.
+    """
+    return f"{table_slug_for_task(table_slug, nlp_config)}_v{task.version}"
 
 
 def schema_for_task(task: workflow.NlpTask) -> pyarrow.Schema:
@@ -118,9 +150,13 @@ def schema_for_task(task: workflow.NlpTask) -> pyarrow.Schema:
 
 
 def output_path_for_task(
-    prefix: str, table_slug: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+    nlp_config: note_utils.NlpConfig,
+    table_slug: str,
+    task: workflow.NlpTask,
+    db: databases.DatabaseBackend,
 ) -> cfs.FsPath:
-    upload_slug = table_slug + f"_v{task.version}"
+    prefix = nlp_config.target
+    upload_slug = upload_slug_for_task(table_slug, task, nlp_config)
     if base_path := db.get_remote_upload_path(prefix, upload_slug):
         return cfs.FsPath(base_path)
 
@@ -214,14 +250,14 @@ class NlpNotePool:
                 if self._next_parquet_path(table_slug, task).name == "nlp.0.parquet":
                     self._write_single_parquet(table_slug, task, [])
 
-    def _table_name(self, table_slug: str) -> str:
-        return table_name_for_task(table_slug, self._config)
-
     def _cache_dir(self) -> cfs.FsPath:
         return cfs.FsPath(self._config.phi_dir)
 
     def _cache_namespace(self, table_slug: str, task: workflow.NlpTask) -> str:
-        return f"{self._table_name(table_slug)}_v{task.version}_{self._model.MODEL_ID}"
+        # Note that this intentionally does not use table_name_for_task(). This namespace names
+        # a folder of cached NLP responses in the user's PHI dir - if we renamed it, every
+        # existing cached response would be orphaned (and re-running would cost real money).
+        return f"{self._config.target}__{table_slug}_v{task.version}_{self._model.MODEL_ID}"
 
     def _make_prompt(self, table_slug: str, task: workflow.NlpTask, text: str) -> models.Prompt:
         schema = task.response_schema.model_json_schema()
@@ -417,10 +453,10 @@ class NlpNotePool:
             if table_slug in notes:
                 rows = notes[table_slug]
                 self._write_single_parquet(table_slug, task, rows)
-                add_upload_refs_for_task(self._config.target, table_slug, task, self._db, rows)
+                add_upload_refs_for_task(self._config, table_slug, task, self._db, rows)
 
     def _next_parquet_path(self, table_slug: str, task: workflow.NlpShared) -> cfs.FsPath:
-        folder = output_path_for_task(self._config.target, table_slug, task, self._db)
+        folder = output_path_for_task(self._config, table_slug, task, self._db)
 
         # First, determine what the next upload number should be
         basenames = [path.name for path in folder.ls()]
@@ -442,29 +478,35 @@ class NlpNotePool:
 
 
 def upload_refs_path(
-    prefix: str, table_slug: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+    nlp_config: note_utils.NlpConfig,
+    table_slug: str,
+    task: workflow.NlpTask,
+    db: databases.DatabaseBackend,
 ) -> cfs.FsPath:
-    path = output_path_for_task(prefix, table_slug, task, db)
+    path = output_path_for_task(nlp_config, table_slug, task, db)
     return cfs.FsPath(str(path) + ".ids")
 
 
 def read_upload_refs_for_task(
-    prefix: str, table_slug: str, task: workflow.NlpTask, db: databases.DatabaseBackend
+    nlp_config: note_utils.NlpConfig,
+    table_slug: str,
+    task: workflow.NlpTask,
+    db: databases.DatabaseBackend,
 ) -> set[str]:
-    path = upload_refs_path(prefix, table_slug, task, db)
+    path = upload_refs_path(nlp_config, table_slug, task, db)
     refs = path.read_text(default="")
     return set(refs.splitlines())
 
 
 def add_upload_refs_for_task(
-    prefix: str,
+    nlp_config: note_utils.NlpConfig,
     table_slug: str,
     task: workflow.NlpTask,
     db: databases.DatabaseBackend,
     rows: list[dict],
 ) -> set[str]:
     refs = sorted(f"{row['note_ref']}" for row in rows)  # sort for tests
-    path = upload_refs_path(prefix, table_slug, task, db)
+    path = upload_refs_path(nlp_config, table_slug, task, db)
     path.parent.makedirs()
     mode = "a" if path.exists() else "w"  # work around memory:// fs having bad "a" semantics
     with path.open(mode) as f:

--- a/cumulus_library/builders/nlp_builder.py
+++ b/cumulus_library/builders/nlp_builder.py
@@ -207,13 +207,14 @@ class NlpBuilder(cumulus_library.BaseTableBuilder):
         for table_slug, task in self._workflow_config.tables.items():
             table_schema = driver.schema_for_task(task)
             location = str(
-                driver.output_path_for_task(self._nlp_config.target, table_slug, task, config.db)
+                driver.output_path_for_task(self._nlp_config, table_slug, task, config.db)
             )
+            table_name = driver.table_name_for_task(table_slug, self._nlp_config)
             remote_types = config.db.col_parquet_types_from_pyarrow(table_schema)
             self.queries.append(
                 base_templates.get_ctas_from_parquet_query(
                     schema_name=config.schema,
-                    table_name=driver.table_name_for_task(table_slug, self._nlp_config),
+                    table_name=table_name,
                     local_location=location,
                     remote_location=location,
                     table_cols=table_schema.names,

--- a/cumulus_library/studies/example_nlp/calculate_ranges.sql
+++ b/cumulus_library/studies/example_nlp/calculate_ranges.sql
@@ -1,3 +1,6 @@
+-- NLP result tables are named `{study}__nlp_{task}_{model}`, so the model you run NLP with
+-- is part of the table name (this study assumes the gpt-oss-120b model). If you run this study
+-- with a different model, update the table referenced below to match.
 CREATE TABLE example_nlp__range_labels AS
 SELECT
     src.note_ref,
@@ -16,4 +19,4 @@ SELECT
         WHEN src.result.age < 65 THEN 'middle aged (45-64)'
         ELSE 'aged (65+)'
     END AS label
-FROM example_nlp__age AS src
+FROM example_nlp__nlp_age_gpt_oss_120b AS src

--- a/docs/study-configuration.md
+++ b/docs/study-configuration.md
@@ -339,6 +339,9 @@ styling.
   These are fine to use elsewhere in the table name, just not at the beginning.
   For example, `my_study__nlp_counts` would cause an error, 
   but `my_study__counts_nlp` would be fine.
+  Tables in this reserved space are not dropped when a study is cleaned or rebuilt, which is why
+  [NLP workflows](workflows/nlp.md) create tables like `my_study__nlp_my_table_gpt_oss_120b`.
+  You can read from those tables in your own queries, you just can't create them yourself.
 
 
 #### Requirements for accepting PRs

--- a/docs/workflows/nlp.md
+++ b/docs/workflows/nlp.md
@@ -48,9 +48,11 @@ contains details on the expectations of each value.
 config_type="nlp"
 
 # You define NLP tasks/tables with the 'tables' dictionary.
-# The keys in the table dictionary define your table names, and the study name will
-# automatically be prepended from the prefix in your manifest.
-# So an entry like [tables.my_table] results in a table like `my_study__my_table`.
+# The keys in the table dictionary define your table names, but the final table name also
+# includes the study prefix from your manifest, an `nlp` marker, and the model you ran with.
+# So an entry like [tables.my_table], run against the gpt-oss-120b model, results in a table
+# like `my_study__nlp_my_table_gpt_oss_120b`.
+# See "Result Table Names" below for more details.
 [tables.table_1]
 
 # `version` will be a number that you will increment every time you change the table definition
@@ -128,6 +130,30 @@ reject_by_word: ["default", "words"]
 reject_by_regex: ["default", regex"]
 ```
 
+### Result Table Names
+
+NLP results are named the same way that [Cumulus ETL](https://docs.smarthealthit.org/cumulus/etl/)
+names the NLP tables it creates, so that all NLP results in your database look alike:
+
+`{study_prefix}__nlp_{table_name}_{model}`
+
+For example, a `[tables.treatment]` entry in the `ibd` study, run with `--nlp-model=gpt-oss-120b`,
+creates the table `ibd__nlp_treatment_gpt_oss_120b`.
+(Hyphens in a model name become underscores, since the model name is part of a SQL table name.)
+
+A few consequences worth knowing about:
+
+- The model is part of the table name, so results from two different models don't overwrite
+  each other, and any study SQL that reads NLP results needs to name the model it expects.
+- The task `version` is **not** part of the table name (it is available as the `task_version`
+  column). Bumping a task version writes results to a new folder and re-points the table at it.
+- `nlp_` is a reserved table prefix, which means these tables are not dropped when a study is
+  cleaned or rebuilt. That's deliberate - NLP results are expensive to regenerate.
+
+The parquet files behind these tables get uploaded to your Athena results bucket, in a folder
+named like the table plus the task version:
+`cumulus_user_uploads/{database}/{study_prefix}/nlp_{table_name}_{model}_v{version}/`
+
 ### Result Table Format
 
 Tables created by the NLP workflow will have the following fields:
@@ -190,7 +216,8 @@ And then once satisfied, upload to Athena.
 1. Start by passing arguments like `--db-type duckdb --database ./testing.db` instead of the usual
    AWS/Athena arguments.
    - NLP parquet files will be written to a user cache folder.
-     On Linux, this will be somewhere like `~/.cache/cumulus-library/nlp/{my_study}/{table}_v0/`
+     On Linux, this will be somewhere like
+     `~/.cache/cumulus-library/nlp/{my_study}/nlp_{table}_{model}_v0/`
    - The tables themselves (that point to those parquet files) will be in the database path you
      gave Cumulus Library (i.e. `./testing.db`).
 1. You can inspect the parquet files with a tool like

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -11,6 +11,7 @@ import hashlib
 import io
 import json
 import os
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest import mock
 
@@ -24,6 +25,7 @@ import pytest
 import cumulus_library
 from cumulus_library import cli, databases, errors, note_utils
 from cumulus_library.builders import nlp_builder
+from cumulus_library.builders.nlp import driver, models, workflow
 from cumulus_library.builders.nlp.models import OpenAIProvider
 from tests import conftest, nlp_utils
 from tests.conftest import duckdb_args
@@ -34,7 +36,7 @@ SALT_BYTES = binascii.unhexlify(SALT_STR)
 
 
 @pytest.fixture
-def note_source(tmp_path) -> note_utils.NoteSource:
+def note_source(tmp_path) -> Iterator[note_utils.NoteSource]:
     """Just make a sample note source with a row - contents not important"""
     with open(f"{tmp_path}/dxr.ndjson", "w", encoding="utf8") as f:
         add_dxr("hello", "hello world", f)
@@ -384,7 +386,7 @@ def test_span_correction(mock_client, tmp_path, mock_db_config):
     with contextlib.redirect_stdout(console_output):
         builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "example_nlp__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_hello_world_gpt_oss_120b")
     assert rows[0]["result"] == {"parent_list": [{"parent_dict": {"spans": [[0, 5], [7, 21]]}}]}
 
     failure_msg = "Could not match span received from NLP server for DiagnosticReport/dxr: forth"
@@ -454,7 +456,7 @@ def test_various_value_types(mock_client, tmp_path, mock_db_config, note_source)
     )
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "example_nlp__task")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt_oss_120b")
     assert rows[0]["result"] == results
 
 
@@ -716,7 +718,7 @@ def test_bedrock_skips_wrapper_in_response(mock_client, tmp_path, mock_db_config
     )
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "example_nlp__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_hello_world_gpt_oss_120b")
     assert rows[0]["result"] == {"hello": "world"}
 
 
@@ -757,7 +759,7 @@ Summary.
 
     builder.execute_queries(mock_db_config, None)
 
-    rows = read_rows(mock_db_config, "example_nlp__hello_world")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_hello_world_gpt_oss_120b")
     assert rows[0]["result"] == {"hello": 0.5}
 
 
@@ -814,9 +816,12 @@ def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_so
 
     assert builder.stats.got_response[0] == 1
 
-    # Confirm we wrote the parquet file out correctly
-    path = "s3://testbucket/athena/cumulus_user_uploads/testdb/example_nlp/task_v0/nlp.0.parquet"
-    with mem_fs.open(path, "rb") as f:
+    # Confirm we wrote the parquet file out correctly, into an ETL-style upload folder
+    # (nlp prefix, task name, model, and task version)
+    upload_dir = (
+        "s3://testbucket/athena/cumulus_user_uploads/testdb/example_nlp/nlp_task_gpt_oss_120b_v0"
+    )
+    with mem_fs.open(f"{upload_dir}/nlp.0.parquet", "rb") as f:
         df = pandas.read_parquet(f)
         rows = json.loads(df.to_json(orient="records"))
 
@@ -824,19 +829,19 @@ def test_write_to_athena(mock_openai_client, mock_boto_client, tmp_path, note_so
     assert rows[0]["note_ref"] == "DiagnosticReport/hello"
 
     # And the id file
-    id_path = "s3://testbucket/athena/cumulus_user_uploads/testdb/example_nlp/task_v0.ids"
-    with mem_fs.open(id_path, "r") as f:
+    with mem_fs.open(f"{upload_dir}.ids", "r") as f:
         assert f.read() == "DiagnosticReport/hello\n"
 
-    # And confirm the query looks right
+    # And confirm the queries look right
     assert builder.queries == [
-        "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`example_nlp__task` ( note_ref STRING, "
+        "DROP TABLE IF EXISTS `main`.`example_nlp__nlp_task_gpt_oss_120b`;",
+        "CREATE EXTERNAL TABLE IF NOT EXISTS `main`.`example_nlp__nlp_task_gpt_oss_120b` "
+        "( note_ref STRING, "
         "encounter_ref STRING, subject_ref STRING, generated_on STRING, task_version INT, "
         "model STRING, system_fingerprint STRING, result STRUCT<ignored: STRING>\n)\n"
         "STORED AS PARQUET\n"
-        "LOCATION 'memory://s3://testbucket/athena/cumulus_user_uploads/"
-        "testdb/example_nlp/task_v0'\n"
-        'tblproperties ("parquet.compression"="SNAPPY");'
+        f"LOCATION 'memory://{upload_dir}'\n"
+        'tblproperties ("parquet.compression"="SNAPPY");',
     ]
 
 
@@ -914,7 +919,7 @@ def test_azure_batching_happy_path(mock_client, tmp_path, mock_db_config, note_s
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
-    rows = read_rows(mock_db_config, "example_nlp__task")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt4o")
     assert rows[0]["result"] == {"ignored": "answer"}
 
     assert model.openai.batches.create.call_args_list[0][1] == {
@@ -933,6 +938,8 @@ def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_sourc
     workflow_path = nlp_utils.basic_workflow(tmp_path)
     model = nlp_utils.MockModel(mock_client, provider="azure", model_id="gpt4o")
 
+    # Note that the cache namespace does not include the nlp prefix/model naming that the
+    # result tables use - renaming it would orphan every previously cached NLP response.
     path_dir = f"{model.phi}/nlp-cache/example_nlp__task_v0_gpt4o"
     os.makedirs(path_dir)
     with open(f"{path_dir}/metadata.json", "w", encoding="utf8") as f:
@@ -954,7 +961,7 @@ def test_azure_resume_batching(mock_client, tmp_path, mock_db_config, note_sourc
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 1
 
-    rows = read_rows(mock_db_config, "example_nlp__task")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt4o")
     assert rows[0]["result"] == {"ignored": "answer"}
 
 
@@ -1092,7 +1099,7 @@ def test_azure_splitting_batch(mock_client, tmp_path, mock_db_config):
     builder.execute_queries(mock_db_config, None)
     assert builder.stats.got_response[0] == 4
 
-    rows = read_rows(mock_db_config, "example_nlp__task")
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt4o")
     assert [row["result"] for row in rows] == [
         {"ignored": "w1"},
         {"ignored": "w2"},

--- a/tests/builders/test_nlp_builder.py
+++ b/tests/builders/test_nlp_builder.py
@@ -208,6 +208,111 @@ def test_filter(mock_client, tmp_path, mock_db_config):
     assert expected_stats in console_output.getvalue()
 
 
+@pytest.mark.parametrize(
+    "model_id,expected_table,expected_folder",
+    [
+        # Hyphens in a model ID get converted to underscores, since the model is part of a
+        # SQL table name (and this matches how the ETL names its own NLP tables).
+        ("gpt-oss-120b", "example_nlp__nlp_task_gpt_oss_120b", "nlp_task_gpt_oss_120b_v2"),
+        ("gpt4o", "example_nlp__nlp_task_gpt4o", "nlp_task_gpt4o_v2"),
+    ],
+)
+@mock.patch("openai.OpenAI")
+def test_naming_conventions(
+    mock_client, model_id, expected_table, expected_folder, tmp_path, mock_db_config
+):
+    """NLP tables & upload folders should look like the ETL's: nlp prefix, task, model, version"""
+    model = nlp_utils.MockModel(mock_client, model_id=model_id)
+    nlp_config = model.nlp_config()
+    task = workflow.NlpTask(version=2)
+
+    assert driver.table_name_for_task("task", nlp_config) == expected_table
+    assert driver.upload_slug_for_task("task", task, nlp_config) == expected_folder
+    # duckdb has no remote upload location, so results land in the local cache dir
+    path = driver.output_path_for_task(nlp_config, "task", task, mock_db_config.db)
+    assert str(path) == f"{tmp_path}/nlp/example_nlp/{expected_folder}"
+
+
+@mock.patch("openai.OpenAI")
+def test_naming_requires_a_model(mock_client):
+    """We can't name a table without knowing the model, so complain early"""
+    model = nlp_utils.MockModel(mock_client)
+    nlp_config = model.nlp_config()
+    nlp_config.model = None
+
+    with pytest.raises(errors.CumulusLibraryError, match="An NLP model ID must be provided"):
+        driver.table_name_for_task("task", nlp_config)
+
+    # The model factory guards against this too, with the same message
+    with pytest.raises(errors.CumulusLibraryError, match="An NLP model ID must be provided"):
+        models.create_model(nlp_config)
+
+
+@mock.patch("openai.OpenAI")
+def test_clean_only_removes_this_task_and_model(mock_client, tmp_path, mock_db_config, note_source):
+    """--clean-nlp should leave other tasks & models alone"""
+    workflow_path = nlp_utils.basic_workflow(tmp_path)
+    model = nlp_utils.MockModel(mock_client)
+
+    root = cfs.FsPath(tmp_path, "nlp", "example_nlp")
+    old_version = root.joinpath("nlp_task_gpt_oss_120b_v9")  # same task & model - gets cleaned
+    other_model = root.joinpath("nlp_task_gpt4o_v0")
+    other_task = root.joinpath("nlp_other_gpt_oss_120b_v0")
+    for folder in [old_version, other_model, other_task]:
+        folder.makedirs()
+
+    builder = nlp_builder.NlpBuilder(
+        toml_config_path=workflow_path, notes=note_source, nlp_config=model.nlp_config(clean=True)
+    )
+    builder.execute_queries(mock_db_config, None)
+
+    assert not old_version.exists()
+    assert other_model.exists()
+    assert other_task.exists()
+
+
+@mock.patch("openai.OpenAI")
+def test_new_task_version_repoints_table(mock_client, tmp_path, mock_db_config, note_source):
+    """Bumping a task version should point the (unversioned) table at the new results"""
+
+    def build(version: int, answer: int) -> None:
+        workflow_path = conftest.write_toml(
+            tmp_path,
+            {
+                "config_type": "nlp",
+                "tables": {
+                    "task": {
+                        "version": version,
+                        "response_schema": '{"title":"test", "type": "object", '
+                        '"properties": {"hello": {"type": "integer"}}}',
+                    },
+                },
+            },
+            "nlp.workflow",
+        )
+        model = nlp_utils.MockModel(mock_client)
+        model.mock_openai_response({"hello": answer})
+        builder = nlp_builder.NlpBuilder(
+            toml_config_path=workflow_path,
+            notes=note_source,
+            nlp_config=model.nlp_config(clean=False),
+        )
+        builder.execute_queries(mock_db_config, None)
+
+    build(version=0, answer=1)
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt_oss_120b")
+    assert rows[0]["result"] == {"hello": 1}
+    assert rows[0]["task_version"] == 0
+
+    # The old version's results are still sitting on disk, but the table should now be
+    # backed by the new version's folder.
+    build(version=1, answer=2)
+    assert cfs.FsPath(tmp_path, "nlp", "example_nlp", "nlp_task_gpt_oss_120b_v0").exists()
+    rows = read_rows(mock_db_config, "example_nlp__nlp_task_gpt_oss_120b")
+    assert rows[0]["result"] == {"hello": 2}
+    assert rows[0]["task_version"] == 1
+
+
 @mock.patch("openai.OpenAI")
 def test_already_uploaded(mock_client, tmp_path, mock_db_config, note_source):
     """Verify that we skip notes that we've already uploaded before"""

--- a/tests/studies/test_example_nlp.py
+++ b/tests/studies/test_example_nlp.py
@@ -53,8 +53,13 @@ def test_full_build(mock_client, tmp_path):
     cli.main(cli_args=build_args)
 
     db = duckdb.connect(f"{tmp_path}/duck.db")
-    age_rows = db.cursor().execute("select result from example_nlp__age").fetchall()
-    race_rows = db.cursor().execute("select result from example_nlp__race").fetchall()
+    # NLP result tables are named after the nlp prefix, the task, and the model used
+    age_rows = (
+        db.cursor().execute("select result from example_nlp__nlp_age_gpt_oss_120b").fetchall()
+    )
+    race_rows = (
+        db.cursor().execute("select result from example_nlp__nlp_race_gpt_oss_120b").fetchall()
+    )
     label_rows = db.cursor().execute("select label from example_nlp__range_labels").fetchall()
 
     assert age_rows[0][0] == {"age": 3, "has_mention": True, "spans": [[0, 5]]}


### PR DESCRIPTION
Should close #596 . Have to pass around the nlp_config a bit more around the driver file, but other than that it wasn't too hard of a fix. Adds some new tests to cover this convention, and updates the example tables around other tests/docs to use the new convention. 

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json