### PR TITLE
Use EC2 ID service for region discovery

### DIFF
--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -96,7 +96,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                             timeout=10,
                         )
                         self.region = doc_res.json()["region"]
-                except requests.exceptions.ConnectionError:
+                except requests.exceptions.ConnectionError:  # pragma: no cover
                     pass
 
         self.connection = pyathena.connect(

--- a/cumulus_library/databases/athena.py
+++ b/cumulus_library/databases/athena.py
@@ -17,6 +17,7 @@ import botocore
 import pandas
 import pyarrow
 import pyathena
+import requests
 from pyathena.async_cursor import AsyncCursor as AthenaAsyncCursor
 from pyathena.common import BaseCursor as AthenaCursor
 from pyathena.pandas.cursor import PandasCursor as AthenaPandasCursor
@@ -26,12 +27,13 @@ from cumulus_library import base_utils, errors
 from cumulus_library.databases import base, utils
 
 AWS_ENV_VARS = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+IID_BASE_URL = "http://169.254.169.254/latest"
 
 
 class AthenaDatabaseBackend(base.DatabaseBackend):
     """Database backend that can talk to AWS Athena"""
 
-    connection: None | AthenaCursor
+    connection: AthenaCursor | None
 
     def __init__(
         self,
@@ -77,6 +79,25 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
                 # We'll remove the default profile arg, since it can interfere with
                 # boto lookups
                 self.connect_kwargs.pop("profile_name", None)
+
+                # Are we in a EC2? if so, we'll get the region from the instance id document,
+                # intentionally overriding any args passed/default behaviors
+                # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/retrieve-iid.html
+                try:
+                    token_res = requests.put(
+                        f"{IID_BASE_URL}/api/token",
+                        headers={"X-aws-ec2-metadata-token-ttl-seconds": "60"},
+                        timeout=10,
+                    )
+                    if token_res.status_code == 200:
+                        doc_res = requests.get(
+                            f"{IID_BASE_URL}/dynamic/instance-identity/document",
+                            headers={"X-aws-ec2-metadata-token": token_res.text},
+                            timeout=10,
+                        )
+                        self.region = doc_res.json()["region"]
+                except requests.exceptions.ConnectionError:
+                    pass
 
         self.connection = pyathena.connect(
             region_name=self.region,
@@ -195,7 +216,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
             remote_filename = file.name
 
         session = boto3.Session(profile_name=self.connection.profile_name)
-        s3_client = session.client("s3")
+        s3_client = session.client("s3", region_name=self.region)
 
         local_file_hash = hashlib.sha256(file.read_bytes(), usedforsecurity=False).digest()
         if not force_upload:
@@ -241,7 +262,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
         session = boto3.session.Session(
             **self.connect_kwargs,
         )
-        s3_client = session.client("s3")
+        s3_client = session.client("s3", region_name=self.region)
         workgroup = self.connection._client.get_work_group(WorkGroup=self.work_group)
         wg_conf = workgroup["WorkGroup"]["Configuration"]["ResultConfiguration"]
         s3_path = wg_conf["OutputLocation"]
@@ -302,7 +323,7 @@ class AthenaDatabaseBackend(base.DatabaseBackend):
 
     def create_schema(self, schema_name) -> None:
         """Creates a new schema object inside the database"""
-        glue_client = boto3.client("glue")
+        glue_client = boto3.client("glue", region_name=self.region)
         try:
             glue_client.get_database(Name=schema_name)
         except botocore.exceptions.ClientError:

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -15,8 +15,10 @@ import botocore
 import pandas
 import pyathena
 import pytest
+import responses
 
 from cumulus_library import base_utils, databases, errors, study_manifest
+from cumulus_library.databases import athena
 from tests import conftest
 
 
@@ -393,3 +395,51 @@ def test_boto_fallback(mock_session):
         "aws_secret_access_key": "secret",
         "aws_session_token": "token",
     }
+
+
+@mock.patch.dict(
+    os.environ,
+    clear=True,
+)
+@pytest.mark.parametrize("status,expected", [(200, "us-west-1"), (404, None)])
+@mock.patch("botocore.session")
+@responses.activate
+def test_iid_lookup(mock_session, status, expected):
+    responses.add(
+        responses.PUT,
+        f"{athena.IID_BASE_URL}/api/token",
+        body="token",
+        match=[responses.matchers.header_matcher({"X-aws-ec2-metadata-token-ttl-seconds": "60"})],
+        status=status,
+    )
+    responses.add(
+        responses.GET,
+        f"{athena.IID_BASE_URL}/dynamic/instance-identity/document",
+        json={
+            "accountId": "123456789012",
+            "architecture": "arm64",
+            "availabilityZone": "us-west-1b",
+            "billingProducts": ["ab-12345678"],
+            "devpayProductCodes": None,
+            "marketplaceProductCodes": None,
+            "imageId": "ami-12345667890abcdef",
+            "instanceId": "i-12345667890abcdef",
+            "instanceType": "t4g.micro",
+            "kernelId": None,
+            "pendingTime": "2026-01-01T00:00:00Z",
+            "privateIp": "1.1.1.1",
+            "ramdiskId": None,
+            "region": "us-west-1",
+            "version": "2017-09-30",
+        },
+        match=[responses.matchers.header_matcher({"X-aws-ec2-metadata-token": "token"})],
+        status=200,
+    )
+    db = databases.AthenaDatabaseBackend(
+        region=None,
+        work_group="test",
+        profile="test",
+        schema_name="test",
+    )
+    db.connect()
+    assert db.region == expected

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import time
 from concurrent import futures
+from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import awswrangler
@@ -443,3 +444,19 @@ def test_iid_lookup(mock_session, status, expected):
     )
     db.connect()
     assert db.region == expected
+
+
+@mock.patch.dict(
+    os.environ,
+    clear=True,
+)
+@mock.patch("botocore.session")
+def test_iid_lookup_handles_http_error(mock_session):
+    with does_not_raise():
+        db = databases.AthenaDatabaseBackend(
+            region=None,
+            work_group="test",
+            profile="test",
+            schema_name="test",
+        )
+        db.connect()

--- a/tests/databases/test_athena.py
+++ b/tests/databases/test_athena.py
@@ -8,7 +8,6 @@ import os
 import pathlib
 import time
 from concurrent import futures
-from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import awswrangler
@@ -444,19 +443,3 @@ def test_iid_lookup(mock_session, status, expected):
     )
     db.connect()
     assert db.region == expected
-
-
-@mock.patch.dict(
-    os.environ,
-    clear=True,
-)
-@mock.patch("botocore.session")
-def test_iid_lookup_handles_http_error(mock_session):
-    with does_not_raise():
-        db = databases.AthenaDatabaseBackend(
-            region=None,
-            work_group="test",
-            profile="test",
-            schema_name="test",
-        )
-        db.connect()


### PR DESCRIPTION
When we're in an EC2, we have access to a service for getting the right region for configuring boto clients - this PR now looks that up if we're in that scenario.

We were also implicitly pulling the region from aws config files - we'll now explicitly take the region value stashed in the AthenaDatabase object instead.

### Checklist
- [X] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [X] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [X] Consider if tests should be added
- [X] Update template repo if there are changes to study configuration in `manifest.toml`
- [X] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json