### PR TITLE
fix: remove SQL comments before splitting on semicolons

### DIFF
--- a/cumulus_library/base_utils.py
+++ b/cumulus_library/base_utils.py
@@ -70,15 +70,29 @@ def load_text(path: str) -> str:
 
 
 def parse_sql(sql_text: str) -> list[str]:
-    commands = []
+    tokens = sqlglot.tokenize(sql_text)
 
-    for statement in sql_text.split(";"):
-        parsed = []
-        for line in statement.splitlines():
+    indices = [t.start for t in tokens if t.token_type == sqlglot.TokenType.SEMICOLON]
+
+    commands = []
+    last_idx = 0
+    for idx in indices:
+        commands.append(sql_text[last_idx:idx])
+        last_idx = idx + 1
+    commands.append(sql_text[last_idx:])
+
+    final_commands = []
+    for cmd in commands:
+        parsed_lines = []
+        for line in cmd.splitlines():
             if not line.strip().startswith("--"):
-                parsed.append(line)
-        commands.append("\n".join(parsed))
-    return filter_strip(commands)
+                parsed_lines.append(line)
+
+        cleaned = "\n".join(parsed_lines).strip()
+        if cleaned:
+            final_commands.append(cleaned)
+
+    return final_commands
 
 
 def filter_strip(commands) -> list[str]:


### PR DESCRIPTION
## Summary
Fixes issue #610 by updating `base_utils.py/sql_parse` to properly handle SQL comments containing semicolons.

Fixes #610

## Changes made
- Updated `cumulus_library/base_utils.py` to fix semicolon splitting logic.

## How has this been tested?
- [x] Ran local unit tests

### Checklist
- [x] Consider if documentation in `docs/` needs to be updated
  - If you've changed the structure of a table, you may need to run `generate-md`
  - If you've added/removed `core` study fields that not in US Core, update our list of those in `core-study-details.md`
  - If you've changed the public API or a class/method that is part of the public api, update `api.md`
- [x] If you've updated the `core` or `discovery` tables, regenerate the reference sql
- [x] Consider if tests should be added
- [x] Update template repo if there are changes to study configuration in `manifest.toml`
- [x] If you're preparing to cut a pip release of a study, add that study to module_allowlist.json